### PR TITLE
Hoist consent lookup out of the per-scope loop on refresh

### DIFF
--- a/src/core/validators/token_validator.go
+++ b/src/core/validators/token_validator.go
@@ -504,22 +504,27 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 			return nil, err
 		}
 
-		for _, inputScopeStr := range inputScopes {
-			// For ROPC tokens, skip consent check (ROPC bypasses consent - user providing credentials = implicit consent)
-			// For auth code flow tokens, check consent if required
-			if !isROPCToken && (client.ConsentRequired || refreshTokenType == "Offline") {
-				// check if user still consents to this scope
-				consent, err := val.database.GetConsentByUserIdAndClientId(nil, tokenUserId, tokenClientId)
-				if err != nil {
-					return nil, err
-				}
-				if consent == nil {
-					return nil,
-						customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant",
-							"The user has either not given consent to this client or the previously granted consent has been revoked.",
-							http.StatusBadRequest)
-				}
+		// For ROPC tokens, skip consent check (ROPC bypasses consent - user providing credentials = implicit consent)
+		// For auth code flow tokens, check consent if required. The lookup arguments are loop-invariant,
+		// so fetch the consent once here instead of on every scope iteration.
+		var consent *models.UserConsent
+		consentCheckRequired := !isROPCToken && (client.ConsentRequired || refreshTokenType == "Offline")
+		if consentCheckRequired {
+			consent, err = val.database.GetConsentByUserIdAndClientId(nil, tokenUserId, tokenClientId)
+			if err != nil {
+				return nil, err
+			}
+			if consent == nil {
+				return nil,
+					customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant",
+						"The user has either not given consent to this client or the previously granted consent has been revoked.",
+						http.StatusBadRequest)
+			}
+		}
 
+		for _, inputScopeStr := range inputScopes {
+			// check if user still consents to this scope
+			if consentCheckRequired {
 				consentScopeExists := false
 				scopesFromConsent := strings.Split(consent.Scope, " ")
 				for _, scopeFromConsent := range scopesFromConsent {

--- a/src/core/validators/token_validator.go
+++ b/src/core/validators/token_validator.go
@@ -505,12 +505,13 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 		}
 
 		// For ROPC tokens, skip consent check (ROPC bypasses consent - user providing credentials = implicit consent)
-		// For auth code flow tokens, check consent if required. The lookup arguments are loop-invariant,
-		// so fetch the consent once here instead of on every scope iteration.
-		var consent *models.UserConsent
+		// For auth code flow tokens, check consent if required. Both the lookup arguments and the consent
+		// scope list are loop-invariant, so fetch and split the consent once here instead of on every
+		// scope iteration.
+		var scopesFromConsent []string
 		consentCheckRequired := !isROPCToken && (client.ConsentRequired || refreshTokenType == "Offline")
 		if consentCheckRequired {
-			consent, err = val.database.GetConsentByUserIdAndClientId(nil, tokenUserId, tokenClientId)
+			consent, err := val.database.GetConsentByUserIdAndClientId(nil, tokenUserId, tokenClientId)
 			if err != nil {
 				return nil, err
 			}
@@ -520,13 +521,13 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 						"The user has either not given consent to this client or the previously granted consent has been revoked.",
 						http.StatusBadRequest)
 			}
+			scopesFromConsent = strings.Split(consent.Scope, " ")
 		}
 
 		for _, inputScopeStr := range inputScopes {
 			// check if user still consents to this scope
 			if consentCheckRequired {
 				consentScopeExists := false
-				scopesFromConsent := strings.Split(consent.Scope, " ")
 				for _, scopeFromConsent := range scopesFromConsent {
 					if scopeFromConsent == inputScopeStr {
 						consentScopeExists = true

--- a/src/core/validators/token_validator_test.go
+++ b/src/core/validators/token_validator_test.go
@@ -2870,6 +2870,90 @@ func TestValidateTokenRequest_RefreshToken_AuthCodeDisabled(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, customErr.GetHttpStatusCode())
 	})
 
+	t.Run("Refresh token with a scope missing from the consent", func(t *testing.T) {
+		mockDB := mocks_data.NewDatabase(t)
+		mockTokenParser := mocks_oauth.NewTokenParser(t)
+		mockPermissionChecker := mocks_user.NewPermissionChecker(t)
+
+		validator := NewTokenValidator(mockDB, mockTokenParser, mockPermissionChecker)
+
+		settings := &models.Settings{
+			UserSessionIdleTimeoutInSeconds: 3600,
+			UserSessionMaxLifetimeInSeconds: 86400,
+		}
+		ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
+
+		input := &ValidateTokenRequestInput{
+			GrantType:    "refresh_token",
+			ClientId:     "client1",
+			RefreshToken: "partial_consent_refresh_token",
+		}
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "client1",
+			Enabled:                  true,
+			AuthorizationCodeEnabled: true,
+			IsPublic:                 true,
+			ConsentRequired:          true,
+		}
+
+		refreshTokenJwt := &oauth.JwtToken{
+			Claims: jwt.MapClaims{
+				"jti": "partial_consent_jti",
+				"typ": "Refresh",
+				"sub": "user123",
+			},
+		}
+
+		refreshToken := &models.RefreshToken{
+			RefreshTokenJti:   "partial_consent_jti",
+			SessionIdentifier: "test_session",
+			CodeId:            sql.NullInt64{Int64: 1, Valid: true},
+			Code: models.Code{
+				ClientId: 1,
+				UserId:   1,
+				Scope:    "openid profile email",
+				User: models.User{
+					Id:      1,
+					Enabled: true,
+				},
+			},
+		}
+
+		userSession := &models.UserSession{
+			SessionIdentifier: "test_session",
+			Started:           time.Now().UTC().Add(-30 * time.Minute),
+			LastAccessed:      time.Now().UTC().Add(-5 * time.Minute),
+		}
+
+		// The user consented to openid and profile, but no longer to email.
+		userConsent := &models.UserConsent{
+			UserId:   1,
+			ClientId: 1,
+			Scope:    "openid profile",
+		}
+
+		mockDB.On("GetClientByClientIdentifier", mock.Anything, "client1").Return(client, nil)
+		mockTokenParser.On("DecodeAndValidateTokenString", "partial_consent_refresh_token", (*rsa.PublicKey)(nil), true).Return(refreshTokenJwt, nil)
+		mockDB.On("GetRefreshTokenByJti", mock.Anything, "partial_consent_jti").Return(refreshToken, nil)
+		mockDB.On("RefreshTokenLoadCode", mock.Anything, refreshToken).Return(nil)
+		mockDB.On("CodeLoadUser", mock.Anything, &refreshToken.Code).Return(nil)
+		mockDB.On("GetUserSessionBySessionIdentifier", mock.Anything, "test_session").Return(userSession, nil)
+		mockDB.On("GetUserBySubject", mock.Anything, "user123").Return(&models.User{Id: 1, Enabled: true}, nil)
+		mockDB.On("GetConsentByUserIdAndClientId", mock.Anything, int64(1), int64(1)).Return(userConsent, nil)
+
+		result, err := validator.ValidateTokenRequest(ctx, input)
+
+		assert.Nil(t, result)
+		assert.Error(t, err)
+		customErr, ok := err.(*customerrors.ErrorDetail)
+		assert.True(t, ok)
+		assert.Equal(t, "invalid_grant", customErr.GetCode())
+		assert.Contains(t, customErr.GetDescription(), "The user has not consented to the 'email' permission")
+		assert.Equal(t, http.StatusBadRequest, customErr.GetHttpStatusCode())
+	})
+
 	t.Run("Refresh token with revoked user permission", func(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		mockTokenParser := mocks_oauth.NewTokenParser(t)

--- a/src/core/validators/token_validator_test.go
+++ b/src/core/validators/token_validator_test.go
@@ -2647,6 +2647,77 @@ func TestValidateTokenRequest_RefreshToken_AuthCodeDisabled(t *testing.T) {
 		assert.Equal(t, refreshTokenJwt, result.RefreshTokenInfo)
 	})
 
+	t.Run("Consent is looked up once for a multi-scope refresh", func(t *testing.T) {
+		mockDB := mocks_data.NewDatabase(t)
+		mockTokenParser := mocks_oauth.NewTokenParser(t)
+		mockPermissionChecker := mocks_user.NewPermissionChecker(t)
+
+		validator := NewTokenValidator(mockDB, mockTokenParser, mockPermissionChecker)
+
+		settings := &models.Settings{}
+		ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
+
+		input := &ValidateTokenRequestInput{
+			GrantType:    "refresh_token",
+			ClientId:     "client1",
+			RefreshToken: "valid_offline_refresh_token",
+		}
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "client1",
+			Enabled:                  true,
+			AuthorizationCodeEnabled: true,
+			IsPublic:                 true,
+			ConsentRequired:          true,
+		}
+
+		futureTime := time.Now().UTC().Add(24 * time.Hour)
+		refreshTokenJwt := &oauth.JwtToken{
+			Claims: jwt.MapClaims{
+				"jti":                         "valid_offline_jti",
+				"typ":                         "Offline",
+				"offline_access_max_lifetime": float64(futureTime.Unix()),
+				"sub":                         "user123",
+			},
+		}
+
+		refreshToken := &models.RefreshToken{
+			RefreshTokenJti: "valid_offline_jti",
+			CodeId:          sql.NullInt64{Int64: 1, Valid: true},
+			Code: models.Code{
+				ClientId: 1,
+				UserId:   1,
+				Scope:    "openid profile email offline_access",
+				User: models.User{
+					Id:      1,
+					Enabled: true,
+				},
+			},
+		}
+
+		userConsent := &models.UserConsent{
+			UserId:   1,
+			ClientId: 1,
+			Scope:    "openid profile email offline_access",
+		}
+
+		mockDB.On("GetClientByClientIdentifier", mock.Anything, "client1").Return(client, nil)
+		mockTokenParser.On("DecodeAndValidateTokenString", "valid_offline_refresh_token", (*rsa.PublicKey)(nil), true).Return(refreshTokenJwt, nil)
+		mockDB.On("GetRefreshTokenByJti", mock.Anything, "valid_offline_jti").Return(refreshToken, nil)
+		mockDB.On("RefreshTokenLoadCode", mock.Anything, refreshToken).Return(nil)
+		mockDB.On("CodeLoadUser", mock.Anything, &refreshToken.Code).Return(nil)
+		mockDB.On("GetUserBySubject", mock.Anything, "user123").Return(&models.User{Id: 1, Enabled: true}, nil)
+		// The refresh carries four scopes; the consent lookup must run once, not once per scope.
+		mockDB.On("GetConsentByUserIdAndClientId", mock.Anything, int64(1), int64(1)).Return(userConsent, nil).Times(1)
+
+		result, err := validator.ValidateTokenRequest(ctx, input)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		mockDB.AssertNumberOfCalls(t, "GetConsentByUserIdAndClientId", 1)
+	})
+
 	t.Run("Valid refresh token with reduced scope", func(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		mockTokenParser := mocks_oauth.NewTokenParser(t)


### PR DESCRIPTION
Fixes #117. The consent guard, lookup, and nil check are loop-invariant, so a refresh with N scopes issued N identical `GetConsentByUserIdAndClientId` reads; this hoists them above the loop and keeps only the per-scope membership test inside. Error codes, messages, and ordering are unchanged, and the added test asserts the lookup now runs once for a multi-scope refresh.