### PR TITLE
Pin JWT signing algorithm

### DIFF
--- a/src/core/oauth/token_parser_jwks.go
+++ b/src/core/oauth/token_parser_jwks.go
@@ -72,7 +72,7 @@ func (tp *JWKSTokenParser) DecodeAndValidateTokenString(token string, _ *rsa.Pub
 
 	claims := jwt.MapClaims{}
 
-	opts := []jwt.ParserOption{}
+	opts := []jwt.ParserOption{jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()})}
 	if withExpirationCheck {
 		opts = append(opts, jwt.WithExpirationRequired())
 	} else {

--- a/src/core/oauth/token_parser_jwks_test.go
+++ b/src/core/oauth/token_parser_jwks_test.go
@@ -1,0 +1,26 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJWKSTokenParserRejectsNonRS256Token(t *testing.T) {
+	tp := NewJWKSTokenParser("https://auth.example.com", nil)
+
+	claims := jwt.MapClaims{
+		"sub": "1234567890",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte("secret"))
+
+	result, err := tp.DecodeAndValidateTokenString(tokenString, nil, true)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "signing method HS256 is invalid")
+	assert.Nil(t, result)
+}

--- a/src/core/oauthdb/token_parser.go
+++ b/src/core/oauthdb/token_parser.go
@@ -81,7 +81,7 @@ func (tp *TokenParser) DecodeAndValidateTokenString(token string,
 	if len(token) > 0 {
 		claims := jwt.MapClaims{}
 
-		opts := []jwt.ParserOption{}
+		opts := []jwt.ParserOption{jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()})}
 		if withExpirationCheck {
 			opts = append(opts, jwt.WithExpirationRequired())
 		} else {

--- a/src/core/oauthdb/token_parser_test.go
+++ b/src/core/oauthdb/token_parser_test.go
@@ -235,6 +235,29 @@ func TestDecodeAndValidateTokenString_InvalidSignature(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestDecodeAndValidateTokenString_RejectsNonRS256Token(t *testing.T) {
+	mockDB := mocks_data.NewDatabase(t)
+	tp := NewTokenParser(mockDB)
+
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey := &privateKey.PublicKey
+
+	mockDB.On("GetAllSigningKeys", mock.Anything).Return([]models.KeyPair{}, nil)
+
+	claims := jwt.MapClaims{
+		"sub": "1234567890",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte("secret"))
+
+	result, err := tp.DecodeAndValidateTokenString(tokenString, publicKey, true)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "signing method HS256 is invalid")
+	assert.Nil(t, result)
+}
+
 func TestDecodeAndValidateTokenString_EmptyToken(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	tp := NewTokenParser(mockDB)


### PR DESCRIPTION
Fixes #81.

Pins both JWT parsers to RS256 and adds coverage for non-RS256 tokens.

Tests: `go test ./oauth ./oauthdb` from `src/core`.