### PR TITLE
Fix a typo.

### DIFF
--- a/authserver/src/internal/server/handler_account_register.go
+++ b/authserver/src/internal/server/handler_account_register.go
@@ -204,7 +204,7 @@ func (s *Server) handleAccountRegisterPost(userCreator userCreator, emailValidat
 			}
 
 			lib.LogAudit(constants.AuditCreatedUser, map[string]interface{}{
-				"email": user.Email,
+				"email": email,
 			})
 
 			if settings.SMTPEnabled {


### PR DESCRIPTION
There was a typo in the `handler_account_register.go:207`, causing the registration process to freeze and generating a panic error:

>  panic: runtime error: invalid memory address or nil pointer dereference
>  
>  -> github.com/leodip/goiabada/internal/server.(*Server).initRoutes.func2.(*Server).handleAccountRegisterPost.func20
>  ->   .../authserver/src/internal/server/handler_account_register.go:207