### PR TITLE
fix(sessions): make ending a session durably cut off access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 tmp/
 .devdata/
 
+# Agent review mailbox (throwaway ping-pong between Claude Code and Codex)
+.review/
+
 # Go workspace file
 go.work
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -1,0 +1,1042 @@
+# Issue 129: ending a user session does not durably cut off access
+
+**Issue:** [#129](https://github.com/leodip/goiabada/issues/129)
+**Issue state:** open (labels: bug, security)
+**Written:** 2026-08-04
+**Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
+**Agreement sealed:** 2026-08-04
+**Run state:** not started
+**PR:** none
+
+**Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
+work sits next to. #128 (closed) built the atomic refresh claim and family containment. #77
+(closed) built the atomic code claim. #127 (closed, not planned) proposed a grant entity. #130
+(open) owns the used-code cleanup NULL bug this issue's body flagged. #131 and #132 (open) are
+residuals of #106 and #128 in the same code. #133, #134, #135 and #137 (open) were filed out of an
+earlier, discarded attempt at this issue and cite decision numbers from a document that no longer
+exists; see "Prior attempt" below. None of them blocks this work.
+
+**Prior attempt.** An earlier `/leo-spec` plus `/leo-run` cycle for #129 reached stage 4 and was
+discarded by `git reset --hard origin/main` on 2026-08-04. The user chose to start over from zero.
+That document, its 14 decisions and its 7 stages are deliberately **not** consulted here, and every
+claim below is re-derived from the code as it stands on `main` at `f8d093f`. The four issues filed
+out of that attempt survive it, but their `decision N` citations point at numbering that no longer
+exists and will need reconciling against this document's section 3.
+
+---
+
+## 0. Code anchors
+
+| Label | File | Function | Locate by | Note |
+|---|---|---|---|---|
+| `admin/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go` | `HandleAPIUserSessionDelete` | `err = database.DeleteUserSession(nil, sessionId)` | termination site 1, bare delete, no revocation |
+| `account/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go` | `HandleAPIAccountSessionDelete` | `if err := database.DeleteUserSession(nil, sessionId); err != nil {` | termination site 2, ownership checked, bare delete |
+| `logout/last-client-delete` | `src/authserver/internal/handlers/handler_account_logout.go` | `handleExistingSessionOnLogout` | `if len(userSession.Clients) == 1 {` | termination site 3, deletes the session only when the last client logs out |
+| `completed/start-new-session` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `newSession, err := userSessionManager.StartNewUserSession(` | gap 3: reached unconditionally, no proof anyone authenticated |
+| `completed/really-authenticated` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `userReallyAuthenticated := authContext.AuthenticatedAt != nil` | computed, then read only inside the valid-session branch |
+| `completed/set-acr-level` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `err = authContext.SetAcrLevel(targetAcrLevel, userSession)` | runs after the branch, on the ambient session, whoever it belongs to |
+| `issue/sid-from-context` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `sessionIdentifier = r.Context().Value(constants.ContextKeySessionIdentifier).(string)` | the sid stamped on the code comes from the cookie, not the AuthContext |
+| `issue/create-code` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `code, err := codeIssuer.CreateAuthCode(createCodeInput)` | the insert gap 3 has to stop; no session lookup precedes it |
+| `pwd/authenticated-at` | `src/authserver/internal/handlers/handler_auth_pwd.go` | `HandleAuthPwdPost` | `authContext.AuthenticatedAt = &utcNow` | the only writer on the level 1 path, so the discriminator for gap 3 |
+| `authorize/prompt-login` | `src/authserver/internal/handlers/handler_authorize.go` | `HandleAuthorizeGet` | `if authContext.HasPromptValue("login") {` | returns before the session lookup, leaving the cookie session live (#133) |
+| `authorize/hint-mismatch` | `src/authserver/internal/handlers/handler_authorize.go` | `HandleAuthorizeGet` | `if authContext.IdTokenHintSub != "" && userSession.User.Subject.String() != authContext.IdTokenHintSub {` | second entry to the same defect, from inside the valid-session block |
+| `authorize/sso-reuse` | `src/authserver/internal/handlers/handler_authorize.go` | `HandleAuthorizeGet` | `authContext.AuthState = oauth.AuthStateLevel1ExistingSession` | the SSO path that never sets `AuthenticatedAt` |
+| `authcontext/generation` | `src/core/oauth/auth_context.go` | `n/a` | `AuthStateGeneration int64` | the AuthContext carries no session identifier of its own |
+| `sessionmgr/start-new` | `src/core/user/usersession_manager.go` | `StartNewUserSession` | `sess.Values[constants.SessionKeySessionIdentifier] = userSession.SessionIdentifier` | rewrites the cookie, so `/auth/issue` sees the replacement sid |
+| `sessionmgr/bump-no-userid` | `src/core/user/usersession_manager.go` | `BumpUserSession` | `if authMethods != "" && authMethods != userSession.AuthMethods {` | assigns methods and ACR, never `UserId` (#133 consequence 2) |
+| `issuer/grant-is-offline` | `src/core/oauth/token_issuer.go` | `grantIsOffline` | `func grantIsOffline(authorizedScope string, sessionIdentifier string) bool {` | an empty sid alone makes a grant offline |
+| `issuer/refresh-type-branch` | `src/core/oauth/token_issuer.go` | `generateRefreshToken` | `if grantIsOffline(scope, code.SessionIdentifier) {` | Offline stores a max lifetime, Refresh stores the sid, never both |
+| `issuer/store-sid` | `src/core/oauth/token_issuer.go` | `generateRefreshToken` | `refreshTokenEntity.SessionIdentifier = claims["sid"].(string)` | so an offline token's own `session_identifier` is empty |
+| `issuer/create-refresh-token` | `src/core/oauth/token_issuer.go` | `generateRefreshToken` | `err := t.database.CreateRefreshToken(nil, refreshTokenEntity)` | gap 2: the child insert, outside any transaction |
+| `issuer/suppress-sid-claim` | `src/core/oauth/token_issuer.go` | `generateAccessTokenCore` | `if len(input.SessionIdentifier) > 0 && !input.GrantIsOffline {` | an offline grant's ACCESS token carries no sid either |
+| `validator/authcode-preauth` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if !wasReused {` | user, generation and expiry checks, all ahead of client auth (#137) |
+| `validator/code-generation` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if codeEntity.AuthStateGeneration != codeEntity.User.AuthStateGeneration {` | #106's redemption gate, the precedent for a code-level marker |
+| `validator/session-branch` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `case "Refresh":` | already fails once the session row is gone |
+| `validator/offline-branch` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `case "Offline":` | checks only the max lifetime, never the session |
+| `validator/refresh-generation` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if refreshToken.AuthStateGeneration != refreshToken.Code.User.AuthStateGeneration {` | sits ahead of the client-ownership check below it |
+| `validator/client-ownership` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if tokenClientId != client.Id {` | the ownership gate a new refresh check should sit behind |
+| `db/refresh-by-sid` | `src/core/data/commondb/refresh_token.go` | `GetRefreshTokensBySessionIdentifier` | `selectBuilder.JoinWithOption(sqlbuilder.InnerJoin, "codes", "codes.id = refresh_tokens.code_id")` | joins through `codes`, so it does reach offline tokens |
+| `db/mark-code-used` | `src/core/data/commondb/code.go` | `MarkCodeAsUsed` | `ub.Equal("used", false),` | the compare-and-set predicate, no revoked term today |
+| `db/delete-used-codes` | `src/core/data/commondb/code.go` | `DeleteUsedCodesWithoutRefreshTokens` | `deleteBuilder.Equal("used", true),` | reaps used codes only; #130 owns its NULL bug |
+| `revoke/refresh-tokens` | `src/authserver/internal/handlers/revocation.go` | `revokeRefreshTokens` | `if err := db.UpdateRefreshToken(tx, rt); err != nil {` | #106's helper, read-modify-write rather than compare-and-set |
+| `middleware/session-check` | `src/authserver/internal/middleware/api_auth.go` | `RequireValidSession` | `session, err := database.GetUserSessionBySessionIdentifier(nil, sid)` | reached only when the token carries a sid |
+| `worker/perform-task` | `src/authserver/internal/workers/background_worker.go` | `performTask` | `func (w *Worker) performTask(ctx context.Context) {` | where any reaper for new durable state would go |
+| `schema/user-sessions` | `src/core/data/sqlitedb/schema.sql` | `n/a` | `CREATE TABLE user_sessions (` | documentation snapshot, not loaded by Go |
+| `test/fresh-ceremony-after-delete` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionDeletedDuringAuthFlow_LoginSucceeds` | `assert.Equal(t, 1, len(userSessions2), "Should have a new session after second login")` | #46's regression guard; the case gap 3's fix must NOT break |
+| `test/completed-new-session` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("Successful flow, new session, consent not required", func(t *testing.T) {` | one of three subtests reaching `StartNewUserSession` with a nil `AuthenticatedAt` |
+
+Counts in this document carry their command:
+
+- 3 termination sites (`admin/session-delete`, `account/session-delete`, `logout/last-client-delete`).
+- 3 subtests reach `StartNewUserSession`
+  (`grep -c 'StartNewUserSession", rr, req' src/authserver/internal/handlers/handler_auth_completed_test.go`).
+- Next free migration number is **000026** on all four engines
+  (`for db in sqlitedb mysqldb postgresdb mssqldb; do ls src/core/data/$db/migrations | grep -o '^[0-9]*' | sort -u | tail -1; done`).
+
+---
+
+## 1. Context
+
+### The three termination sites
+
+All three delete the `user_sessions` row and revoke nothing. Each passes `nil` for the
+transaction, so none of them is a boundary against anything running concurrently.
+
+| Site | What it does | Revokes tokens? |
+|---|---|---|
+| `DELETE /api/v1/admin/user-sessions/{id}` (`admin/session-delete`) | deletes the `UserSession` | no |
+| `DELETE /api/v1/account/sessions/{id}` (`account/session-delete`) | deletes the `UserSession`, ownership checked | no |
+| `GET/POST /auth/logout` (`logout/last-client-delete`) | deletes one `UserSessionClient`, and the `UserSession` when it was the only one | no |
+
+The logout case is per-client and only incidentally ends a session. The predicate is
+`len(userSession.Clients) == 1`, evaluated after the client row is deleted, so the session dies
+exactly when the departing client was the sole one on it.
+
+### Gap 1: an offline grant outlives its session
+
+Session deletion already contains a **session-bound** refresh token. `validator/session-branch`
+loads the session by identifier and rejects with `invalid_grant` when the row is missing.
+
+It does not contain an **offline** one. `validator/offline-branch` checks only the
+`offline_access_max_lifetime` claim and never consults the session. Offline refresh tokens also
+carry no session identifier of their own: `issuer/refresh-type-branch` chooses one of two storage
+shapes, and `issuer/store-sid` sets `session_identifier` on the Refresh branch only, so the Offline
+branch leaves it empty and stores a `max_lifetime` instead.
+
+So after "end session", a client holding an `offline_access` grant that was authorized through that
+session keeps refreshing, bounded only by that grant's max lifetime.
+
+The join that reaches those rows does exist. `db/refresh-by-sid` inner-joins `codes` on
+`codes.id = refresh_tokens.code_id` and filters `codes.session_identifier`, and the **code** row
+does carry the sid even for an offline grant, because `issuer/grant-is-offline` returns true from
+the `offline_access` scope rather than from an empty sid. ROPC tokens have `code_id = NULL` and are
+correctly excluded, having no session to belong to.
+
+**Access tokens are affected too, and this is not in the issue body.** `issuer/suppress-sid-claim`
+omits the `sid` claim for an offline grant. `middleware/session-check` reaches its session lookup
+only for a token that has a sid, so an offline grant's access token is checked against the user's
+generation instead. Session termination does not move that generation, and must not, so an offline
+access token issued before termination stays acceptable at Goiabada's own endpoints until it
+expires. Revoking refresh tokens alone leaves that window open.
+
+### Gap 2: a concurrent refresh inserts a surviving replacement
+
+Rotation claims the presented token and inserts its replacement as two separate commits.
+`issuer/create-refresh-token` passes `nil` for the transaction. A refresh that validated before a
+termination sweep therefore inserts its child after the sweep commits, and for an offline grant
+nothing invalidates that child.
+
+> **Correction to the issue body.** It describes rotation as marking the parent revoked with
+> `UpdateRefreshToken(nil, ...)`. #128 replaced that with a compare-and-set,
+> `MarkRefreshTokenAsRevoked`. The race the body describes survives the change, because it is the
+> child *insert* that escapes, not the parent claim, but the citation is stale.
+
+`revoke/refresh-tokens` is #106's sweep helper and is a read-modify-write over rows it already
+loaded, not a compare-and-set. It skips rows already marked revoked and reports only the JTIs it
+transitioned, which is a contract #77's reuse cascade depends on.
+
+**Gap 2 may cost nothing beyond gap 1, depending on decision 4.** The issue's sketch closes it with
+a `codes.revoked` column plus an edit to `db/mark-code-used`. Verified that a cheaper route exists:
+
+- A rotated child **inherits its parent's `code_id`**. `issuer/create-refresh-token` sets `CodeId`
+  from the `code` it was handed, and on the refresh path that code is
+  `validateResult.CodeEntity`, which the validator derives as `codeEntity = &refreshToken.Code`.
+  So every descendant of a grant points at the same `codes` row.
+- The refresh validator therefore **already holds the originating session identifier** for every
+  auth-code-derived refresh token, offline ones included, as `refreshToken.Code.SessionIdentifier`.
+  No new join and no new column are required to read it.
+
+A refresh-path check keyed on that value rejects every present *and future* descendant of the
+grant, because the racing child inherits the same code and so the same sid. Under a design that
+marks the *session* rather than the *rows*, gap 2 closes as a consequence of gap 1's check rather
+than as separate work, and `db/mark-code-used` needs no edit. This is a claim about the refresh
+path only; an unredeemed code still needs its own gate, which is decision 7.
+
+### Gap 3: an in-flight ceremony recreates the session
+
+Verified sequence, and the reason a marker on existing rows is not by itself a boundary.
+
+1. An SSO ceremony validates session S at `authorize/sso-reuse`, copies its `UserId`, `AcrLevel`,
+   `AuthMethods` and `AuthStateGeneration` onto the AuthContext, and proceeds. It never reaches the
+   password handler, so `AuthenticatedAt` stays nil.
+2. "End session" deletes S.
+3. The ceremony resumes at `/auth/completed`.
+4. `HandleAuthCompletedGet` finds no valid session and takes the else branch, which calls
+   `completed/start-new-session` **unconditionally**, from `authContext.UserId`, with no requirement
+   that anyone authenticated. `completed/really-authenticated` computes the very fact that would
+   distinguish the two cases and is consulted only inside the *valid session* branch, to refresh
+   `AuthTime`.
+5. `sessionmgr/start-new` writes the replacement session's identifier into the cookie.
+6. `/auth/issue` reads the sid from the request context at `issue/sid-from-context`, which is now
+   the replacement, and `issue/create-code` inserts a fresh, unmarked code.
+7. Nothing rejects it. The code is new, so no marker on old rows applies, and the user's generation
+   never moved.
+
+The consent screen delays code insertion the same way, widening the window from milliseconds to
+however long a person takes to click.
+
+**The AuthContext carries no session identifier.** `authcontext/generation` is the neighbouring
+field; there is no sid field beside it. The ceremony's originating session is knowable only from
+the cookie, and the cookie is rewritten in step 5. Nothing durable ties the code issued in step 6
+back to the session that was terminated in step 2.
+
+> **Departure from the issue body.** It calls the fix "almost certainly: fail and force
+> re-authentication". Verification says the predicate cannot be "no valid session", because
+> `test/fresh-ceremony-after-delete` covers a legitimate case with exactly that shape: session
+> deleted, then a **new** ceremony in which the user really does enter a password, which must keep
+> succeeding. That is #46's regression guard. The discriminator that separates the two is whether
+> *this ceremony* performed level 1 authentication, which is what
+> `completed/really-authenticated` already computes and `pwd/authenticated-at` is the only level 1
+> writer of.
+
+### Costs already visible in the tests
+
+Three subtests in `test/completed-new-session`'s file drive the else branch with a nil
+`AuthenticatedAt` and assert `StartNewUserSession` is called. Any gate on
+`completed/really-authenticated` breaks all three, so the gap 3 work is **not** additive at the
+unit tier.
+
+### What #106 already built, and why it does not extend
+
+#106 added a per-user `auth_state_generation`, checked at `validator/code-generation`,
+`validator/refresh-generation` and `middleware/session-check`, plus `RevokeUserAuthState` and
+`revoke/refresh-tokens` in `revocation.go`. The generation is the part that survives a race,
+precisely because a rotated child inherits its parent's generation rather than the user's current
+value.
+
+It cannot be reused here. Incrementing a user-wide counter to sign out one device invalidates every
+other device that user has, which is the opposite of what the action means. The sweep helper is
+reusable; the boundary is not.
+
+### The pre-authentication oracle in the same block
+
+`validator/authcode-preauth` runs the user-enabled check, the generation check and the expiry check
+**before** client-secret validation and before PKCE. So a presenter holding a stolen code learns
+whether the account's generation moved without proving anything. This is live today and #137 owns
+it. It matters here because a new redemption check placed in that block inherits the same leak.
+
+On the refresh path, `validator/refresh-generation` likewise sits ahead of
+`validator/client-ownership`.
+
+### Test landscape
+
+- **Style.** `testify/assert` throughout, `t.Run` subtests rather than table structs in the handler
+  tests, `mockery` mocks under `src/core/data/mocks` and `mocks_*` packages.
+- **Unit.** `handler_auth_completed_test.go` is a single `TestHandleAuthCompletedGet` with 10
+  subtests. `token_validator_test.go` is 33 tests over 5168 lines. `revocation_test.go` has 8.
+- **No unit tests exist for either session-delete endpoint.** Neither
+  `handler_api_users_sessions_test.go` nor `handler_api_account_sessions_test.go` exists. Absent
+  infrastructure, so whichever stage touches those handlers creates the file.
+- **Data.** `src/authserver/tests/data/` runs all four engines and holds per-migration tests
+  (`migration_000024_auth_state_generation_test.go`, `migration_000025_family_index_test.go`) as the
+  precedent for a new migration.
+- **Integration.** `session_deletion_test.go` (the #46 guard), `session_bearer_revocation_test.go`
+  (3 tests pinning that a deleted session rejects bearer tokens),
+  `token_refresh_concurrent_test.go` and `token_authcode_concurrent_test.go` (the double-spend
+  harness a gap 2 test would mirror), `api_users_sessions_test.go`, `api_account_sessions_test.go`,
+  `authorize_existing_session_test.go`.
+
+### Documentation
+
+`site/src/content/docs/concepts/user-sessions.mdx` documents credential changes and live sessions
+for #106 and says nothing about explicit termination. `site/src/content/docs/integration/rest-api.mdx`
+describes the admin endpoint as "Terminates a user session by ID" and the account one as "Terminate
+session", with no claim about tokens. Nothing in the docs is falsified by this change, but the word
+"terminates" currently overpromises, and the gap that makes it overpromise is what this issue
+closes.
+
+### Failure direction
+
+Every gap here **fails open**: it preserves access that an operator or user believed they had
+removed. That is the opposite of #131's residual, which its own body calls fail-closed. It is the
+argument against deferring any of the three on grounds of window size, since the window is
+attacker-influenceable: a holder of a stolen offline refresh token can rotate in a loop while
+termination is attempted.
+
+---
+
+## 2. Goal
+
+1. Ending a session at an explicit "end this session" endpoint durably cuts off the grants that
+   session authorized, including offline ones, and cannot be undone by anything already in flight.
+2. A ceremony whose originating session was terminated mid-flight cannot complete into a usable
+   authorization code, while a ceremony in which the user actually authenticated still succeeds.
+3. A refresh racing a termination cannot leave a usable descendant.
+4. Whatever durable state is introduced has a stated retention position, whether that is a reaper
+   or a defended decision to keep the rows.
+5. The behaviour of ordinary RP-initiated logout is a recorded decision rather than an accident.
+
+### Out of scope
+
+- **#130**, the `DeleteUsedCodesWithoutRefreshTokens` NULL bug. Live today, already filed,
+  independent of this change unless a decision here edits that predicate.
+- **#133**'s full remedy: the cross-user session binding defect, its
+  browser-stays-signed-in-as-A consequence, the `completed/set-acr-level` leak and its test
+  coverage. Whether this issue implements the one-line guard is decision 10.
+- **#137**, moving the pre-existing generation and disabled-user checks behind client
+  authentication. Decision 7 covers only where a *new* check goes.
+- **#131** and **#132**, the rotation coordination residuals of #106 and #128.
+- **#135**, client-scoped "disconnect this application" revocation.
+- Third-party resource servers accepting an already-issued access token by signature alone. Inherent
+  to stateless tokens and already documented.
+- Reaping anything that exists today. `user_sessions` and its two existing reapers are untouched.
+
+---
+
+## 3. Open questions and decisions
+
+Twelve items. Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual at
+`/auth/issue` that the registry design did not have, which is item 12. Numbers are never reused, and
+decision 4 records its own reversal rather than being rewritten silently.
+
+1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
+
+   The issue does not close until the concurrency window is shut. Gaps 1 and 3 are implemented and
+   reviewed as earlier stages, which is delivery sequencing rather than scope reduction.
+
+   The deciding argument is that gap 2's marginal cost collapsed under verification. Because a
+   rotated child inherits its parent's `code_id` (`issuer/create-refresh-token` takes `CodeId` from
+   the code it is handed, and on the refresh path that code is `&refreshToken.Code`), a refresh-path
+   check keyed on the grant's originating session identifier rejects every present and future
+   descendant. So gap 2 needs no `codes.revoked` column, no new bulk method, and no edit to the
+   `db/mark-code-used` predicate that #77 hardened. The issue's own cost estimate for gap 2 priced a
+   design this document is not obliged to adopt.
+
+   Supporting: all three gaps fail open, preserving access someone believed they had removed, which
+   is the opposite direction from #131's residual that its own body calls fail-closed. And the
+   window is not merely theoretical: a holder of a stolen offline refresh token can rotate in a loop
+   while termination is attempted, so its size is adversary-influenceable.
+
+   **Rejected:** gaps 1 and 3 only, deferring gap 2 to a follow-up scoped alongside #131 and #132.
+   That would require amending goal 3, which promises a racing refresh leaves no usable descendant,
+   so the issue would assert something false. It also rested on the three races sharing a
+   serialization boundary, and their own texts refute that: #132 carries a section headed "Why #131
+   does not own this", and #132's race is family-scoped where gap 2's is session-scoped.
+
+   **Also rejected:** gap 1 only. It leaves the headline defect intact, since an in-flight ceremony
+   still recreates the session and mints a code no marker on existing rows reaches.
+
+   Note the sequencing commitment: gap 2 is staged last, but it still blocks #129 closing.
+
+2. **Yes. Ending a session revokes the offline grants whose ceremony rode it.** Status: **Decided**
+   Raised by: user
+
+   "Originated in it" means `codes.session_identifier` matches the terminated session, which is the
+   grant whose authorization ceremony rode that session. `db/refresh-by-sid` is exactly that query.
+
+   The deciding argument is that the repository has already taken this position for a neighbouring
+   action, and the inconsistency of not taking it here would be indefensible. `RevokeUserAuthState`
+   sweeps `GetRefreshTokensByUserId`, which is user-scoped and so includes offline tokens, and
+   `site/src/content/docs/concepts/user-sessions.mdx` states that a credential change covers "every
+   kind of grant, including offline refresh tokens whose browser session has already expired".
+   An operator told that a password change kills offline grants but an explicit "end this session"
+   does not has been handed a distinction with no principle behind it.
+
+   Supporting: the session list surfaces device name, type, OS and IP, so the action already reads
+   as "this device", and an offline grant obtained through a ceremony on that device is that
+   device's access.
+
+   Also supporting, and convenient: #106 already calls `db/refresh-by-sid` in production for its
+   *preserved* set, for the mirror-image reason (it reaches offline tokens through the `codes`
+   join). The query gap 1 needs is therefore already exercised on all four engines rather than new.
+
+   **Rejected:** leaving offline grants alone, on a literal reading of OIDC Core section 11
+   ("usable even when the End-User is not present (not logged in)"). It contradicts #106 and the
+   shipped documentation, and it reduces gap 1 to a no-op, since session-bound tokens already stop
+   working at `validator/session-branch` the moment the row is gone.
+
+   **Also rejected:** a setting. A security boundary behind a flag means the insecure position
+   exists, has to be documented, and has to be tested in both states, and nothing indicates demand.
+
+3. **No. RP-initiated logout's revocation behaviour is unchanged, and pinned by tests.**
+   Status: **Decided** Raised by: user
+
+   The dividing line is **intent, not database effect**. "End this session" is a security action
+   aimed at a device. Logout is navigation: the user is finished with one application. That
+   `logout/last-client-delete` deletes the session row when the departing client was the only one is
+   session-lifecycle bookkeeping, and it does not convert the action into a revocation decision.
+
+   This is what makes decisions 2 and 3 coherent rather than contradictory despite sharing a
+   database effect. It is also where the specifications land: OIDC Core section 11's statement that
+   an offline token is usable when the End-User is "not logged in" addresses exactly the logout case
+   and says nothing about administrative or account-level termination. OIDC RP-Initiated Logout is
+   silent on token revocation, and RFC 9700 section 4.14.2 says an authorization server **may**
+   revoke on a security event such as logout, permitting either answer.
+
+   Consequence for the current behaviour, which the stage that touches logout pins with tests so a
+   later change has to be deliberate: an offline grant survives logout in every case, and a
+   session-bound grant belonging to the client that just logged out **keeps working** while other
+   clients remain on the session, because neither `validator/session-branch` nor
+   `middleware/session-check` reads `UserSessionClient` at all.
+
+   **Rejected:** sweeping sid-wide on logout. `handleExistingSessionOnLogout` is per-client, so this
+   revokes grants belonging to clients that never logged out.
+
+   **Also rejected:** sweeping only when logout deletes the session. The outcome would depend on how
+   many other clients happen to share the session, which is invisible to the person clicking log
+   out, so the same action revokes nothing or everything.
+
+   The capability a user might actually want here, revoking one client's grants without touching the
+   session, needs client-scoped revocation within a session, which no query provides today. That is
+   #135 and it stays out of scope per section 2.
+
+   **Constrains decision 5:** enforcement cannot sit unconditionally inside `DeleteUserSession`,
+   because logout reaches it.
+
+4. **`codes.revoked` carries the boundary. The grant record is the marker.** Status: **Decided**
+   Raised by: user
+
+   > **This reverses a first answer, and the reversal is the interesting part.** The registry of
+   > terminated session identifiers was chosen first, then withdrawn when the user required that the
+   > state be reaped rather than retained. Keep this history: the registry is a reasonable design and
+   > the only thing wrong with it is its retention profile, so anyone revisiting this should know it
+   > lost on that ground and not on correctness.
+
+   At termination, mark every code of that session revoked. Reject a revoked code at redemption, and
+   reject a refresh token whose code is revoked. Semantics: **revoked means reject, not revoked means
+   continue normal processing.**
+
+   The boundary must still be a **positive record of termination**, and that requirement is what
+   rules out the obvious non-solution. The absence of a session row cannot mean "terminated":
+   `performTask` calls `DeleteIdleSessions` and `DeleteExpiredSessions`, so sessions vanish as
+   routine housekeeping, and per decision 2 an offline grant is designed to survive exactly that. So
+   `validator/offline-branch` cannot simply be made to consult the session the way
+   `validator/session-branch` does; that would kill every offline grant whose browser session merely
+   expired, which is the feature working as intended. Something has to be written down at
+   termination. The question decided here is only *where*.
+
+   Two properties make `codes` the right place, and both were verified rather than assumed.
+
+   **(a) It closes gap 2 structurally, with no race left to bound.** A rotated child inherits its
+   parent's `code_id` (`issuer/create-refresh-token`, and on the refresh path the code is
+   `&refreshToken.Code`). Marking the code therefore marks every present and future descendant at
+   once. The child is **born already rejected**, because the fact predates its existence. This is
+   categorically stronger than a sweep over rows that happen to exist, which is what every
+   timing-based design reduces to.
+
+   **(b) Its retention manages itself, so there is no horizon to defend.** `db/delete-used-codes`
+   reaps a code only when no refresh token references it, and `DeleteExpiredRefreshTokens` removes
+   descendants once past `expires_at` or `max_lifetime`. So the marker outlives every token that
+   could reference it, automatically, and becomes reclaimable exactly when the last one dies. This
+   is what decision 8 rests on.
+
+   `fieldtag:"dont-update"` on the model field keeps a stale `Code` from writing `revoked = false`
+   back: `UpdateCode` builds with `WithoutTag("dont-update")`, and #106 tags
+   `RefreshToken.AuthStateGeneration` the same way for the same reason.
+
+   Cost: a `codes.revoked` column via migration 000026 on four engines,
+   `RevokeCodesBySessionIdentifier(tx, sid)` plus four engine wrappers, `AND revoked = false` added
+   to the `db/mark-code-used` predicate that #77 hardened, rejections at both validator sites, an
+   extension to `db/delete-used-codes` so unused revoked codes are reaped (decision 8), and an
+   `/auth/issue` liveness check for the one case a code-level marker cannot reach (decision 6).
+
+   **Rejected: a registry of terminated session identifiers, retained indefinitely.** Correct, and
+   the only design that is airtight even against an unbounded handler stall. Rejected because it
+   never frees disk: it is keyed on a session identifier, which has no natural lifetime, and gap 2's
+   racing child (an offline token with up to `RefreshTokenOfflineMaxLifetimeInSeconds`, seeded at
+   31536000 seconds) means no finite horizon can be shown safe. The user's requirement is that the
+   state be reclaimable, and this design cannot satisfy it.
+
+   **Rejected: a registry with a bounded horizon plus conditional inserts.** Making `CreateCode` and
+   `CreateRefreshToken` refuse atomically when the grant's session is marked would let the horizon
+   shrink to the code lifetime. But its safety then rests on a statement's read snapshot never being
+   meaningfully older than the statement itself, which is engine-specific, and it adds
+   conditional-insert plumbing to two hot data-layer paths across four engines. `codes.revoked` gets
+   the same guarantee from row inheritance instead of from isolation semantics.
+
+   **Rejected: a tombstone on `user_sessions`.** It changes the semantics of
+   `GetUserSessionBySessionIdentifier`, which has 23 call sites across 14 files
+   (`grep -rn "GetUserSessionBySessionIdentifier(" src/ --include=*.go | grep -v mock | grep -v _test | grep -v "func (" | wc -l`),
+   including both middlewares, the validator, the token issuer, `BumpUserSession` and both list
+   endpoints. A missed call site fails open, and a tombstone reaching `BumpUserSession` is brought
+   back to life.
+
+   **Rejected: a per-session generation.** Tombstone blast radius plus more machinery, for nothing.
+   #106 needed a counter to preserve one session while revoking the rest; inside a single terminated
+   session there is no such requirement, so the fact is a boolean and a counter is strictly more.
+
+   **Rejected: transactional serialization as the carrier.** By the issue's own note it cannot
+   recognise a ceremony that began before the termination, so it still needs a persisted marker.
+
+   **#134 becomes moot** and should be closed: it tracks the retention of a terminated-session
+   registry, and no registry is being built.
+
+5. **The two explicit endpoints only, through a shared helper.** Status: **Decided**
+   Raised by: user
+
+   A helper called from `admin/session-delete` and `account/session-delete` performs three writes
+   **in one transaction**, so the durable fact and the revocation cannot land separately:
+   `RevokeCodesBySessionIdentifier`, the sid-scoped refresh-token sweep through `db/refresh-by-sid`,
+   and `DeleteUserSession`.
+
+   `DeleteUserSession` has six callers
+   (`grep -rn "DeleteUserSession(" src/ --include=*.go | grep -v mock | grep -v _test | grep -v "func (" | grep -v "data/"`),
+   and only two of them are the action this issue is about:
+
+   | Caller | Marker? | Why |
+   |---|---|---|
+   | `admin/session-delete` | yes | the explicit administrative action |
+   | `account/session-delete` | yes | the explicit self-service action |
+   | `logout/last-client-delete` | no | decision 3 |
+   | `sessionmgr/start-new` device sweep | no | displaces a session on ordinary re-login by the same user on the same device; not a security action, and it would revoke the grants of a session the user is actively replacing |
+   | `revocation.go` (#106 sweep) | no | the per-user generation is a strictly stronger boundary already, so a marker adds nothing |
+   | `handler_token.go` (#77 reuse cascade) | no | already sweeps sid-scoped tokens including offline ones through `db/refresh-by-sid` |
+
+   The background reapers call `DeleteIdleSessions` and `DeleteExpiredSessions` rather than
+   `DeleteUserSession`, so they are excluded by construction rather than by choice.
+
+   **Rejected:** enforcing inside `DeleteUserSession` with an opt-out. It guarantees no call site
+   forgets, but four of the six callers would pass the opt-out, and a flag that most callers disable
+   expresses intent worse than two explicit calls do. It also puts a registry write inside the reuse
+   cascade and the #106 sweep, where decision 4's own reasoning says it is redundant.
+
+   **Rejected:** adding the #77 reuse cascade. It would harden that path against a racing child, but
+   it widens this change into #77's territory, and the cascade already revokes offline tokens, so the
+   only gain is against the race #132 tracks.
+
+6. **Restart level 1 authentication. The gate is `!hasValidUserSession && !userReallyAuthenticated`.**
+   Status: **Decided** Raised by: user
+
+   In `HandleAuthCompletedGet`, the else branch reaches `completed/start-new-session` only when this
+   ceremony actually authenticated. Otherwise set `AuthStateRequiresLevel1`, save, and redirect to
+   `/auth/level1`.
+
+   Per section 1 the predicate **cannot** be "no valid session": `test/fresh-ceremony-after-delete`
+   is #46's guard over a legitimate case with exactly that shape, and it must stay green. The
+   discriminator is whether *this ceremony* performed level 1 authentication, which
+   `completed/really-authenticated` already computes from `AuthenticatedAt` and never consults here.
+
+   Restarting is chosen over failing to the client because the situation is precisely "this person
+   needs to authenticate", and it is how the codebase already expresses that at
+   `authorize/prompt-login` and on the no-valid-session path in `HandleAuthorizeGet`. It preserves
+   the ceremony's client, scope, state, nonce and PKCE parameters. There is no loop risk: the second
+   pass has `AuthenticatedAt` set by `pwd/authenticated-at` and takes the branch legitimately.
+
+   **The gate is broader than gap 3**, and that is deliberate. `completed/start-new-session` today
+   mints a session from `authContext.UserId` with no proof anyone authenticated, in *any* scenario
+   where the session vanished, not only after a deliberate termination.
+
+   Verified supporting facts:
+
+   - `AuthContext` is stored as JSON in the session cookie (`json.Marshal` in `SaveAuthContext`,
+     `json.Unmarshal` in `GetAuthContext`), so `AuthenticatedAt` round-trips as RFC 3339 and the
+     discriminator survives the redirect chain.
+   - On the path that reaches `/auth/completed` the only writers of `AuthenticatedAt` are
+     `pwd/authenticated-at` and the OTP handler, both real authentication. `authorize/sso-reuse`
+     leaves it nil.
+   - **`prompt=none` needs no separate answer.** `handlePromptNone` sets
+     `AuthStateReadyToIssueCode` and goes directly to `/auth/issue`, so it never reaches this gate.
+     Its own exposure is the case below, covered by the redemption check.
+
+   > **Load-bearing fragility, worth a test and a comment.** `handlePromptNone` *does* set
+   > `AuthenticatedAt` from the session it reused. It never reaches `/auth/completed` today, so the
+   > discriminator holds, but if that ever changed the gate would silently pass. The gate's meaning
+   > is "this ceremony authenticated", and only its current call graph makes `AuthenticatedAt` mean
+   > that.
+
+   **This gate closes only part of gap 3.** Two sub-cases:
+
+   - **Before `/auth/completed`.** The SSO ceremony is stopped by this gate. No durable state needed.
+   - **After `/auth/completed`, before `/auth/issue`.** The session was alive at `/auth/completed`
+     and was bumped; the user then sits on the consent screen. `issue/sid-from-context` still reads
+     the terminated session's identifier from the cookie, and `issue/create-code` stamps it onto a
+     **brand-new** code. Decision 4's marker cannot reach it, because a code-level fact cannot be
+     written onto a row that does not exist yet. This is also the `prompt=none` exposure, since
+     `handlePromptNone` bumps the session and goes straight to `/auth/issue`.
+
+   The second sub-case is closed by a **liveness check at `/auth/issue`**: refuse to mint a code when
+   the ceremony's bound session identifier no longer resolves to a session row, and restart level 1
+   as above. This is deliberately a *liveness* check rather than a termination check, so it needs no
+   marker and no registry, and it is correct on its own terms: a ceremony must not bind a grant to a
+   session that no longer exists, whether it was terminated or merely reaped. Its residual is
+   decision 12.
+
+   **Cost, already verified:** three subtests in `test/completed-new-session`'s file drive the else
+   branch with a nil `AuthenticatedAt` and must gain one. The gap 3 work is not additive at the unit
+   tier.
+
+   **Rejected:** failing to the client with `login_required` or `access_denied`. It costs the user a
+   round trip through the client to arrive at the same password form, and discards a ceremony that
+   could have completed correctly.
+
+   **Also rejected:** a 500. The state is reachable through a legitimate administrative action, so it
+   is not an invariant violation, and it would surface as an error page instead of a login prompt.
+
+7. **After client authentication and PKCE, and after the reuse return.** Status: **Decided**
+   Raised by: user
+
+   Two placements, one per grant type:
+
+   - **`authorization_code`:** client secret, then PKCE, then the `if wasReused` return, **then** the
+     revoked-code check. Not in `validator/authcode-preauth`.
+   - **`refresh_token`:** after `validator/client-ownership`, rejecting when
+     `refreshToken.Code.Revoked`. Client-secret validation already runs at the top of that case,
+     before the token is even parsed, so the refresh path is behind client authentication by
+     construction and only the ownership ordering is a choice.
+
+   The code path's check reads `codeEntity.Revoked` and the refresh path's reads
+   `refreshToken.Code.Revoked`, both already loaded: `RefreshTokenLoadCode` populates the whole code
+   row, and the validator derives `codeEntity = &refreshToken.Code`. No new query is needed at either
+   site.
+
+   The deciding argument is that the codebase already took a position against this disclosure and
+   ordering silently undoes it. `invalidGenerationMessage`'s own comment says that naming the cause
+   "would tell an attacker holding a stolen token exactly what happened". A generic message is
+   defeated when *which* generic message you get is itself the signal, which is the defect #137
+   describes. Adding a new member to a class that already has an open issue to close it would be
+   going backwards.
+
+   The reuse return stays ahead of the registry check so #77's containment cascade is not pre-empted:
+   the reused-code error carries the code entity and drives `revokeAndAuditAuthCodeReuse`, and a
+   registry rejection landing first would suppress it. Reuse is also the stronger signal, and it
+   already revokes everything the registry check would have refused.
+
+   Placing this check correctly gives #137 a pattern to follow plus a negative control to copy, which
+   is worth more than consistency with the neighbours it is deliberately not joining.
+
+   **Cost:** a comment explaining why the check sits apart from the checks around it, or a reviewer
+   tidies it back into `validator/authcode-preauth`. Section 5's negative controls are what make the
+   ordering testable rather than merely intended.
+
+   **Rejected:** placing it in `validator/authcode-preauth` with its neighbours. Consistent and
+   comment-free, but it widens the exact class #137 exists to close, letting an unauthenticated
+   presenter of a stolen code learn whether the session was terminated.
+
+   **Also rejected:** absorbing #137 by reordering the pre-existing generation and disabled-user
+   checks in the same change. Cleaner end state, but those checks belong to #106 and #137 was filed
+   deliberately to own the behaviour change, and folding it in enlarges this issue's review surface
+   and regression risk. #137 stays out of scope per section 2.
+
+8. **The two existing reapers already do it, plus one predicate extension for unused revoked codes.**
+   Status: **Decided** Raised by: user
+
+   Settled by decision 4 rather than independently, since the carrier chosen is the one whose
+   retention needs no horizon.
+
+   **Used revoked codes: nothing changes.** `db/delete-used-codes` reaps a code only when no refresh
+   token references it, and `DeleteExpiredRefreshTokens` removes descendants once past `expires_at`
+   or `max_lifetime`. So a revoked code survives exactly as long as some descendant could present it
+   and is reclaimed once the last one dies. That is the correct lifetime, derived rather than chosen,
+   and it is why no cutoff has to be defended.
+
+   **Unused revoked codes need a new predicate.** A code revoked at termination while still
+   unredeemed has `used = false`, and `db/delete-used-codes` filters `used = true`, so those rows
+   would accumulate forever. The extension reaps `revoked = true AND used = false AND created_at <
+   cutoff`. Safe with a short cutoff, and provably so: an unused code has no refresh tokens by
+   definition, and it is unredeemable after 60 seconds anyway per `authCodeExpirationInSeconds`. So
+   the cutoff here really is the code lifetime plus a clock allowance, which is the horizon that was
+   *wrong* for a session-keyed registry and is *right* for a code-keyed one.
+
+   The distinction is worth keeping straight, because the wrong version looks identical: a
+   session-keyed marker cannot use a code-lifetime horizon, because a refresh token references it for
+   up to `RefreshTokenOfflineMaxLifetimeInSeconds` (seeded at 31536000). A code-keyed marker can,
+   *for the unused case only*, because an unused code has no descendants at all.
+
+   **Rejected:** a time horizon on the whole marker, of any length. Under decision 4's carrier it is
+   unnecessary for used codes and would be actively unsafe, since it could reap a code whose live
+   offline descendant is still refreshing.
+
+   **Rejected:** leaving unused revoked codes in place. It reintroduces unbounded growth, which is the
+   defect that moved decision 4 off the registry in the first place.
+
+   > **Note for the run.** Disk is only actually reclaimed once #130 is fixed:
+   > `db/delete-used-codes` builds `NotIn("id", SELECT code_id FROM refresh_tokens)`, and because ROPC
+   > refresh tokens have `code_id = NULL`, `x NOT IN (…, NULL)` is UNKNOWN rather than TRUE, so the
+   > predicate matches nothing once any ROPC token exists. #130 owns that and it stays out of scope
+   > per section 2, but the reclamation claimed here is latent until it lands. The correctness of
+   > decision 4 does not depend on it; only the disk saving does.
+
+9. **Emit both events.** Status: **Decided** Raised by: user
+
+   `AuditDeletedUserSession` keeps its existing payload untouched (`userSessionId`, `loggedInUser`),
+   and a new `terminated_user_session` event carries the security detail: `userId`, `userSessionId`,
+   `sessionIdentifier`, `revokedRefreshTokenJtis` and `revokedCodeCount`, plus `loggedInUser`.
+
+   The user's choice, taken over the recommendation below. Its argument is compatibility: any external
+   consumer parsing `deleted_user_session` with a strict schema keeps working untouched, and the two
+   records carry different meanings, one a session-lifecycle fact and one a security action.
+
+   Both are emitted **after the termination transaction commits**, following
+   `revokeAndAuditAuthCodeReuse`, which audits only once the revoke succeeded, so neither event can
+   claim something that rolled back.
+
+   Field choices follow existing precedent rather than invention: `AuditAuthCodeReuseDetected` already
+   carries `sessionIdentifier` and `revokedRefreshTokenJtis` for this exact shape, and #106's
+   `AuditRevokedUserAuthState` lists JTIs too. Codes get a **count** rather than a list of IDs because
+   no event in the codebase lists code IDs, and a count answers the only question an auditor has here,
+   whether anything was revoked.
+
+   Cost: a new constant plus an entry in the audit event list in `constants.go`.
+
+   **The known downside, and its mitigation.** Two rows per action makes "how many sessions were
+   terminated" ambiguous to count. Mitigation, which the documentation stage must state:
+   `terminated_user_session` is the event to count for terminations, and `deleted_user_session` is the
+   lifecycle record that accompanies it.
+
+   **Not chosen (was recommended):** extending `AuditDeletedUserSession` in place. The action is the
+   same action doing more, a JSON payload makes added keys additive, both emitters were being changed
+   together so no partial payload could arise, and one row per action avoids the correlation the
+   chosen option requires. Recorded because if the counting ambiguity ever becomes a nuisance, this is
+   the alternative and the reason it lost was compatibility, not correctness.
+
+10. **No. #133 stays whole and #129 does not touch it.** Status: **Decided** Raised by: user
+
+    #133 is independent on its own terms: it needs no termination, no offline grant and no race, and
+    both its entry paths (`authorize/prompt-login`, `authorize/hint-mismatch`) leave a live session
+    cookie in place with no user comparison anywhere downstream. `sessionmgr/bump-no-userid` assigns
+    methods and ACR but never `UserId`.
+
+    The only argument for entangling them was decision 4's original registry design, which needed the
+    ceremony's originating session identifier bound onto the `AuthContext`, and would therefore have
+    persisted a wrong user association deliberately rather than incidentally. **Decision 4's reversal
+    removed that need**: `codes.revoked` requires no `AuthContext` field, and both of this issue's
+    gates read the ambient sid the way `/auth/issue` already does.
+
+    Verified that #129 is neutral rather than merely uninvolved:
+
+    - Decision 6's gate fires only when there is **no** valid session. #133's `prompt=login` path has
+      user A's session valid, so the gate never sees it and the bump branch is taken exactly as today.
+    - Decision 12's statement reads the same ambient session identifier `issue/sid-from-context`
+      already uses, so it introduces no new association.
+
+    **Rejected:** taking the one-line guard as cheap hardening while `HandleAuthCompletedGet` is open
+    anyway. It splits #133's coverage across two issues, and by #133's own analysis the guard alone is
+    not the fix: `completed/set-acr-level` runs after the branch and must be fed the new session or
+    nil, or A's ACR is still grafted onto B's code. Shipping the guard without that leaves the leak
+    live while looking fixed, which is worse than not starting.
+
+    **Action for #133:** its text claims "#129 implements the same-user guard as part of its stage 5".
+    That is no longer true and should be corrected when its decision-number citations are reconciled.
+
+11. **Out of scope, and documented explicitly rather than inherited.** Status: **Decided**
+    Raised by: user
+
+    Goal 1's "durably cuts off" covers refresh tokens and authorization codes. An offline grant's
+    access token stays acceptable until it expires, 5 minutes by default.
+
+    The reason it cannot be reached is structural rather than a matter of effort.
+    `issuer/suppress-sid-claim` omits the `sid` claim for an offline grant, and the token carries no
+    other grant identifier, so `middleware/session-check` has nothing to look up. It falls through to
+    the per-user generation comparison, and termination must not move that counter, since doing so
+    would invalidate every other device belonging to that user, which is the whole reason this issue
+    exists separately from #106.
+
+    **The documentation consequence is the load-bearing part of this decision.**
+    `site/src/content/docs/concepts/user-sessions.mdx` currently says that after a credential change,
+    Goiabada's **own** endpoints "reject a token from a superseded session on the very next request".
+    That is true for #106, because the generation moves. It is **false** for session termination of an
+    offline grant, where even Goiabada's own endpoints keep accepting the access token until expiry.
+    The stage that touches documentation must state that difference rather than let the existing
+    sentence be read as covering this case too, because a reader would otherwise conclude the opposite
+    of what is true.
+
+    **Rejected:** including the `sid` claim on offline access tokens so the middleware can reach them.
+    It would make every offline grant's access token stop working as soon as its browser session was
+    reaped, since the middleware treats a missing session as invalid. That breaks `offline_access` by
+    design, and it is exactly the outcome decision 2 was careful to avoid.
+
+    **Rejected:** adding a grant identifier claim plus a lookup. It closes the window properly, but it
+    is a wire-format change plus a database read on every authenticated API request, which is
+    disproportionate to a 5 minute default window whose mitigation (short access-token expiry) is
+    already documented.
+
+12. **A compensating revoke after the insert, as one statement.** Status: **Decided** Raised by: user
+
+    Exposed by decision 4's reversal. The registry design did not have this residual, because a marker
+    keyed on the session identifier catches a code inserted at any later time. A marker keyed on the
+    code cannot, so decision 6 adds a liveness check at `/auth/issue`, and that check is a read
+    followed by an insert.
+
+    The interleaving it leaves: `/auth/issue` reads the session and finds it live, termination commits,
+    then `issue/create-code` commits. That code is bound to a session that no longer exists and
+    carries no marker, because it did not exist when `RevokeCodesBySessionIdentifier` ran.
+
+    What survives such a code's redemption, verified:
+
+    - A **session-bound** refresh token dies at `validator/session-branch`, which finds no session
+      row. Nothing to do.
+    - An **offline** refresh token survives, up to `RefreshTokenOfflineMaxLifetimeInSeconds`. This is
+      the residual worth closing.
+    - The **access token** survives to its expiry either way, which is decision 11.
+
+    **The fix.** Keep the liveness read, because it produces the good outcome in the common case where
+    the session is genuinely gone: restart level 1 per decision 6, rather than minting a code and
+    revoking it. Then, immediately after `issue/create-code`, run one statement:
+
+    ```sql
+    UPDATE codes SET revoked = true, updated_at = ?
+    WHERE id = ?
+      AND NOT EXISTS (SELECT 1 FROM user_sessions WHERE session_identifier = ?)
+    ```
+
+    **Why this composes rather than merely narrowing.** Two sweepers now cover each other:
+
+    - If the code insert commits **before** termination's `RevokeCodesBySessionIdentifier` statement
+      reads `codes`, termination marks it.
+    - If it commits **after**, this statement observes the session already gone and marks it.
+
+    The only interleaving escaping both is one where the code insert lands between the termination
+    transaction's `UPDATE` statement and that transaction's `COMMIT`, so this statement still reads the
+    session as present. That is a genuinely tight window between two bounded statements, rather than
+    the unbounded handler stall the read-only check leaves.
+
+    It also reuses the column decision 4 already adds, needs no new insert path, and keeps
+    `CreateCode` on the `sqlbuilder` struct-insert pattern.
+
+    **Cost:** one extra indexed `UPDATE` per authorization code issued, normally matching zero rows.
+    Accepted as the price of not leaving a fail-open hole.
+
+    **Rejected:** a conditional insert,
+    `INSERT INTO codes (...) SELECT ... WHERE EXISTS (SELECT 1 FROM user_sessions WHERE session_identifier = ?)`.
+    It prevents rather than compensates, so no bad code ever exists, which is the stronger property.
+    Rejected on maintenance risk: it means a hand-written insert for `codes` on four engines, diverging
+    from the struct-insert every other create method uses, on the most security-critical insert in the
+    codebase, and a hand-written column list is exactly where a later added column gets forgotten.
+
+    **Rejected:** accepting the residual and filing a follow-up alongside #131 and #132. Defensible,
+    since those three want the same missing primitive, but the compensating statement closes most of
+    it now for one `UPDATE`, so deferring would be paying a security cost to avoid a trivial one.
+
+    > **Residual, stated rather than implied.** The interleaving above is not closed. It belongs to the
+    > same class as #131 and #132: ordering a write against a sweep portably across four engines. The
+    > run should record it in section 7 and it is a candidate follow-up, but it does not block this
+    > issue.
+
+---
+
+## 4. Design
+
+Ending a session becomes a security action with a durable consequence, and the durable consequence
+lives on the **grant record** rather than on the session or in a side table.
+
+### 4.1 The property that makes this safe
+
+**A refresh token can only ever descend from a code, and a descendant inherits its parent's
+`code_id`.** So marking a code is not a sweep over rows that happen to exist; it is a statement about
+the whole grant, past and future. A child inserted a millisecond or a month after termination reads
+its own grant as revoked, because the fact was written before that child existed.
+
+Everything else follows from this. Gap 2 needs no serialization, because there is no window between
+"the fact is true" and "the row exists" to serialize. And retention needs no defended horizon,
+because `db/delete-used-codes` already refuses to reap a code while any refresh token references it,
+so the marker outlives every token that could present it and becomes reclaimable exactly when the
+last one dies (decision 8).
+
+The second property, which the first does not give: **absence of a session never means terminated.**
+`performTask` reaps idle and expired sessions routinely and offline grants are designed to outlive
+them, so termination has to write something positive down. That is why `validator/offline-branch`
+cannot simply be taught to consult the session, and it is the constraint that ruled out every design
+inferring termination from a missing row (decision 4).
+
+### 4.2 Termination
+
+One helper, called from `admin/session-delete` and `account/session-delete` only (decision 5), doing
+three writes in **one transaction**:
+
+1. `RevokeCodesBySessionIdentifier(tx, sid)`, marking every code of that session revoked.
+2. The sid-scoped refresh-token sweep: `db/refresh-by-sid` to load, then `revoke/refresh-tokens` to
+   mark. This reaches offline tokens because the query joins through `codes` (decision 2), and it is
+   the same call #106 already makes for its preserved set.
+3. `DeleteUserSession(tx, id)`.
+
+Step 1 is what survives; steps 2 and 3 are cleanup that makes the effect immediate. Both audit events
+fire after the commit (decision 9).
+
+The four other `DeleteUserSession` callers are untouched, each for a reason recorded in decision 5.
+`logout/last-client-delete` in particular keeps its current behaviour exactly, pinned by tests
+(decision 3).
+
+### 4.3 Where the marker is checked
+
+Two reads, both of data already loaded, so neither adds a query (decision 7):
+
+| Site | Reads | Position |
+|---|---|---|
+| `authorization_code` redemption | `codeEntity.Revoked` | after client secret, after PKCE, after the `if wasReused` return |
+| `refresh_token` validation | `refreshToken.Code.Revoked` | after `validator/client-ownership` |
+
+Both sit **behind** client authentication, deliberately apart from the checks in
+`validator/authcode-preauth`. That block leaks whether a user's generation moved to anyone holding a
+stolen code, which is #137, and a new check placed there would join that class. The `wasReused`
+return stays ahead so #77's containment cascade is not pre-empted, and reuse already revokes
+everything a revoked-code rejection would have refused.
+
+`MarkCodeAsUsed` gains `AND revoked = false`, so a code cannot be claimed between validation and
+claiming. Without it, validation and claiming are separate steps and a code revoked in between would
+still be claimed.
+
+### 4.4 Gap 3, in two halves
+
+The issue proposes failing when the session is gone. **Verified wrong, and decision 6 records the
+departure:** `test/fresh-ceremony-after-delete` is #46's guard over a legitimate case with exactly
+that shape. The discriminator is whether *this ceremony* authenticated.
+
+**Half one, before `/auth/completed`.** The else branch reaches `completed/start-new-session` only
+when `userReallyAuthenticated`. Otherwise set `AuthStateRequiresLevel1` and redirect to
+`/auth/level1`. `completed/really-authenticated` already computes this and currently consults it only
+in the branch where it does not matter. No durable state involved.
+
+This is broader than gap 3 by design: `completed/start-new-session` today mints a session from
+`authContext.UserId` with no proof anyone authenticated, whenever the session has vanished for any
+reason.
+
+**Half two, after `/auth/completed`.** The session was alive and bumped, then the user sits on the
+consent screen; `prompt=none` reaches the same place by going straight from `handlePromptNone` to
+`/auth/issue`. Here `issue/create-code` mints a **new** code, which a code-level marker cannot reach.
+Two statements cover it (decisions 6 and 12):
+
+1. A liveness read at `/auth/issue`: if the bound sid resolves to no session row, restart level 1.
+   This is a liveness check, not a termination check, so it needs no marker and is right on its own
+   terms, since a ceremony must not bind a grant to a session that no longer exists.
+2. Immediately after the insert, one compensating statement:
+   `UPDATE codes SET revoked = true, updated_at = ? WHERE id = ? AND NOT EXISTS (SELECT 1 FROM user_sessions WHERE session_identifier = ?)`.
+
+Statement 2 and termination's own step 1 cover each other. A code committing before termination reads
+`codes` is marked by termination; a code committing after is marked by statement 2. Only a code
+landing between the termination transaction's `UPDATE` and its `COMMIT` escapes both, which decision
+12 records as an open residual in the same class as #131 and #132.
+
+### 4.5 Retention
+
+Nothing new to reap for used codes: the existing pair already gives the right lifetime. One predicate
+is added so unused revoked codes do not accumulate, reaping
+`revoked = true AND used = false AND created_at < cutoff`. Safe with a short cutoff because an unused
+code has no refresh tokens by definition and is unredeemable after 60 seconds anyway.
+
+The horizon that is **wrong** for a session-keyed marker is **right** here, and the difference is
+worth keeping straight because the two look identical: a session-keyed marker is referenced by
+refresh tokens for up to `RefreshTokenOfflineMaxLifetimeInSeconds` (seeded at 31536000), while an
+unused code has no descendants at all.
+
+Actual disk reclamation is latent until #130 lands, since `db/delete-used-codes` currently matches
+nothing once any ROPC refresh token exists. Correctness here does not depend on that; only the saving
+does.
+
+### 4.6 What deliberately does not change
+
+- **RP-initiated logout**, in any respect (decision 3), with today's contract pinned by tests
+  including that a logged-out client's session-bound token keeps working while others share the
+  session.
+- **The per-user generation.** Termination must never move it, or one device's sign-out would
+  invalidate every other device. That asymmetry with #106 is the reason this issue exists separately.
+- **`validator/authcode-preauth`'s existing checks.** #137 owns reordering them.
+- **`#133`'s same-user guard** (decision 10). Verified that #129 is neutral on it.
+- **Offline grants' access tokens** (decision 11), scoped out with a documentation obligation rather
+  than silently.
+
+### 4.7 Departures from the issue
+
+| Issue says | Verified reading | Recorded in |
+|---|---|---|
+| gap 3 should "fail and force re-authentication" when the session is gone | the predicate must be "this ceremony did not authenticate", or #46's regression breaks | decision 6 |
+| gap 2 needs `codes.revoked` plus a bulk method plus a `MarkCodeAsUsed` edit, priced as significant | the same column closes gaps 1 and 2 together, because descendants inherit `code_id`; the marginal cost of gap 2 is close to zero | decisions 1, 4 |
+| a session tombstone or registry is the natural carrier | both were considered; the registry lost on retention, the tombstone on blast radius across 23 call sites | decision 4 |
+| rotation marks the parent with `UpdateRefreshToken(nil, ...)` | #128 replaced that with a compare-and-set; the race survives but the citation is stale | section 1, gap 2 |
+| the fix is about refresh tokens | offline grants' **access** tokens survive too, and the shipped documentation currently implies otherwise | decision 11 |
+
+---
+
+## 5. Seams
+
+Nine boundaries. Existing ones are marked, because preferring them is the point: **every seam here is
+an existing test file**, and the only new artefacts are two data methods.
+
+### Data tier, all four engines
+
+1. **`Database.RevokeCodesBySessionIdentifier(tx, sid)`** (new). Owns the exhaustive table for which
+   rows the marker reaches: codes of the target session, codes of an unrelated session left alone,
+   unknown sid, empty sid, a session whose codes are already revoked (idempotent, and the returned
+   count reflects rows actually transitioned). Also owns the two questions a mock can never answer:
+   does the **failure path** return an error rather than a benign zero, and does it **enlist in the
+   caller's transaction** rather than the pool. A rolled-back transaction forces both, following
+   `TestTransaction_RollbackUndoesMultiStatementDelete` in `transaction_test.go`.
+
+2. **`Database.MarkCodeAsUsed(tx, id)`** (existing, in `code_test.go`). Owns the claim predicate. The
+   new row is a revoked but unused code, which must **not** be claimable. Keep the existing
+   already-used row: together they prove the predicate has both terms, and either alone passes with
+   the other term deleted.
+
+3. **`Database.DeleteUsedCodesWithoutRefreshTokens(tx, before)` and the unused-revoked reaper**
+   (existing method, extended). Owns what is reaped and, more importantly, **what is retained**: a
+   revoked code with a live refresh token must survive, because decision 8's whole safety argument is
+   that the marker outlives its descendants. That retention row is the regression guard for decision
+   4 and its value is invisible once the design is right, so it gets a "keep this" note.
+
+4. **The compensating revoke** (new method, decision 12). Owns: marks the code when no session row
+   exists, does nothing when one does, and is a single statement. The "does nothing" row is the one
+   that matters, since a method that always revoked would pass every other assertion.
+
+### Unit tier
+
+5. **`validators.ValidateTokenRequest`** (existing, `token_validator_test.go`). Owns the exhaustive
+   rejection **and ordering** table for both grant types. The ordering rows are decision 7's only
+   testable content and are what stop the checks drifting back into `validator/authcode-preauth`:
+
+   - a revoked code with a **wrong PKCE verifier** returns the PKCE error, not the revoked-code error;
+   - a revoked code presented with a **wrong client secret** returns the client-authentication error;
+   - a **reused** revoked code still returns the reuse error, so #77's cascade is not pre-empted;
+   - a revoked grant's refresh token presented by the **wrong client** returns the ownership error.
+
+   Each of those is a negative case that names the gate meant to reject it, so none can pass with the
+   revoked check deleted. Consumers elsewhere get thin tests, deliberately, per section 8 of the
+   testing reference.
+
+6. **`HandleAuthCompletedGet`** (existing, `handler_auth_completed_test.go`, 10 `t.Run` subtests).
+   Owns decision 6's branch table. New row: no valid session and `AuthenticatedAt` nil, asserting a
+   redirect to `/auth/level1` and that `StartNewUserSession` is **not** called. The three existing
+   subtests reaching `StartNewUserSession` gain a non-nil `AuthenticatedAt`, which is the recorded
+   non-additive cost.
+
+7. **`HandleIssueGet`** (existing, `handler_auth_issue_test.go`, `TestHandleIssueGet` with 3 `t.Run`
+   subtests). Owns the liveness branch from decision 6: a bound sid resolving to no session redirects
+   to `/auth/level1` and no code is created; a live session proceeds. Extend `TestHandleIssueGet`
+   rather than adding a sibling, inheriting its setup. Its "Successfully issues a code" subtest gains
+   the session lookup and the compensating call to its mock expectations, which is a second
+   non-additive cost alongside seam 6's. Whether the compensating statement *works* belongs to seam 4,
+   so this seam asserts only that it is issued.
+
+   Note the implicit-flow subtests in the same file also reach `HandleIssueGet`, and
+   `handleImplicitFlow` issues tokens directly without creating a code. Whether the liveness check
+   sits before or after the implicit-flow branch decides whether those subtests change; put it after,
+   so implicit flow is untouched and the check guards only `issue/create-code`.
+
+### Integration tier, dev container
+
+8. **`POST /auth/token`** (existing suites). The highest seam that can observe the advertised
+   behaviour, and where the headline claim is proven without reaching into storage: authorize with
+   `offline_access`, terminate the session, then refresh and expect rejection. Paired with the reverse
+   assertion, that a grant on an **unrelated** session still refreshes, since without it the test
+   passes against a change that revokes everything.
+
+9. **The session-management endpoints** (existing suites: `api_users_sessions_test.go`,
+   `api_account_sessions_test.go`, `api_account_logout_request_test.go`, `session_deletion_test.go`).
+   Owns three contracts at once:
+
+   - both `DELETE` endpoints revoke, with ownership still enforced on the account one;
+   - `/auth/logout` behaviour is **unchanged**, decision 3, including that a logged-out client's
+     session-bound refresh token keeps working while other clients share the session. This pins
+     today's behaviour so #135 has to change it deliberately;
+   - the mid-flight ceremony, gap 3, driven on one HTTP client so the cookie is shared: begin an SSO
+     ceremony, terminate the session before it completes, and assert no usable code is issued. Plus
+     the #46 case, `test/fresh-ceremony-after-delete`, still green, which is the pair that proves
+     decision 6 chose the right predicate rather than merely a strict one.
+
+**Rejected seams**
+
+- **Asserting `codes.revoked` from handler or integration tests.** A side channel into storage: it
+  passes with the endpoint broken, and it breaks on any refactor that moves the fact. The endpoint
+  observation is "the refresh is refused". Seams 1 to 4 own the column.
+- **Mock expectations as the only evidence for the new data methods.** A mock proves callers propagate
+  what it returned, never that the real implementation avoids collapsing a query, scan or `rows.Err()`
+  failure into a benign zero. For a method that gates access, that fails open for the duration of a
+  database fault with the suite green. Seams 1 and 4 carry real cases for exactly this.
+- **A unit seam as the primary home for the termination helper's atomicity.** `revocation_test.go` is
+  mock-based, following #106, so it can show the transaction is threaded through all three writes but
+  not that a failure rolls them back. The helper gets unit coverage there for the threading, and
+  seam 1's rolled-back-transaction case plus seam 9 carry the atomicity.
+- **A new test file for the termination helper.** `revocation_test.go` already exists beside it and
+  owns this shape.
+
+> **Obligation for the run.** Per section 5 of the testing reference, every table above is executed in
+> the scratchpad before it is written into section 6, and re-run after any revision. Counts are never
+> carried forward across a change.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -1334,29 +1334,34 @@ Tiers: unit (three modules), data (four engines). Integration not applicable, no
 Docs: none, internals only. Verified in section 2 that `CLAUDE.md` and `AGENTS.md` enumerate neither
 migrations nor the `codes` table, and no page on the docs site describes either.
 
-1. Migration `000026_add_code_revoked`, up and down, for all four engines. Types follow
-   `refresh_tokens.revoked` on each: sqlite `numeric`, mysql `tinyint(1)`, postgres `boolean`, mssql
-   `BIT`. Each declares `NOT NULL DEFAULT` false, and mssql names its default constraint
-   `df_codes_revoked` so the down migration can drop the constraint before the column, which is the
-   hazard 000024 documents. **No index**: the sweep is keyed on `session_identifier`, which
-   `idx_codes_session_identifier` from 000024 already covers, and stage 6's reaper scans by
-   `created_at`. Status: **Done**
-2. The four `schema.sql` snapshots gain the column, in the position the migration puts it (after
-   `used`). Documentation only, never loaded by Go. Status: **Done**
-3. `models.Code.Revoked` with `db:"revoked"` and `fieldtag:"dont-update"`, carrying the comment
-   decision 4 requires: an ordinary full-row `UpdateCode` must not be able to write the marker back
-   to false. Mirrors `Code.AuthStateGeneration`. Status: **Done**
-4. `RevokeCodesBySessionIdentifier(tx, sid) (int64, error)` in `commondb/code.go`, its declaration in
-   the `Code` block of `data/database.go`, the one-line wrapper in each of the four engine packages,
-   and regenerated mocks (`authserver/generate-mocks.sh`, run in the dev container). The predicate is
+Each step carries its status on its own numbered line, because that is what the guard parses. A status
+on a continuation line reads as an untraced step and refuses the gate.
+
+1. **Migration `000026_add_code_revoked`, up and down, on four engines.** Status: **Done**
+   Types follow `refresh_tokens.revoked` on each: sqlite `numeric`, mysql `tinyint(1)`, postgres
+   `boolean`, mssql `BIT`. Each declares `NOT NULL DEFAULT` false, and mssql names its default
+   constraint `df_codes_revoked` so the down migration can drop the constraint before the column,
+   which is the hazard 000024 documents. **No index**: the sweep is keyed on `session_identifier`,
+   which `idx_codes_session_identifier` from 000024 already covers, and stage 7's reaper scans by
+   `created_at`.
+2. **The four `schema.sql` snapshots gain the column.** Status: **Done**
+   In the position the migration puts it, after `used`. Documentation only, never loaded by Go.
+3. **`models.Code.Revoked`, tagged `dont-update`.** Status: **Done**
+   With the comment decision 4 requires: an ordinary full-row `UpdateCode` must not be able to write
+   the marker back to false. Mirrors `Code.AuthStateGeneration`.
+4. **`RevokeCodesBySessionIdentifier(tx, sid) (int64, error)`.** Status: **Done**
+   In `commondb/code.go`, declared in the `Code` block of `data/database.go`, with the one-line
+   wrapper in each of the four engine packages and regenerated mocks
+   (`authserver/generate-mocks.sh`, run in the dev container). The predicate is
    `session_identifier = ? AND revoked = false`, the assignment sets `revoked` and `updated_at`, and
    the return is `RowsAffected`. An empty identifier returns an error rather than being used as a
-   filter. Status: **Done**
-5. `db/mark-code-used` gains `AND revoked = false`, with the comment section 4.3 requires: validation
-   and claiming are separate steps, so without this term a code revoked in between is still claimed.
-   The interface doc comment gains the same note. Status: **Done**
-6. Data cases at **seam 1**, in `code_test.go`, all four engines. Two tests: the sweep's table, and
-   the transaction and failure path a mock cannot answer for. The rows, all executed:
+   filter.
+5. **`db/mark-code-used` gains `AND revoked = false`.** Status: **Done**
+   With the comment section 4.3 requires: validation and claiming are separate steps, so without this
+   term a code revoked in between is still claimed. The interface doc comment gains the same note.
+6. **Data cases at seam 1, in `code_test.go`, all four engines.** Status: **Done**
+   Two tests: the sweep's table, and the transaction and failure path a mock cannot answer for. The
+   rows, all executed before being written here:
 
    | Case | Expected | Which gate rejects it, or what it proves |
    |---|---|---|
@@ -1371,21 +1376,35 @@ migrations nor the `codes` table, and no page on the docs site describes either.
    **Keep the unrelated-session row and the rolled-back row.** The first is the only case that fails
    if the sweep is written session-wide by mistake, which would sign out every device of every user.
    The second is the only case exercising the real implementation's transaction handling; every
-   mock-based test above it passes with the parameter ignored. Status: **Done**
-7. Data cases at **seam 2**, extending `TestMarkCodeAsUsed` rather than adding a sibling: a revoked
-   but unused code is **not** claimable, and stays unused afterwards. **Keep the existing
+   mock-based test above it passes with the parameter ignored.
+7. **Data cases at seam 2, extending `TestMarkCodeAsUsed`.** Status: **Done**
+   A revoked but unused code is **not** claimable, and stays unused afterwards. **Keep the existing
    already-used row beside it**, since either row alone still passes with the other term deleted from
    the predicate. Plus `TestUpdateCode_DoesNotClobberRevoked`, mirroring the four existing
    `DoesNotClobber` tests, which is the only case that fails if the `dont-update` tag on the model
-   field is dropped. Status: **Done**
-8. `migration_000026_code_revoked_test.go`, following 000024 and 000025: the column is absent at
-   000025, is `NOT NULL` defaulting to false afterwards, a `codes` row that predates it lands
-   `revoked = false`, and the down migration then the re-apply are clean. The pre-existing row is
-   seeded through the ORM at 000026 and carried down to 000025 and back, rather than hand-written at
-   000025, which is what makes the case affordable: `codes` has twenty NOT NULL columns and foreign
-   keys into `clients` and `users`. Status: **Done**
-9. Verify: `check-anchors.sh`, then `where.sh test --type modules` and
-   `where.sh test --type data --db <each of the four>`. Status: **Done**
+   field is dropped.
+8. **`migration_000026_code_revoked_test.go`.** Status: **Done**
+   Following 000024 and 000025: the column is absent at 000025, is `NOT NULL` defaulting to false
+   afterwards, a `codes` row that predates it lands `revoked = false`, and the down migration then
+   the re-apply are clean. The pre-existing row is seeded through the ORM at 000026 and carried down
+   to 000025 and back, rather than hand-written at 000025, which is what makes the case affordable:
+   `codes` has twenty NOT NULL columns and foreign keys into `clients` and `users`.
+9. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules` and
+   `where.sh test --type data --db <each of the four>`.
+
+**As built.** Every step landed as written, with two departures worth naming.
+
+`handler_token.go` was edited, which no step listed: a comment rewrite and one changed `slog.Debug`
+message, no behaviour. Step 5 made the old text false, because a false return from
+`db/mark-code-used` now means "no row transitioned" rather than "already used", and the comment there
+told the reader it meant authorization-code reuse. The reviewer found it, and the fix belongs to this
+stage rather than a later one because this stage is what falsified it.
+
+The order was inverted against the skill: the code existed before section 6 did. Section 5's closing
+obligation requires the case tables to be executed before they are written down, and a data-tier table
+cannot run without the migration and the method. Section 7's plan entry records what executing them
+changed, which is the return on doing it in that order.
 
 ### Stage 2: rejection at redemption and at refresh
 Status: **Not started**

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,11 +5,18 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** stages 1 to 5 committed, 2026-08-05. Stage 5 passed its gate at review round 2, whose
-one quality finding (a lost negative case for `userReallyAuthenticated`'s pre-existing `!IsZero()`
-term) was resolved inside the stage. Decision 15 was answered on PR #138 ("Let's go with option A"), so
-the gate reads a dedicated level 1 proof on the `AuthContext` rather than `AuthenticatedAt`. Next:
-stage 6, the `/auth/issue` liveness check and the compensating revoke, still a sketch.
+**Run state:** stages 1 to 5 committed, 2026-08-05. Stage 6, the `/auth/issue` liveness check and the
+compensating revoke, is expanded, implemented and green on all three tiers, but **halted and
+uncommitted** on decision 16, raised by its round 1 code review on 2026-08-05 and awaiting the user on
+PR #138. The finding: the new refusal restarts level 1 unconditionally, so a `prompt=none` ceremony
+whose session ends in the redirect hop is shown a password form instead of being returned
+`login_required`, which contradicts the no-UI contract this repository documents and implements
+everywhere else. Decision 6 says restart level 1 for this case and explicitly rejected
+`login_required`, so reconciling the two is the user's call. Expanding the stage also found that the
+terminated ceremony reaches `/auth/issue` with an **empty** session identifier rather than a dead one,
+because the session middleware clears it first, and that an empty identifier alone makes the resulting
+grant offline; the stage entry in section 6 carries the reasoning. Next after stage 6: stages 7 and 8,
+both still sketches.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -115,6 +122,14 @@ log can cite it the same way. Nothing above the line changed.
 | `test/completed-gate-otp` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and only OTP authenticated this ceremony, restarts level 1"` | stage 5, decision 15's unit row, the one that fails against the round 1 gate |
 | `test/otp-alone-no-recreate` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession` | `"the ended session must not be recreated by a ceremony that only verified OTP")` | stage 5, decision 15's integration case, paired with `test/fresh-ceremony-after-delete` in the same file |
 | `test/completed-authtime-zero` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("Successful flow, existing session, zero AuthenticatedAt does not refresh AuthTime"` | stage 5 round 2, the valid-session row covering `userReallyAuthenticated`'s pre-existing `!IsZero()` term, which the gate does not read |
+| `db/revoke-code-if-session-gone` | `src/core/data/commondb/code.go` | `RevokeCodeIfSessionGone` | `ub.NotExists(sessionExists),` | stage 6, decision 12's one statement |
+| `issue/liveness-restart` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `if !sessionIsLive {` | stage 6, decision 6's second half, after the implicit-flow branch |
+| `issue/compensating-revoke` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `codeRevoked, err := database.RevokeCodeIfSessionGone(` | stage 6, immediately after `issue/create-code` |
+| `test/revoke-code-gone-data` | `src/authserver/tests/data/code_test.go` | `TestRevokeCodeIfSessionGone` | `a code whose session is still alive` | stage 6, seam 4's keep-this row, the one a method that always revoked would fail |
+| `test/revoke-code-gone-tx` | `src/authserver/tests/data/code_test.go` | `TestRevokeCodeIfSessionGone_TransactionAndFailurePath` | `a code revoked inside a rolled-back transaction` | stage 6, the two questions a mock cannot answer |
+| `test/issue-liveness` | `src/authserver/internal/handlers/handler_auth_issue_test.go` | `TestHandleIssueGet` | `t.Run("No session identifier in the context, restarts level 1"` | stage 6, seam 7's gate row; the three other new rows sit below it |
+| `test/consent-window-no-code` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedOnConsentScreen_NoCodeIsIssued` | `the ended session must not be recreated by a ceremony waiting on the consent screen` | stage 6, the third of the file's paired ceremonies |
+| `middleware/session-identifier` | `src/authserver/internal/middleware/middleware_session_identifier.go` | `MiddlewareSessionIdentifier` | `ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)` | **pre-existing code, not written by the run.** The row exists because stage 6 and decision 16 cite this label three times each and it was declared nowhere, so the citations resolved to nothing. The locator is the only line that puts the identifier in the request context, which is the fact both cite |
 
 Counts in this document carry their command:
 
@@ -432,15 +447,17 @@ Verified as owing nothing, stated because silence reads the same as forgetting:
 
 ## 3. Open questions and decisions
 
-Fifteen items, all `Decided`. Opened at eleven; decision 4's reversal onto a code-level marker
-exposed a residual at `/auth/issue` that the registry design did not have, which is item 12. The
+Sixteen items, fifteen `Decided` and **one `Open`**, which is item 16 and is what halts the run.
+Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual at `/auth/issue`
+that the registry design did not have, which is item 12. The
 reconciliation pass of 2026-08-04 added two more: tracing which endpoints the "End session" buttons
 reach found that interactive logout writes nothing to the database (item 13), and the four-surface
 documentation sweep found three confirmation modals whose copy this change makes incomplete (item 14).
 Item 15 was raised by the run during stage 5, when the code review found that decision 6's gate is
 satisfied by OTP alone; it halted the run until the user answered it on PR #138 on 2026-08-05, and it
-keeps the question it was escalated with rather than being trimmed to its answer. Numbers are never
-reused, and decision 4 records its own reversal rather than being rewritten silently.
+keeps the question it was escalated with rather than being trimmed to its answer. Item 16 was raised
+the same way at stage 6's gate, and is the second and last of the two decision 6 has now cost.
+Numbers are never reused, and decision 4 records its own reversal rather than being rewritten silently.
 
 1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
 
@@ -1150,9 +1167,87 @@ reused, and decision 4 records its own reversal rather than being rewritten sile
     Answering C when A was right leaves explicit termination defeatable by an in-flight ceremony, which
     is the defect #129 exists to close, on a path a stolen cookie reaches.
 
----
+16. **What does `/auth/issue` do when the liveness check fails and the ceremony carries
+    `prompt=none`?** Status: **Open** Raised by: reviewer, raised during stage 6
 
-## 4. Design
+    **The question.** Stage 6 built `issue/liveness-restart` exactly as decision 6 words it: when the
+    ceremony's bound session identifier no longer resolves to a session row, refuse to mint a code, set
+    `AuthStateRequiresLevel1` and redirect to `/auth/level1`. Decision 6 names `prompt=none` as reaching
+    this same place. But `/auth/level1` sends the browser on to `/auth/pwd`, which renders a password
+    form, and a `prompt=none` request must display no UI at all. For that one shape the new refusal
+    therefore replaces a fail-open with a contract violation rather than with an error.
+
+    **What hangs on it.** One branch in `HandleIssueGet`, whether `test/issue-liveness` grows an eighth
+    row, and whether `session_deletion_test.go` gains a fourth ceremony. Stage 6 is implemented, green
+    on all three tiers and reviewed, but **uncommitted**, because the branch in question is one of the
+    two statements the stage exists to add.
+
+    **Verified reachable, on the code rather than by reading the decision.** Four hops, each confirmed:
+
+    1. `handlePromptNone` in `handler_authorize.go` runs its silent checks, bumps the session, sets
+       `AuthStateReadyToIssueCode` and issues a 302 to `/auth/issue`. Every one of its own failures
+       returns to the client through `redirToClientWithError`, and `login_required` is what it sends
+       when its session lookup finds no row.
+    2. The session is terminated between that 302 and the browser following it.
+    3. `middleware/session-identifier` is global and puts the identifier in the request context only
+       when the row exists, so `issue/sid-from-context` reads the empty string, which is the same shape
+       the consent-screen case arrives in and the reason the check fires at all.
+    4. `issue/liveness-restart` fires and redirects to `/auth/level1`, which sets
+       `AuthStateLevel1Password` and redirects to `/auth/pwd`. Nothing downstream reads
+       `authContext.Prompt`: `HasPromptValue` has three production callers, in `handler_authorize.go`,
+       `handler_auth_completed.go` and `handler_consent.go`, and none of them is on this path.
+
+    So the client, typically a hidden iframe performing silent renewal, is handed a login page and no
+    error at all, and waits for its own timeout instead of reading `login_required`.
+
+    **What it contradicts, in this repository rather than in the abstract.**
+    `site/src/content/docs/concepts/prompt-parameter.mdx` says of `none`: "Silent authentication. Must
+    not display any UI. Returns an error if the user is not authenticated or consent is not available."
+    OIDC Core 3.1.2.1 is the same requirement. And `HandleIssueGet` already answers a neighbouring case
+    the other way: its `id_token_hint` mismatch branch calls `redirToClientWithError` with
+    `login_required` and clears the auth context, in the same function a few lines above the new check.
+
+    **Why the run cannot answer it.** Two reasons, either sufficient. decisions.md never auto-resolves
+    anything in authentication, session or public-interface territory, whatever the demonstration looks
+    like. And decision 6 does not merely omit this shape, it decides it: it names `prompt=none` as the
+    other entry to the second sub-case, says restart level 1 there, and explicitly **rejects** "failing
+    to the client with `login_required` or `access_denied`". Reading that rejection as scoped to
+    interactive ceremonies would be paraphrasing the decision rather than applying it, which is the line
+    decisions.md draws.
+
+    **Options, with the run's recommendation.**
+
+    - **A, recommended: return `login_required` to the client for a `prompt=none` ceremony, and keep the
+      level 1 restart for every other one.** `redirToClientWithError` with `constants.ErrorLoginRequired`
+      then `ClearAuthContext`, copying the `id_token_hint` branch directly above it in the same
+      function. No code is minted either way, so the fail-open decision 6 closes stays closed, and the
+      client learns what actually happened. Decision 6's reasoning for rejecting `login_required`
+      survives intact where it applies: it costs an interactive user "a round trip through the client to
+      arrive at the same password form", and a `prompt=none` client has no password form to arrive at
+      and is forbidden from showing one. Cost: one branch, one unit row at `test/issue-liveness`, and
+      one integration case, which is cheap here because `codeFromSameSession` already drives
+      `prompt=none` to the `/auth/issue` redirect with `assertRedirect` and follows it with `loadPage`,
+      so the case terminates the session between those two lines.
+    - **B: restart level 1 for every ceremony, as decision 6 words it, and document the divergence.**
+      Keeps stage 6 exactly as built and needs no code at all. It requires editing
+      `concepts/prompt-parameter.mdx` to carve out an exception to "Must not display any UI", and it
+      leaves a silent-renewal client with no error to act on in a window this issue newly created.
+    - **C: mint the code for `prompt=none` and let the compensating statement handle it.** Ruled out
+      rather than weighed, and the reason is measured rather than argued: on this path the identifier is
+      **empty**, and `db/revoke-code-if-session-gone` refuses an empty identifier at entry, so the
+      compensating call returns an error and the handler answers 500. Mutation 1's log line in section 7
+      is that guard firing. A 500 in the iframe is worse than either A or B on every axis.
+    - **D: return `login_required` for every ceremony, reversing decision 6's rejection outright.**
+      Simpler than A, one branch and no `Prompt` read, and it makes `/auth/issue` behave uniformly. It
+      discards a ceremony that could have completed correctly, which is precisely what decision 6
+      weighed and rejected, and it would redden `test/consent-window-no-code`, whose assertion is that
+      the consent-screen ceremony reaches `/auth/pwd`.
+
+    **What each mistake costs.** Answering A when B was right costs one branch and one test row, and
+    leaves the interactive behaviour decision 6 chose untouched. Answering B when A was right ships an
+    authorization server that renders a login form in response to a request that forbids one, in a
+    window #129 itself introduces, and the client cannot tell that from a hang. Both are recoverable in
+    one stage; the asymmetry is that B's cost lands on integrators rather than on this run.
 
 Ending a session becomes a security action with a durable consequence, and the durable consequence
 lives on the **grant record** rather than on the session or in a side table.
@@ -2004,21 +2099,189 @@ Three things worth naming beyond the steps.
    the user really does enter a password, which is the shape follow-up 3 already describes.
 
 ### Stage 6: the `/auth/issue` liveness check and the compensating revoke
-Status: **Not started**
-Detail: **sketch**
+Status: **In progress**
+Seams: 4 (the compensating revoke, in `code_test.go` on four engines) and 7 (`HandleIssueGet`,
+extending `TestHandleIssueGet` in the existing `handler_auth_issue_test.go`), plus the mid-flight
+ceremony in `session_deletion_test.go`, which is where stage 5 put its pair and where #46's guard
+already lives.
+Tiers: unit (three modules), data (four engines), integration (dev container). Data applies here
+where stage 5 said it did not: this stage adds an interface method and a statement no other tier
+runs against mysql, postgres, mssql and sqlite.
+Docs: the second sentence held back from stage 4's concepts section, the consent-screen window, in
+`concepts/user-sessions.mdx`.
 
-Decision 6's second half plus decision 12. A liveness read at `/auth/issue`, placed **after** the
-implicit-flow branch so `handleImplicitFlow` is untouched and only `issue/create-code` is guarded:
-when the bound session identifier resolves to no session row, restart level 1 as in stage 5.
-Immediately after the insert, one compensating statement as a new data method on four engines,
-`UPDATE codes SET revoked = true, updated_at = ? WHERE id = ? AND NOT EXISTS (SELECT 1 FROM
-user_sessions WHERE session_identifier = ?)`, so a code that committed after the termination's sweep
-read `codes` is marked by the second sweeper. Seams 4 (the data method, whose "does nothing when a
-session exists" row is the one that matters, since a method that always revoked would pass every
-other assertion) and 7 (the liveness branch, extending `TestHandleIssueGet`). Tiers: unit, data,
-integration for the mid-flight ceremony on one HTTP client, plus the #46 guard still green, which is
-the pair proving decision 6 chose the right predicate rather than merely a strict one. Docs: the
-second sentence held back from stage 4's concepts section, the consent-screen window.
+Decision 6's second half plus decision 12. Gap 3's remaining exposure is a ceremony that passed
+`/auth/completed` while its session was alive, sat on the consent screen, and reaches `/auth/issue`
+after the session was ended. Stage 1's marker cannot reach the code it mints, because a code-level
+fact cannot be written onto a row that does not exist yet.
+
+**Expanding against the code changed the shape of the exposure, and this is the stage's one
+substantive departure from the sketch.** The sketch, following decision 6, says the check fires
+"when the bound session identifier resolves to no session row". Verified at
+`middleware/session-identifier`: the sid never arrives stale. `MiddlewareSessionIdentifier` is
+global (`s.router.Use` in `server.go`), it looks the session up on **every** request, and it puts
+the identifier in the request context **only** when the row exists. `issue/sid-from-context` reads
+that context, so the terminated ceremony arrives at `/auth/issue` with an **empty** sid rather than
+a dead one. Confirmed at the integration tier rather than by reading alone: the handler logs
+`sessionIdentifier=""` on the new case.
+
+> **One clause of this was wrong when first written, and the correction is worth keeping.** The
+> paragraph originally added that the sid "stays empty on every later request because the cookie no
+> longer carries it", reasoning from the `delete` plus `Save` in the middleware's nil-session branch.
+> The run's own integration log refutes it: the middleware logs "clearing the session identifier"
+> again on each following request, so the clearing does not persist in the browser cookie and the
+> middleware re-does it every time. Harmless, one repeated session lookup for an orphaned cookie, and
+> pre-existing in code this stage does not touch, so it is not drafted as a follow-up. It is recorded
+> because the stage's comment leaned on it, and now leans only on the request context, which is what
+> the handler reads and what the middleware source states unambiguously.
+
+That matters because an empty sid is not inert here. `issuer/grant-is-offline` returns true when the
+sid is empty **or** the scope contains `offline_access`, so a code minted with no sid produces an
+`Offline` refresh token: `issuer/refresh-type-branch` stores a max lifetime instead of a sid, and
+`validator/offline-branch` never consults a session. So the code issued in this window yields a
+refresh token good for up to `RefreshTokenOfflineMaxLifetimeInSeconds`, seeded at 31536000 seconds,
+**whether or not the client asked for `offline_access`**. The window decision 6 called the second
+sub-case of gap 3 is therefore wider than the offline grants decision 2 is about, and the check has
+to treat an empty sid as the liveness failure it is, or it never fires on the production path at
+all.
+
+The three hops, each read rather than assumed: `HandleConsentPost` touches no session row, so the
+consent submission proceeds regardless; it sets `AuthStateReadyToIssueCode` and redirects; and every
+path that reaches `/auth/issue` in the authorization-code flow (`HandleAuthCompletedGet` when no
+consent is needed, `HandleConsentGet` and `HandleConsentPost` after consent, and `handlePromptNone`)
+has either bumped or created a live session, so a legitimate code-flow request never carries an
+empty sid. That last one is what makes the empty case safe to refuse, and the integration tier is
+what proves it: every existing ceremony in the suite goes through this handler.
+
+1. **`RevokeCodeIfSessionGone(tx, codeId, sessionIdentifier) (bool, error)`.**
+   Status: **Done**
+   In `commondb/code.go`, declared in the `Code` block of `data/database.go` next to
+   `RevokeCodesBySessionIdentifier`, with the one-line wrapper in each of the four engine packages
+   and regenerated mocks (`authserver/generate-mocks.sh`, run in the dev container). One statement:
+   assign `revoked` and `updated_at`, predicate `id = ? AND revoked = false AND NOT EXISTS (SELECT 1
+   FROM user_sessions WHERE session_identifier = ?)`, return `RowsAffected == 1`. Built with
+   `sqlbuilder`'s `NotExists` over a nested select builder, which is the shape
+   `db/delete-used-codes` already uses for its `NotIn` subquery.
+
+   The `revoked = false` term makes the bool mean "this call transitioned it" rather than "matched
+   a row". Predicted as stage 1's MySQL-specific lesson; **measured to be broader**, and the
+   correction is in the run log: the mutation that drops the term fails the idempotence row on all
+   four engines, because the `updated_at` assignment changes on every call and so an already-revoked
+   row reports as affected everywhere. It is reachable here, not hypothetical: the interleaving where
+   termination's own sweep marked the code first is exactly the one where both sweepers fire.
+
+   An empty session identifier and a zero code id are refused at entry rather than used as filters.
+   The empty case is the load-bearing one: `NOT EXISTS` over an identifier no row carries is
+   trivially true, so an empty sid would revoke whatever code it was handed. Same guard and same
+   reasoning as `db/revoke-codes-by-sid`.
+2. **The liveness check at `/auth/issue`.** Status: **Done**
+   In `HandleIssueGet`, **after** the implicit-flow branch and before `createCodeInput`, so
+   `handleImplicitFlow` is untouched and only `issue/create-code` is guarded. When the sid is empty,
+   or when it resolves to no session row, set `AuthStateRequiresLevel1`, save the auth context,
+   redirect to `/auth/level1` and return. A failed lookup is a 500, not a restart.
+   The comment carries the three things a later reader needs: that an empty sid is the shape the
+   terminated ceremony actually arrives in, because the middleware clears a dead identifier from the
+   cookie before any handler runs; that an empty sid is what makes the code an offline grant at
+   `issuer/grant-is-offline`, so refusing it is not belt-and-braces; and that this is deliberately a
+   **liveness** check rather than a validity one, so it asks whether the row resolves and leaves
+   idle timeout and max age to `/auth/completed`, which has already applied them.
+3. **The compensating revoke, immediately after the insert.** Status: **Done**
+   Decision 12. `RevokeCodeIfSessionGone(nil, code.Id, sessionIdentifier)` directly after
+   `issue/create-code`'s error check, ahead of the `AuditCreatedAuthCode` entry. On a database error,
+   `InternalServerError`: the code exists and is unmarked, so handing it to the client would be the
+   fail-open this statement exists to close, and the code expires unredeemed in 60 seconds either
+   way. When it does revoke, one `slog.Warn` naming the race, with the code id and the session
+   identifier and neither the code nor its hash.
+   No audit event, deliberately. Decision 9's payload is termination's, decision 12 asks for one
+   statement, and a new event would mean a constant, three registrations and the `constants_test.go`
+   guards for an operational fact that `slog` already carries.
+   The comment states what composes: termination marks codes that exist when it sweeps, this marks a
+   code whose session was already gone when it landed, and the interleaving that escapes both is
+   follow-up 1 rather than an oversight.
+4. **Data cases at seam 4, in `code_test.go`, all four engines.** Status: **Done**
+   Two tests mirroring `test/revoke-codes-data` and its transaction sibling, since this method has
+   the same two questions a mock cannot answer. Expectations written before running them:
+
+   | Case | Expected | Which mechanism answers it, or what it proves |
+   |---|---|---|
+   | a code whose session row exists | false, code stays unrevoked | **keep this row.** It is the only one that fails against a method that always revokes, which passes every other assertion here |
+   | a code whose session row is gone | true, code revoked | decision 12's job, the statement's whole purpose |
+   | the same call again | false, still revoked | idempotent, and the bool means "this call transitioned it" rather than "matched a row", which is the `revoked = false` term. Measured to bite on all four engines, not only MySQL |
+   | the target session gone while an **unrelated** session row exists | true, revoked | the `NOT EXISTS` is keyed on the identifier passed. Without this row a subquery missing its `WHERE` clause passes, and then the statement would stop revoking anything the moment any session existed |
+   | a second code of the same gone session, not named by id | untouched | the `id = ?` term. Without it this is a session-wide sweep wearing a code-shaped signature |
+   | empty session identifier | error, nothing revoked | the entry guard, not the `=` predicate. Without it the trivially true `NOT EXISTS` revokes the code |
+   | zero code id | error | the entry guard, matching `MarkCodeAsUsed` |
+   | inside a transaction, then roll back | unrevoked afterwards | it enlisted in the caller's transaction rather than the pool |
+   | on the finished transaction | error, false | the failure path does not collapse into a benign false, which for a gate means failing open through a database fault |
+5. **Unit cases at seam 7, extending `TestHandleIssueGet`.** Status: **Done**
+   In the existing `handler_auth_issue_test.go`, inheriting its setup rather than adding a sibling.
+   Expectations written before running them:
+
+   | Case | Expected | Which gate answers it, or what it proves |
+   |---|---|---|
+   | no session identifier in the request context | 302 to `/auth/level1`, saved context reading `requires_level_1`, and no code created | the liveness check on the shape the middleware actually produces. "No code created" is enforced rather than asserted: the strict `mocks_oauth.CodeIssuer` carries no `CreateAuthCode` expectation |
+   | a sid resolving to no session row | the same | the other half of the same predicate, for the narrow race where the middleware saw the session live |
+   | the session lookup fails | 500, no code created | a database fault must not read as a terminated session, and must not read as a live one either |
+   | a live session | code issued as before, and `RevokeCodeIfSessionGone` called with that code's id and that sid | decision 12's statement is issued. Whether it **works** is seam 4's, per section 5 |
+   | the compensating revoke fails | 500, and the client is not redirected with a code | the fail-closed direction of step 3 |
+   | the three existing subtests that reach `CreateAuthCode` gain a sid, the session lookup and the compensating call | outcomes unchanged | **keep these as the positive control.** They are the ordinary ceremony, and they fail against a check that refuses a live session. This is the non-additive cost seam 7 recorded |
+   | the implicit-flow subtests, untouched | unchanged, and no session lookup | the check sits **after** the implicit branch. They carry no sid and stub neither the lookup nor the revoke, so hoisting the check above the branch fails them on the strict mock |
+6. **The docs sentence, in `concepts/user-sessions.mdx`.** Status: **Done**
+   The second of the two sentences held back from stage 4, into the `## Ending a session` section
+   beside stage 5's. Stage 5's paragraph says a sign-in relying on the ended session cannot become a
+   replacement session; this one closes the other half, that a sign-in already past that point and
+   waiting on the consent screen cannot come back and collect an authorization code either. Written
+   for someone deciding whether ending a session is enough, so it says the outcome rather than the
+   mechanism, and it does not describe the residual interleaving, which is follow-up 1's and reads
+   to a user as doubt about the feature.
+7. **The mid-flight integration case, in `session_deletion_test.go`.** Status: **Done**
+   `TestSessionEndedOnConsentScreen_NoCodeIsIssued`, the third of the file's paired ceremonies and
+   the one that varies the window rather than the credential: the session is alive through
+   `/auth/completed`, so the stage 5 gate cannot fire, and is ended while the browser sits on the
+   consent screen. Driven on one HTTP client so the cookie is shared, with a `ConsentRequired`
+   client, following the shape of the two tests already in the file and using this suite's own
+   consent submission form, the one `secondOfflineGrantForSameUser` posts.
+
+   | Case | Expected | What it proves |
+   |---|---|---|
+   | session ended on the consent screen, then consent submitted | `/auth/consent` posts to `/auth/issue` as always, and `/auth/issue` redirects to `/auth/level1` and then `/auth/pwd`, with no code reaching the client and no session recreated | gap 3's second half at the highest seam that can see it. The consent POST succeeding first is deliberate: it is what makes `/auth/issue` the load-bearing hop rather than an incidental one |
+   | `test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` | unchanged and green | the pair decision 6 rests on. This stage's check is the one that could redden the first: a code flow whose session vanished is exactly #46's shape one hop later |
+
+   The ordinary ceremony is the control, and it is named rather than duplicated: `createOfflineGrant`
+   and `secondOfflineGrantForSameUser` both drive consent through to a code, and
+   `codeFromSameSession` drives `prompt=none` straight to `/auth/issue`, so the suite already fails
+   loudly if the check refuses a live session. Asserting `codes.revoked` here is rejected by section
+   5 and is not attempted.
+8. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules`, `where.sh test --type data --db <each of
+   the four>` and `where.sh test --type integration`, all in the foreground. The integration tier is
+   load bearing at this gate rather than routine: this stage puts a new refusal in front of every
+   authorization code the suite issues.
+
+**As built.** All eight steps landed. Eight anchor rows added to section 0, and no sealed row moved.
+Four things worth naming beyond the steps.
+
+1. **The empty-sid finding is the stage, not a detail of it.** The sketch's predicate, "resolves to no
+   session row", never fires on the path gap 3's second half actually takes, because
+   `middleware/session-identifier` removes a dead identifier from the request context before any
+   handler sees it. The mutation that restores the sketch's literal predicate is mutation 1 in the run
+   log: it leaves the unit tier one row down and the new integration case failing with a code in the
+   client's redirect. Two claims that make it worth refusing rather than merely tidy were verified
+   against the code: `issuer/grant-is-offline` reads an empty sid as an offline grant on its own, and
+   `issue/create-code` has exactly one production caller, so after this stage no path mints a code
+   with an empty sid at all.
+2. **One clause of the expansion was wrong and is corrected in place**, with the correction marked
+   rather than absorbed: the middleware's attempt to clear the identifier from the *cookie* does not
+   persist, so it re-clears on every later request. The stage's comment no longer leans on it. Not
+   drafted as a follow-up, and the reasoning is in the run log.
+3. **The `revoked = false` term is broader than predicted.** Stage 1 recorded it as a MySQL-specific
+   requirement for its count. Measured here, dropping it fails the idempotence row on **all four**
+   engines, because `updated_at` changes on every call. The step, the table and both comments were
+   corrected to say what was measured.
+4. **The data table's nine predicted rows are eight calls.** "A code whose session is gone" and "the
+   target session gone while an unrelated session row exists" are one call, because the fixture's live
+   session is still in the table while it runs and a shared test database always holds other sessions
+   anyway. The property both rows were for is intact and is what mutation 6 kills.
 
 ### Stage 7: reaping unused revoked codes
 Status: **Not started**
@@ -2780,14 +3043,185 @@ is throwaway so the correction lives here.
 `Decided`. Round 2 was the second and last round at this gate, its one finding is resolved rather than
 carried, so the gate is passed and the stage is committed.
 
+### Stage 6, 2026-08-05
+
+**Landed.** Gap 3's second half. `db/revoke-code-if-session-gone`, that is
+`RevokeCodeIfSessionGone`, one statement on four engines with its interface declaration, four
+wrappers and regenerated mocks; `issue/liveness-restart`, the refusal to mint a code for a ceremony
+whose session no longer resolves, placed after the implicit-flow branch; and
+`issue/compensating-revoke`, decision 12's statement immediately after the insert. Tests:
+`test/revoke-code-gone-data` and `test/revoke-code-gone-tx` at the data tier, four new unit rows at
+`test/issue-liveness` plus three existing subtests amended, and `test/consent-window-no-code` at the
+integration tier. One paragraph in `concepts/user-sessions.mdx`. Eight anchor rows added.
+
+**What changes for a user.** The window this closes is the one a person can hold open: past
+`/auth/completed`, where the session was alive and was bumped, and waiting on the consent screen. End
+the session while they sit there and, before this commit, pressing Accept still returned a working
+authorization code. After it the ceremony goes back to the login page, and if a code is somehow minted
+after the session went away it is revoked in the same request. With stage 5 that makes goal 2 true in
+both halves.
+
+**The exposure was wider than decision 6 describes, and this is the stage's substantive finding.**
+The sketch and decision 6 say the check fires when the bound identifier "resolves to no session row".
+It never does, on the path that matters: `middleware/session-identifier` is global, looks the session
+up on every request, and puts the identifier in the request context **only** when the row exists, so
+`issue/sid-from-context` yields an empty string rather than a dead identifier. And an empty identifier
+is not inert, which is the part that decides severity: `issuer/grant-is-offline` returns true from an
+empty sid alone, so the code minted in that window yields an **Offline** refresh token,
+`issuer/refresh-type-branch` stores a max lifetime instead of a sid, and `validator/offline-branch`
+never consults a session. The grant would therefore have outlived the terminated session by up to
+`RefreshTokenOfflineMaxLifetimeInSeconds`, seeded at 31536000 seconds, **whether or not
+`offline_access` was requested**. The check treats an empty identifier as the liveness failure it is,
+and `issue/create-code` has exactly one production caller, so no path mints a code with an empty sid
+now.
+
+Verified alongside it, because each could have made the refusal wrong: `HandleConsentPost` reads no
+session row, so the consent submission is unaffected and the refusal lands one hop later; every path
+reaching `/auth/issue` in the code flow has bumped or created a live session
+(`HandleAuthCompletedGet`, `HandleConsentGet`, `HandleConsentPost`, `handlePromptNone`), so a
+legitimate request never carries an empty identifier; and the implicit branch is deliberately ahead of
+the check, since `handleImplicitFlow` issues no refresh token and its access-token window is decision
+11's, which this stage does not touch.
+
+**Tiers.** Modules green, all three modules, 2720 passing test lines, zero `FAIL`.
+`TestHandleIssueGet` at 7 subtests where `main` has 3. Data green on **all four engines**, run
+separately, with both new tests passing on each. Integration green on **all four engines**, 4756
+passing test lines, zero `FAIL`, with `test/consent-window-no-code`,
+`test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` each passing once per engine.
+`check-anchors.sh` passes all 71 rows, `gofmt -l` is silent on every file this stage touches,
+`git diff --check` is clean, and `cd site && npm run build` completes with 42 pages. The data tier
+applies here where stages 2 to 5 recorded it as not applicable, because this stage adds an interface
+method and a statement no other tier runs against four engines.
+
+**Mutation evidence, six mutations, each applied to the real code, run, and reverted in this
+session.** The failure sets are disjoint, and mutation 1 is the one that answers the finding above.
+
+1. **The sketch's literal predicate restored**, an empty identifier treated as live. At the unit tier
+   exactly one row failed, "No session identifier in the context". At the integration tier on sqlite
+   exactly `test/consent-window-no-code` failed, with the ceremony landing on the client's redirect
+   URI, while `test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` stayed green. The
+   server log under the mutation also carries `can't revoke a code with an empty session identifier`
+   from the compensating call, which is the data method's own guard catching what the handler let
+   through.
+2. **The refusal removed**, the predicate computed and ignored. Both no-session rows failed, and only
+   those.
+3. **The compensating revoke dropped.** Four unit rows failed: the three that reach `CreateAuthCode`
+   and the failure row. Nothing at the integration tier could have caught it, which is why the unit
+   rows exist: the interleaving it compensates for cannot be driven through HTTP.
+4. **The check hoisted above the implicit-flow branch**, which is the natural-looking tidy-up since
+   the identifier is read above both. Exactly the ten implicit-flow subtests failed and no code-flow
+   row moved, so the placement is pinned by tests that were already in the file.
+5. **The `revoked = false` term dropped.** The idempotence row failed on **mysql, sqlite, postgres and
+   mssql**, which refutes the prediction that this was MySQL specific: `updated_at` changes on every
+   call, so an already-revoked row reports as affected everywhere. The step, the case table and both
+   comments now say what was measured. The transaction sibling stayed green under it, which is what
+   makes the failure legible.
+6. **The subquery's own predicate dropped**, `NOT EXISTS (SELECT 1 FROM user_sessions)`. Both data
+   tests failed, the first on "a code whose session is gone must be revoked": with any session row
+   anywhere in the table the statement stops revoking anything, forever, and silently.
+
+**Deviations from the plan as written.** Four, all named in the stage's as-built note: the empty-sid
+predicate, which is a departure from the sketch and from decision 6's wording rather than from a step;
+one clause of the expansion corrected after its own integration log refuted it; the `revoked = false`
+term measured to be broader than stage 1 predicted; and nine predicted data rows landing as eight
+calls.
+
+**One observation recorded rather than filed, and the choice is deliberate.** The middleware's attempt
+to clear a dead session identifier from the cookie does not persist: the clean integration run logs
+"clearing the session identifier" again on each following request of the same ceremony. It is
+pre-existing, in code this stage does not touch, and its cost is one repeated session lookup plus a
+repeated warning for a browser holding an orphaned cookie. Not drafted as a follow-up because the
+mechanism was not identified, and an issue whose body says the cause is unknown is worth less than
+this paragraph; the security-relevant half, that the identifier never reaches a handler while the row
+is missing, is verified from the middleware source and from the handler's own log line
+`sessionIdentifier=""`. Nothing about it changes what this stage does.
+
+**Nothing deferred, nothing contested, no decision raised** at the point this paragraph was written,
+and the review then refuted its second clause. It read: section 3 keeps its fifteen items, all
+`Decided`, because the one judgement this stage made, whether an empty identifier counts as a liveness
+failure, resolves under section 3 rather than needing a new item. That much stands: decision 6 fixes
+the outcome (restart level 1 when the ceremony's session no longer exists) and the empty identifier is
+that condition as the code presents it, so treating it as a liveness failure is applying the decision
+rather than choosing past it. What the paragraph missed is the shape of the *outcome* rather than of
+the predicate, for one ceremony that must never see a page. Decision 16 is the entry below. No new
+follow-up: the two problems this stage surfaced are its own to fix and the cookie observation above.
+
+**Review request.** Written after everything above, which is stage 3's lesson: the trace goes into the
+agreement at the moment it is known, because the mailbox does not survive the next gate.
+
+### Stage 6 round 1, 2026-08-05: the review, and decision 16
+
+**The review.** `codex`, request `129-20260805T163300Z`, all three axes `reviewed`. It re-ran the whole
+tier set independently rather than reading alone: modules on all three modules, data separately on
+sqlite, mysql, postgres and mssql, integration on all four engines, `npm run build` in `site` at 42
+pages, `check-anchors.sh` at 71 rows, `git diff --check`, and `gofmt -l` on every changed Go file. It
+recorded the diff hash `bf72016a…` before and after verifying, unchanged, so it edited nothing. It
+explicitly declined to reopen decision 12's accepted residual and assessed the six mutations statically,
+which is the only way a reviewer forbidden from editing source can.
+
+Not reached, and neither mattered to this gate: unchanged cryptographic primitives, token signature
+validation, redirect matching, authorization on unrelated endpoints, and unrelated rate limiters.
+
+**Found sound, recorded so a later round does not re-derive it.** The four-engine statement and its two
+entry guards; the fail-closed direction of both new error paths; the empty-identifier handling; the
+placement after the implicit-flow branch; the interactive ceremony's behaviour; that the change logs
+only the session identifier and the numeric code id and never a code, hash, refresh token, secret or
+OTP; that it adds no route and no user-controlled record lookup; and that it does not pre-empt the
+termination audit events.
+
+**One finding, on the conformance axis, `blocking`, `needs_human`. Confirmed against the code and
+raised as decision 16.**
+
+> The new no-session branch always saves `AuthStateRequiresLevel1` and redirects to `/auth/level1`. A
+> `prompt=none` ceremony reaches that branch when its session ends after `handlePromptNone` validated
+> and bumped the session and redirected to `/auth/issue`. The result is a login screen, although this
+> repository documents that `prompt=none` must display no UI and must return an error to the client.
+
+Verified rather than accepted, and it stands on four hops written out in decision 16: `handlePromptNone`
+does redirect to `/auth/issue` after bumping; `middleware/session-identifier` yields an empty identifier
+once the row is gone; `issue/liveness-restart` fires on that; and `/auth/level1` sets
+`AuthStateLevel1Password` and redirects to `/auth/pwd`, which renders a form. The gap that makes it a
+defect rather than a debate is the third hop's silence: `HasPromptValue` has exactly three production
+callers, in `handler_authorize.go`, `handler_auth_completed.go` and `handler_consent.go`, so nothing
+between `/auth/issue` and the password form knows the request forbids UI. The reviewer's own
+`forced_answer` matches `HandleIssueGet`'s existing `id_token_hint` mismatch branch, a few lines above
+the new check, which already returns `login_required` through `redirToClientWithError`.
+
+**Why this escalated instead of being fixed inside the stage.** Not because the fix is unclear; it is
+about as forced as they come, and the run recommends it. Because decision 6 **decided** this shape
+rather than omitting it: it names `prompt=none` as the second sub-case's other entry, says restart level
+1, and explicitly rejects `login_required`. Overriding a sealed rejection is the user's call, and
+decisions.md refuses to auto-resolve authentication, session or public-interface questions whatever the
+demonstration looks like. Recorded as the second escalation of this run, both from decision 6, which is
+within decisions.md's "one or two on a hard change is normal" and is worth the next `/leo-spec` knowing:
+decision 6 carried two questions its own text could not answer, and both were found by a reviewer
+reading the built code rather than by the interview.
+
+**State at the halt.** Stage 6's thirteen-file diff is complete, green on every tier it claims, and
+**uncommitted**, exactly as stage 5 waited on decision 15. Nothing that rests on decision 16 is
+committed. This agreement is committed, carrying decision 16 `Open` and this entry, because the next
+session reads the agreement rather than the transcript. One bookkeeping fix rode along: the
+`middleware/session-identifier` label was cited three times by the stage 6 text and declared in no
+anchor row, so the citations resolved to nothing while `check-anchors.sh` stayed green, since it
+validates declared rows rather than cited labels. The row now exists and the checker covers it at 72.
+
+**When the answer arrives**, it lands in decision 16 with the user's words, and whatever it decides is
+built inside stage 6 rather than a later one: under option A that is one branch reading
+`authContext.HasPromptValue("none")`, an eighth row at `test/issue-liveness`, and a fourth ceremony in
+`session_deletion_test.go` terminating the session between `codeFromSameSession`'s `assertRedirect` and
+its `loadPage`. Step 2 of the stage and both of its case tables gain the row, and the stage then needs a
+round 2 on the new branch rather than a fresh gate.
+
 ---
 
 ## 8. Deferred decisions
 
-Nothing deferred. Stages 1 to 5 met no question that was safe to postpone on a stated assumption: the
-one judgement call stage 5 made resolved under section 3 (recorded in its run log entry), and the one
-question stage 5 could not answer was a security finding, which reviewer.md forbids deferring. That was
-decision 15, which halted the run rather than sitting here and was answered by the user on 2026-08-05.
+Nothing deferred. Stages 1 to 6 met no question that was safe to postpone on a stated assumption: the
+judgement calls stages 5 and 6 made each resolved under section 3 (recorded in their run log entries),
+and the two questions the run could not answer were both in authentication territory, which
+decisions.md forbids deferring. Those are decisions 15 and 16, which halted the run rather than sitting
+here. Decision 15 was answered by the user on 2026-08-05; decision 16 is `Open` and is what the run is
+currently waiting on.
 
 This section stays in the document even while empty, because the closing PR comment reports it and an
 absent section reads the same as a forgotten one.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,8 +5,10 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** in progress, started 2026-08-04. Stages 1 to 4 done, so the behaviour change has landed.
-Stage 5, the `/auth/completed` gate, is next and is still a sketch.
+**Run state:** blocked on decision 15, 2026-08-05. Stages 1 to 4 done, so the behaviour change has
+landed. Stage 5, the `/auth/completed` gate, is implemented and reviewed but **uncommitted**: round 1
+found a blocking security finding, the run confirmed it against the code, and the question it raises is
+decision 15, escalated on PR #138. The run resumes when that is answered.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -105,6 +107,8 @@ log can cite it the same way. Nothing above the line changed.
 | `test/terminate-offline-endpoint` | `src/authserver/tests/integration/api_users_sessions_test.go` | `TestAPIUserSessionDelete_TerminatesTheOfflineGrantsOfThatSession` | `THE SURVIVOR IS THE HALF THAT CARRIES THIS TEST` | stage 4, seam 8's headline claim and its same-user control |
 | `test/second-offline-grant` | `src/authserver/tests/integration/credential_change_revocation_test.go` | `secondOfflineGrantForSameUser` | `func secondOfflineGrantForSameUser(t *testing.T, base *offlineGrant, password string) *offlineGrant {` | stage 4, the one new harness helper |
 | `test/logout-revokes-nothing` | `src/authserver/tests/integration/api_account_logout_request_test.go` | `TestLogout_WithIdTokenHint_RevokesNoGrants` | `logout must revoke nothing, decision 3` | stage 4, decision 3 pinned |
+| `completed/level1-restart` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `if !userReallyAuthenticated {` | stage 5, decision 6's gate, inside the else branch and ahead of `completed/start-new-session` |
+| `test/completed-gate` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and this ceremony did not authenticate, restarts level 1"` | stage 5, the gate's own row; the zero-time sibling sits directly below it |
 
 Counts in this document carry their command:
 
@@ -422,12 +426,14 @@ Verified as owing nothing, stated because silence reads the same as forgetting:
 
 ## 3. Open questions and decisions
 
-Fourteen items. Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual
-at `/auth/issue` that the registry design did not have, which is item 12. The reconciliation pass of
-2026-08-04 added two more: tracing which endpoints the "End session" buttons reach found that
-interactive logout writes nothing to the database (item 13), and the four-surface documentation sweep
-found three confirmation modals whose copy this change makes incomplete (item 14). Numbers are never
-reused, and decision 4 records its own reversal rather than being rewritten silently.
+Fifteen items, one of them `Open`. Opened at eleven; decision 4's reversal onto a code-level marker
+exposed a residual at `/auth/issue` that the registry design did not have, which is item 12. The
+reconciliation pass of 2026-08-04 added two more: tracing which endpoints the "End session" buttons
+reach found that interactive logout writes nothing to the database (item 13), and the four-surface
+documentation sweep found three confirmation modals whose copy this change makes incomplete (item 14).
+Item 15 was raised by the run during stage 5, when the code review found that decision 6's gate is
+satisfied by OTP alone; it is the only `Open` item and it halts the run. Numbers are never reused, and
+decision 4 records its own reversal rather than being rewritten silently.
 
 1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
 
@@ -1045,6 +1051,74 @@ reused, and decision 4 records its own reversal rather than being rewritten sile
     **Rejected: one shared key for all three surfaces.** It would be less churn, and it is against the
     established convention here, where identical strings like "End session" and "Are you sure?" each
     carry three per-surface keys. Mixing a shared key into a per-surface scheme is what review flags.
+
+15. **Does decision 6's gate require level 1 authentication in this ceremony, or is OTP enough?**
+    Status: **Open** Raised by: reviewer, raised during stage 5
+
+    Escalated on PR #138. The run cannot answer it: decisions.md never auto-resolves anything in
+    authentication or session territory, and reviewer.md never lets the run alone settle a security
+    finding.
+
+    **The question.** Decision 6 fixes the gate as `!hasValidUserSession && !userReallyAuthenticated`,
+    and stage 5 shipped exactly that, reading `completed/really-authenticated`. But
+    `AuthenticatedAt` has two writers, not one. The OTP handler sets it too, so a ceremony that
+    reached level 2 by SSO reuse and never touched the password form satisfies the gate on OTP alone,
+    and `completed/start-new-session` recreates the session that was just explicitly terminated.
+
+    **What hangs on it.** The gate expression at `completed/level1-restart`, whether the `AuthContext`
+    gains a field, and whether stage 5's case table grows two rows and an integration case. Stage 5 is
+    implemented, verified and reviewed but **uncommitted**, because the gate is the thing in question.
+
+    **Verified reachable, on the code rather than by reading the decision.** Five hops, each confirmed:
+
+    1. `authorize/sso-reuse` sets `AuthStateLevel1ExistingSession` and leaves `AuthenticatedAt` nil.
+    2. `HandleAuthLevel1CompletedGet` sends the ceremony to `/auth/level2` when the target ACR is
+       higher than the session's, which is the ordinary step-up.
+    3. `HandleAuthLevel2Get` sets `AuthStateLevel2OTP` for `level2_mandatory`, and for
+       `level2_optional` when the user has OTP. No password is required to arrive and no session
+       liveness is re-read.
+    4. The session is terminated at this point. `HandleAuthOtpPost` checks only that the state is
+       `AuthStateLevel2OTP`; it reads no session row, so termination is invisible to it. On success it
+       sets `AuthenticatedAt = now` and redirects to `/auth/completed`.
+    5. `HandleAuthCompletedGet` finds no session row, so `hasValidUserSession` is false, computes
+       `userReallyAuthenticated` as **true**, passes the gate and calls `StartNewUserSession`.
+
+    **The sub-case that decides the severity.** For a user **without** OTP on a `level2_mandatory`
+    client, `HandleAuthOtpGet` generates a fresh secret, renders it into the enrollment page and stores
+    it in the http session. So the browser is handed the secret it will be tested on, and a holder of a
+    stolen session cookie can produce a valid code with no password and no second factor of their own.
+    Termination then does not stop that ceremony.
+
+    **The sealed text disagrees with itself, which is why this is the user's call and not the run's.**
+    Decision 6's supporting facts name both writers and call them "both real authentication", so the
+    predicate the run implemented is the predicate the seal describes. Section 1's departure note says
+    the discriminator is whether this ceremony performed **level 1** authentication, of which
+    `pwd/authenticated-at` "is the only level 1 writer". Under the first reading stage 5 is correct as
+    built. Under the second it is incomplete, and goal 1's "cannot be undone by anything already in
+    flight" stays false for this ceremony.
+
+    **Options, with the run's recommendation.** Fully stated in the PR comment; recorded here so the
+    agreement is self-contained.
+
+    - **A, recommended: a dedicated level 1 proof on the `AuthContext`.** A new field written only by
+      `pwd/authenticated-at`; the gate reads it, `AuthenticatedAt` keeps its existing job of refreshing
+      `AuthTime` on step-up. Makes the gate mean what section 1 says it means, in one place, and covers
+      any future route that reaches `/auth/completed` without a password rather than only the OTP one.
+    - **B: a liveness read in the OTP handler.** At `HandleAuthOtpPost`, when `AuthenticatedAt` is nil
+      on entry the ceremony did no level 1, so require the bound session to still resolve. Needs no new
+      field, but leaves the gate reading a field that does not mean what it says and duplicates the
+      reasoning in a second handler.
+    - **C: accept it, and document the limit.** Defensible on decision 6's literal text, and cheapest.
+      The run does not recommend it: the enrollment sub-case makes it a fail-open reachable with a
+      stolen cookie alone.
+    - **D: defer to a follow-up.** Ruled out rather than weighed. Gap 3's first half is what section 2
+      goal 2 and section 4.4 ask for, and a follow-up for work the agreement owes narrows the run's
+      scope while reporting success.
+
+    **What either mistake costs.** Answering A or B when C was right costs one field or one query plus
+    the honest user's rare extra password entry, in the race where a session expires mid-step-up.
+    Answering C when A was right leaves explicit termination defeatable by an in-flight ceremony, which
+    is the defect #129 exists to close, on a path a stolen cookie reaches.
 
 ---
 
@@ -1745,18 +1819,96 @@ stated reason.
    pin, and decision 13 leaves the path itself to #109, where it is drafted as follow-up 2.
 
 ### Stage 5: the `/auth/completed` gate
-Status: **Not started**
-Detail: **sketch**
+Status: **In progress**
+Seams: 6 (`HandleAuthCompletedGet`, in the existing `handler_auth_completed_test.go`).
+Tiers: unit (three modules) and integration (dev container). Data not applicable: no query, no
+migration, no interface method, no model change.
+Docs: the first of the two sentences held back from stage 4's concepts section, that a ceremony in
+flight cannot complete into a recreated session.
 
-Decision 6's first half: in `HandleAuthCompletedGet`, reach `completed/start-new-session` only when
-`!hasValidUserSession && !userReallyAuthenticated` is false, otherwise set `AuthStateRequiresLevel1`,
-save, and redirect to `/auth/level1`. The discriminator is already computed at
-`completed/really-authenticated` and today is consulted only in the branch where it does not matter.
-Carries the comment decision 6 asks for about `handlePromptNone` being the fragile neighbour. Seam 6,
-whose new row asserts the redirect and that `StartNewUserSession` is not called, and whose three
-existing subtests gain a non-nil `AuthenticatedAt`, which is the non-additive cost section 1 recorded.
-Tier: unit. Docs: the first of the two sentences held back from stage 4's concepts section, that a
-ceremony in flight cannot complete into a recreated session. Expand against stage 4's code.
+Decision 6's first half. The else branch of `HandleAuthCompletedGet` reaches
+`completed/start-new-session` today with no proof anyone authenticated; after this stage it reaches it
+only when this ceremony did. The discriminator is already computed at
+`completed/really-authenticated` and is consulted only inside the valid-session branch, where it
+decides whether to refresh `AuthTime`.
+
+**The integration tier is an addition to the sketch, and `test/fresh-ceremony-after-delete` is the
+reason.** The sketch said unit only and left the integration run to stage 6. Expanding against the
+code says otherwise: this stage is the single change in the run whose predicate could redden #46's
+guard, because that guard's shape, session deleted then a fresh ceremony, is exactly the predicate
+decision 6 rejected. A stage that could break an existing suite runs that suite rather than
+discovering it one stage later. Coverage the plan missed, not a scope change, and stage 6 still owns
+the new mid-flight integration case.
+
+**Nothing else about the restart changes**, and that is a decision rather than an omission. Decision 6
+lists what the restart preserves: the ceremony's client, scope, state, nonce and PKCE parameters. It
+says nothing about clearing `authContext.AuthMethods`, which `authorize/sso-reuse` copied off the
+session that has since been terminated, and this stage does not clear it. The resulting inaccuracy is
+pre-existing rather than introduced, since today's ungated else branch carries the same stale value
+into `StartNewUserSession`; it is verified and drafted as follow-up 3 in section 9.
+
+1. **The gate, at the top of the else branch in `HandleAuthCompletedGet`.** Status: **Done**
+   Landed at `completed/level1-restart`, inside the else branch as written.
+   When `!userReallyAuthenticated`, set `AuthStateRequiresLevel1`, save the auth context, redirect to
+   `/auth/level1` and return, before `completed/start-new-session` is reached. Inside the else branch
+   rather than above `if hasValidUserSession`, because `hasValidUserSession` is already false there,
+   so the gate reads as the one condition it adds and the SSO branch is visibly untouched.
+   Carries the comment decision 6 asks for, three things a later reader needs: that the predicate is
+   deliberately "this ceremony authenticated" rather than "no valid session", because
+   `test/fresh-ceremony-after-delete` is #46's guard over a legitimate case with the second shape;
+   that there is no loop, since the second pass has `AuthenticatedAt` set by `pwd/authenticated-at`;
+   and that `handlePromptNone` is the fragile neighbour, because it *does* set `AuthenticatedAt` from
+   the session it reused and only its current call graph, straight to `/auth/issue` without passing
+   here, keeps the discriminator meaning what it says.
+2. **The two comments this stage falsifies.** Status: **Done**
+   `pwd/authenticated-at` and the OTP handler's matching write both say `AuthenticatedAt` is "used by
+   handler_auth_completed to decide whether to refresh the session's AuthTime". After this stage it
+   also decides whether a session may be created at all, which is the stronger consumer and the one a
+   later reader must not delete by accident. Same class and same reasoning as stage 1's finding 1: the
+   stage that falsifies a comment owns fixing it, because the alternative hands the next reader a
+   wrong contract.
+3. **Unit cases at seam 6.** Status: **Done**
+   Landed at `test/completed-gate` and its zero-time sibling, with the three positive controls
+   amended. Every row below shipped and was executed.
+   In `TestHandleAuthCompletedGet`, extending it rather than adding a sibling, on the same strict mock
+   quartet its ten subtests already use. Expectations written before running them:
+
+   | Case | Expected | Which gate rejects it, or what it proves |
+   |---|---|---|
+   | no valid session, `AuthenticatedAt` nil, which is the terminated-SSO shape | 302 to `/auth/level1`, the saved context reading `requires_level_1`, and `StartNewUserSession` never called | decision 6's gate. "Never called" is enforced rather than asserted: the strict mock carries no `StartNewUserSession` expectation, so reaching it fails the case on its own, and neither audit event is stubbed either |
+   | no valid session, `AuthenticatedAt` non-nil but the zero time | 302 to `/auth/level1` | the `!IsZero()` term of `completed/really-authenticated`. A gate written as `AuthenticatedAt == nil` passes this row, which is the only thing that catches that spelling |
+   | the three existing subtests reaching `StartNewUserSession` gain a non-nil `AuthenticatedAt` | outcomes unchanged: 302 to `/auth/issue` or `/auth/consent`, `StartNewUserSession` called with the same arguments | **keep these as the positive control.** They are `test/fresh-ceremony-after-delete`'s shape at the unit tier, session gone and the user really authenticated, and they fail against a gate keyed on the session alone. This is the non-additive cost section 1 recorded |
+   | the three existing subtests with a valid session and `AuthenticatedAt` nil, untouched | unchanged: SSO reuse still bumps and proceeds | the gate is confined to the else branch. These are the rows that fail if it is hoisted above `if hasValidUserSession`, which is the natural-looking tidy-up |
+
+   No new audit event, no new mock method and no new fixture: the gate reads a field the handler
+   already computes and writes a state the router already knows.
+4. **The docs sentence, in `concepts/user-sessions.mdx`.** Status: **Done**
+   Into the `## Ending a session` section stage 4 created, and limited to what is true after this
+   commit: a sign-in that was riding on the ended session cannot quietly become a replacement session.
+   It must **not** yet say that no code can be issued, because the consent-screen window at
+   `/auth/issue` is stage 6 and stays open until then. `reference/security.mdx`'s durable-termination
+   bullet is checked and needs no edit: it summarises what termination revokes and claims nothing
+   about ceremonies.
+5. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules` and `where.sh test --type integration`, the
+   latter for the reason stated above. Both in the foreground.
+
+**As built.** All five steps landed as written. Two anchor rows added, `completed/level1-restart` and
+`test/completed-gate`, and no sealed row needed re-sweeping: unlike stage 4 this stage replaces no
+cited call, it only adds a branch above one.
+
+Two things worth naming beyond the steps.
+
+1. **The predicted case table shipped unchanged**, which is rare enough in this run to say plainly.
+   Twelve subtests where there were ten, the two new ones passing and the three amended positive
+   controls passing with their original assertions, including the `StartNewUserSession` argument
+   expectations, because the handler overwrites `AuthenticatedAt` from the new session before saving
+   and the amendment therefore cannot be observed downstream of the gate.
+2. **The follow-up this stage found is recorded in section 9 rather than fixed here.** The restart
+   reuses the ceremony's `AuthContext`, which still carries the terminated session's `AuthMethods`, so
+   a user who re-authenticates with a password alone can land a new session and a token claiming
+   `otp`. Verified reachable, verified pre-existing, and deliberately not this stage's work: decision 6
+   fixes what the restart preserves, and `amr` accuracy is neither in a goal nor in any decision.
 
 ### Stage 6: the `/auth/issue` liveness check and the compensating revoke
 Status: **Not started**
@@ -2262,13 +2414,141 @@ was written.
 **No round 2.** All three axes reviewed with the tiers actually executed and zero findings is the clean
 case the reviewer reference describes, and nothing changed after the reviewed hash.
 
+### Stage 5, 2026-08-05
+
+**Landed.** `completed/level1-restart`, the gate on the else branch of `HandleAuthCompletedGet`: with
+no valid session and no authentication in this ceremony, the handler sets `AuthStateRequiresLevel1`,
+saves and redirects to `/auth/level1` instead of minting a session from `authContext.UserId`. Plus the
+two falsified comments at `pwd/authenticated-at` and its OTP twin, `test/completed-gate` and its
+zero-time sibling, the three positive-control subtests amended, and one paragraph in
+`concepts/user-sessions.mdx`. Two anchor rows added to section 0.
+
+**What changes for a user.** A ceremony that was riding on a session ended mid-flight now stops at the
+login page rather than silently recreating the session it was riding. Stages 1 to 4 could not reach
+this: they mark and reject **existing** grants, and this ceremony's code does not exist yet when
+termination runs. The remaining half of gap 3, a ceremony already past `/auth/completed` and sitting on
+the consent screen, stays open until stage 6, which is why the docs sentence is worded around session
+recreation and says nothing about code issuance.
+
+**Tiers.** Unit green, all three modules (`where.sh test --type modules`, "All tests completed
+successfully", no `FAIL` lines). `TestHandleAuthCompletedGet` verified individually: 12 subtests where
+there were 10, all passing. Integration green on **all four engines**
+(`where.sh test --type integration`), 4748 passing test lines across the four logs, zero `FAIL`, and
+`test/fresh-ceremony-after-delete` passing once per engine, which is the assertion this stage most had
+to earn. No data tier, correctly: no query, no migration, no interface method, no model change.
+`check-anchors.sh` passes all 59 rows, `gofmt -l` is silent, `git diff --check` is clean, and
+`cd site && npm run build` completes with 42 pages.
+
+**The integration tier was not in the sketch**, which said unit only and left the tier to stage 6. It
+was added at expansion for a stated reason, in the stage header above: this is the one change in the
+run whose predicate could redden #46's guard, and a stage that could break an existing suite runs it
+rather than finding out one stage later. It cost four minutes and it is the evidence decision 6 rests
+on, since decision 6's whole argument is that the issue's proposed predicate would break that test and
+this one does not.
+
+**Mutation evidence, three mutations, each applied to the real handler, run, and reverted in this
+session.** The three failure sets are disjoint, which is the point: each row family answers for exactly
+one mistake.
+
+1. **The predicate reduced to the missing session alone**, `if true` inside the else branch, which is
+   the issue body's own proposal and the one section 1 says is wrong. Exactly the three positive
+   controls failed, the "new session" subtests for consent-not-required, consent-required and
+   `offline_access`. Nothing else moved. Those three are `test/fresh-ceremony-after-delete`'s shape at
+   the unit tier, so this is #46's regression caught two tiers below where it would otherwise surface.
+2. **The `!IsZero()` term dropped**, `if authContext.AuthenticatedAt == nil`. Exactly one row failed,
+   the zero-time sibling, which is the only case in the file that distinguishes the two spellings.
+   Without that row this mutation ships.
+3. **The gate hoisted above `if hasValidUserSession`**, which is the natural-looking tidy-up since the
+   condition reads as if it belongs there. Exactly the three SSO-reuse subtests failed, "existing
+   session (SSO reuse)", "User is not enabled" and "Scope is filtered and becomes empty", all three
+   being valid-session cases with a nil `AuthenticatedAt`. They were already in the file and needed no
+   amendment, so the confinement of the gate was covered before this stage was written.
+
+**Deviations from the plan as written.** Two, both named in the stage's as-built note: the integration
+tier added at expansion with its reason, and the `AuthMethods` staleness left alone and drafted as
+follow-up 3 rather than fixed here.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
+`Decided`. The one judgement call this stage made, whether clearing the terminated session's
+`AuthMethods` belongs here, resolves under section 3 rather than needing a new item: decision 6
+enumerates what the restart preserves and does not ask for it, section 2 scopes no goal to `amr`
+accuracy, and the defect is verified as pre-existing rather than introduced, so fixing it here would be
+this run narrowing one issue while widening another.
+
+**Review request.** Written after everything above, which is stage 3's lesson: the trace goes into the
+agreement at the moment it is known, because the mailbox does not survive the next gate.
+
+**Review, round 1.** `gpt-5.6-sol`, effort high, request `129-20260805T111428Z`. All three axes read
+`reviewed`. It ran the modules tier (green, three modules), the integration tier (green on mysql,
+postgres, mssql and sqlite), `check-anchors.sh` (59 rows), `npm run build` in `site` (42 pages),
+`gofmt -l` on the changed Go files, `git diff --check`, and it re-verified the diff hash
+`40b6dacd` before writing, so the response answers the diff the request named. Not reached: the data
+tier, correctly, this stage adds no data-layer behaviour; the three mutations, assessed statically
+because a reviewer may not modify source under review; and unchanged client-secret comparison, PKCE,
+redirect validation, token validation, unrelated endpoint authorization and rate-limiter internals.
+
+One finding, and it is the security axis.
+
+1. **OTP alone satisfies a gate meant to prove level 1 authentication.** `Raised by: reviewer`,
+   blocking, confidence high, `needs_human: true`. Status: **Open**
+
+   **Confirmed against the code**, not taken on the reviewer's word. `AuthenticatedAt` has two writers
+   on the path to `/auth/completed`, and `handler_auth_otp.go` is the second one. The five hops are
+   written out in decision 15: an SSO ceremony reaches `/auth/level2` from
+   `HandleAuthLevel1CompletedGet` without a password; `HandleAuthLevel2Get` sets `AuthStateLevel2OTP`;
+   `HandleAuthOtpPost` verifies the state and nothing else, reads no session row, and sets
+   `AuthenticatedAt`; `completed/level1-restart` then computes `userReallyAuthenticated` as true with
+   the session row gone and calls `completed/start-new-session`. `HasValidUserSession` and
+   `UserSessionLoadUser` both handle the nil session cleanly, so nothing intervenes with a 500.
+
+   The reviewer's enrollment sub-case checks out too, and it is what makes this reachable with a
+   stolen cookie rather than only by the legitimate user: for a user without OTP on a
+   `level2_mandatory` client, `HandleAuthOtpGet` generates the secret, renders it into the enrollment
+   page and stores it in the http session, so the browser is handed the secret it will be tested on.
+
+   **Not refuted, and the one refutation available was weighed and rejected.** Decision 6's supporting
+   facts do name the OTP handler as a writer and call both writers "real authentication", so "the run
+   built what was sealed" is true. It does not dispose of the finding. Section 1's departure note, also
+   sealed, says the discriminator is **level 1** authentication and that `pwd/authenticated-at` is its
+   only writer, so the two sealed passages disagree about exactly this ceremony. And a conformance
+   defence does not answer a security axis: the gate fails open on a reachable path either way.
+
+   **Escalated rather than fixed.** decisions.md never auto-resolves authentication or session
+   questions whatever the demonstration looks like, and reviewer.md never lets the run alone settle a
+   security finding. The fix is also not forced: option A adds a field to a shape persisted in the
+   cookie, option B adds a query to a second handler, and both are defensible, which is a choice and
+   not a collision. Decision 15 carries the question, the options and the recommendation.
+
+**Where the stage got to, for whoever resumes.** All five steps are implemented and their code is
+**uncommitted**, deliberately: the gate expression is the subject of decision 15 and nothing resting on
+an `Open` decision gets committed. The working tree holds
+`handler_auth_completed.go`, `handler_auth_completed_test.go`, `handler_auth_otp.go`,
+`handler_auth_pwd.go` and `concepts/user-sessions.mdx`; only this document is committed. The tiers
+above were green on that tree and the reviewer re-ran them, so the next session does not need to
+re-establish that. What it needs to do is read the answer to decision 15 from PR #138, flip the item to
+`Decided` with the user's own reasoning, apply it inside stage 5, extend the seam 6 table with the
+OTP-after-termination row, add the `session_deletion_test.go` case if the answer is A or B, re-run
+modules and integration, and open round 2 at this gate.
+
+---
+
+## 8. Deferred decisions
+
+Nothing deferred. Stages 1 to 5 met no question that was safe to postpone on a stated assumption: the
+one judgement call stage 5 made resolved under section 3 (recorded in its run log entry), and the one
+question stage 5 could not answer was a security finding, which reviewer.md forbids deferring. It is
+decision 15 in section 3, `Open`, and it halts the run rather than sitting here.
+
+This section stays in the document even while empty, because the closing PR comment reports it and an
+absent section reads the same as a forgotten one.
+
 ---
 
 ## 9. Follow-ups
 
-Both found while grounding, both verified against code, both outside this change under section 2, and
-neither is a way to avoid work #129 owes. The run appends here as it finds more, and never files
-anything.
+The first two were found while grounding, the third while building stage 5. All three are verified
+against code, all three are outside this change under section 2, and none is a way to avoid work #129
+owes. The run appends here as it finds more, and never files anything.
 
 1. **A code insert can still land between a termination's `UPDATE` and its `COMMIT`.**
    `bug`, `security`, `go`. Found while settling decision 12. Status: **Drafted**
@@ -2327,3 +2607,54 @@ anything.
    active session on that device and can only end it with the "End session" button. Whatever B decides
    about per-client versus whole-session teardown, this path should reach the same code as the
    `id_token_hint` path rather than bypassing it.
+
+3. **A session-less completion inherits the terminated session's `amr`.**
+   `bug`, `security`, `go`. Found while building stage 5. Status: **Drafted**
+
+   `authorize/sso-reuse` copies `userSession.AuthMethods` onto the `AuthContext`, and nothing clears
+   it if that session later stops backing the ceremony. When `HandleAuthCompletedGet` takes the else
+   branch it passes that value straight to `completed/start-new-session`, and `issue/create-code`
+   stamps the same value onto the code, which becomes the token's `amr`. So a session whose methods
+   were `pwd otp` can produce a **new** session, and a token, claiming `otp` when no OTP was verified
+   in the ceremony that created it.
+
+   Verified end to end: `handler_authorize.go` assigns `authContext.AuthMethods = userSession.AuthMethods`
+   on the SSO branch; `AddAuthMethod` in `pwd/authenticated-at` appends rather than replaces, and is a
+   no-op when `pwd` is already present; `completed/start-new-session` forwards
+   `authContext.AuthMethods` verbatim; `handler_auth_issue.go` sets `AuthMethods: authContext.AuthMethods`
+   on the code. `acr` is not affected, because `completed/set-acr-level` recomputes it from the target
+   when there is no session.
+
+   **Pre-existing, and #129 neither introduces nor widens it.** Before stage 5 the ungated else branch
+   carried the same stale value into a session created with no authentication at all; after stage 5 the
+   same value survives a restart in which the user really does authenticate, which is strictly the
+   better of the two. Decision 6 enumerates what the restart preserves and does not ask for the methods
+   to be cleared, and no goal in section 2 covers `amr` accuracy, so fixing it here would widen #129
+   into claim semantics.
+
+   Reachability, stated because it is narrow: the target ACR must not require level 2, or
+   `HandleAuthLevel1CompletedGet` sends the ceremony to `/auth/level2` and the `otp` is genuinely
+   earned. So it needs a user with OTP whose session reached level 2 for one client, then an
+   authorization request from a client whose ACR target is level 1, then the session ending mid-flight.
+
+   Searched `gh issue list --state open --search "amr auth methods"` and the full open list: nothing
+   tracks it. #133 is the closest neighbour and is a different mechanism, a live session belonging to
+   another user rather than a dead session's methods surviving on the context.
+
+   **Body:** An authorization ceremony that reuses an existing session copies that session's
+   `AuthMethods` onto its `AuthContext` in `HandleAuthorizeGet`, and nothing clears the copy if the
+   session stops backing the ceremony. `HandleAuthCompletedGet`'s no-valid-session branch then passes
+   the stale value to `StartNewUserSession`, and `HandleIssueGet` stamps it onto the authorization
+   code, so it reaches the token as `amr`.
+
+   The result is a session row, and a token, recording `otp` for an authentication in which only a
+   password was verified. `acr` is unaffected: `SetAcrLevel` recomputes it from the target when there
+   is no session, so the two claims disagree, and a relying party trusting `amr` over `acr` reads a
+   second factor that did not happen in that ceremony.
+
+   Reproduce with a user who has OTP enabled: authenticate at level 2 for one client, then send an
+   authorization request from a client whose default ACR is level 1, and end the session while that
+   request is in flight. The ceremony restarts at level 1 (#129 decision 6), the user enters a password,
+   and the new session records `pwd otp`. Clearing the inherited methods when the ceremony no longer
+   has the session it inherited them from looks like the fix, but it is a claim-semantics change and
+   wants its own decision.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,19 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** stages 1 to 7 committed, 2026-08-05. **Stage 7 closed on a clean round 1**: one predicate
+**Run state:** **all eight stages committed, 2026-08-05.** Stage 8, the last, closed on a clean review
+round 1 whose diff hash matched the committed tree exactly: two integration tests carrying gap 2's
+evidence and no production line, since gap 2 closed structurally in stages 1 and 2. Its expansion found
+that the marker's refusal and the sweep's are different gates with different messages, the marker's
+answering first, which is what makes the sequential case discriminating; and the race it drives reaches
+gap 2's own interleaving on mssql and sqlite, where the replacement it hands out is still live in
+storage and the marker is the only thing refusing it. Two mutations measured, and what stayed green
+under them is the argument for the stage: stage 4's headline case and stage 6's consent ceremony both
+pass with the marker's read or its write removed, and only these two tests fail. Section 3 has zero
+`Open` items, section 8 nothing deferred, section 9 four drafted follow-ups the run never files.
+Remaining: the closing pass, which is the full suite across every tier, sections 8 and 9 posted to the
+pull request, and `gh pr ready`. Below, the earlier state, kept because the run log reads against it.
+**Stage 7 closed on a clean round 1**: one predicate
 extension so codes revoked while still unredeemed do not accumulate (decision 8), green on the modules
 tier and on the data tier across all four engines, with five mutations measured. Its expansion found
 that where the `NOT IN` subquery sits decides whether the whole extension works at all under #130, and
@@ -22,7 +34,7 @@ the fix plus two assertions that can observe a committed response landed inside 
 clean. Expanding the stage also found that the terminated ceremony reaches `/auth/issue` with an
 **empty** session identifier rather than a dead one, because the session middleware clears it first,
 and that an empty identifier alone makes the resulting grant offline; the stage entry in section 6
-carries the reasoning. Next: stage 8, gap 2's evidence, still a sketch and the last stage.
+carries the reasoning. Next: stage 8's gate, and then the run's closing pass on the pull request.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -144,6 +156,8 @@ log can cite it the same way. Nothing above the line changed.
 | `db/reap-revoked-unused` | `src/core/data/commondb/code.go` | `DeleteUsedCodesWithoutRefreshTokens` | `deleteBuilder.Equal("revoked", true),` | stage 7, decision 8's second branch. `db/delete-used-codes` above still resolves, to the first branch's `used = true` term, which the extension leaves in place |
 | `test/reap-revoked-unused` | `src/authserver/tests/data/code_test.go` | `TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnused` | `must outlive it, and deleting the code would cascade the descendant away` | stage 7, seam 3's keep-this row, the only case in the suite that fails when the `used = false` term is dropped |
 | `test/reap-ropc-null-code-id` | `src/authserver/tests/data/code_test.go` | `TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnusedWithRopcTokenPresent` | `a refresh token with a NULL code_id exists` | stage 7, the row that fails if the `NOT IN` subquery is hoisted out of the used branch, which is the mutation that ships the whole extension inert |
+| `test/child-born-rejected` | `src/authserver/tests/integration/token_refresh_concurrent_test.go` | `TestToken_Refresh_ChildOfATerminatedGrantIsBornRejected` | `THE ONE COLUMN CLEARED BELOW IS THE ONLY THING THE INTERLEAVING DECIDES` | stage 8, gap 2's deterministic evidence. The locator is the paragraph defending the reconstruction, which is the part of this test a reader has to be able to find |
+| `test/refresh-races-termination` | `src/authserver/tests/integration/token_refresh_concurrent_test.go` | `TestToken_Refresh_RacingATermination_LeavesNoUsableDescendant` | `replacement %d is still live in storage` | stage 8, the same window driven for real. The locator is the log line that says the run reached gap 2's own interleaving, which is what mssql and sqlite print |
 
 Counts in this document carry their command:
 
@@ -2536,17 +2550,152 @@ naming beyond the steps.
    | 14, the cutoff moved inside the used branch, so the new branch has none | the worker-cutoff survival row, alone | the shared `created_at` term is load bearing, and the row that proves it is the one that uses the worker's own cutoff |
 
 ### Stage 8: gap 2's evidence
-Status: **Not started**
-Detail: **sketch**
+Status: **Done**
+Seams: 8 (`POST /auth/token`), in the existing `token_refresh_concurrent_test.go`, which the sketch
+names and which is right for a second reason it does not give: that file already owns a rotation race
+at this seam, it carries `refreshTokenJti` and the release-together harness, and #128's double-spend
+case is the shape both new cases vary. The offline-grant fixtures come from
+`credential_change_revocation_test.go`, cross-file in the same package, exactly as stage 4's endpoint
+cases use them.
+Tiers: integration (dev container) only, and the other two are **not applicable rather than skipped**:
+this stage adds no production code, so nothing outside `tests/integration` changes, and `modules`
+(internal, core, adminconsole) does not compile that package, so a run there would exercise nothing
+this stage wrote. Data likewise: no query, no interface method, no migration, no model change.
+Docs: **none, and verified rather than assumed.** Two searches over `site/src/content/docs/`.
+`concurrent|race|in flight|at the same time|simultaneous` finds three pages and none is about
+termination: `concepts/tokens.mdx` and `reference/security.mdx` state the rotation invariant this
+stage does not touch, and `reference/environment-variables.mdx` is unrelated. `rotat|replacement
+token|replaced` finds the same rotation material plus `integration/rest-api.mdx` on audit retention.
+The `## Ending a session` section stages 4 to 6 wrote already says the refresh tokens of that session
+are revoked, which this stage proves rather than extends, and nothing observable changes here at all:
+the stage adds two test functions and no production line. A sentence promising race safety was
+considered and deliberately not written, for the reason stage 6 gave about follow-up 1's residual: it
+would read to a user as doubt about the feature, and it would over-claim while the neighbouring
+window in follow-up 1 is still open.
 
-Gap 2 closes structurally in stages 1 and 2, since a rotated child inherits its parent's `code_id`
-and so is born already rejected. What is missing is the proof, and decision 1 requires it before the
-issue closes. An integration test mirroring `token_refresh_concurrent_test.go`'s harness: a grant
-whose refresh races a termination leaves no usable descendant, checked both ways round, the child
-issued before termination and the child issued after it, on an `offline_access` grant since a
-session-bound one already dies at `validator/session-branch`. Seam 8. Tier: integration. Docs: none
-unless the evidence contradicts what stage 3 documented, which would be a blocking decision rather
-than a docs edit. Staged last per decision 1.
+Gap 2 is the one gap that was never implemented, because decision 4 chose the carrier that closes it
+structurally: a rotated child inherits its parent's `code_id`, so marking the code marks every
+descendant, including one inserted after the termination committed. Decision 1 requires the proof
+before the issue closes, and this stage is that proof and nothing else. If the evidence had
+contradicted what stages 4 to 6 documented, that would have been a blocking decision rather than a
+docs edit; it does not.
+
+**Three things the expansion learned from the code, none of which the sketch could have.**
+
+- **The two refusals are different gates with different messages, and the marker's answers first.**
+  `validator/refresh-code-revoked` sits in `ValidateTokenRequest`, which runs before the handler, and
+  it answers `invalid_grant` with "The refresh token is invalid because the associated session has
+  expired or been terminated." The handler's own revoked-row branch answers the same error code with
+  "This refresh token has been revoked." and additionally runs #128's family containment. So a child
+  that the termination sweep revoked **and** whose code is marked is refused by the marker, and the
+  `error_description` is what names which gate did it. That is what makes the sequential case
+  discriminating rather than decorative: on the error code alone the two gates are indistinguishable
+  from outside.
+- **No interleaving lets a racing child escape rejection**, which is why the race case asserts an
+  unconditional invariant rather than a probability. The sweep marks the code, every descendant
+  carries that `code_id`, and the marker is read from the row's joined code on every presentation.
+  What the interleaving decides is only **which** gate refuses the child: the handler's branch when
+  the sweep saw it, the validator's marker when it did not. Follow-up 1's escaping window is a
+  **code** insert at `/auth/issue`, not a refresh-token insert, and nothing in it reaches this path.
+- **The window cannot be forced over HTTP, so the case that matters is reconstructed rather than
+  raced.** A child issued after the termination is a child whose own `revoked` column is false while
+  its code is marked. Every part of that state is produced by the real server except the one bit the
+  interleaving decides, so step 1 creates it by clearing that one column on a server-minted,
+  rotation-written row after the real endpoint terminated the session. It is the only case in this
+  run where deleting `validator/refresh-code-revoked` returns a **working token** rather than a
+  differently worded refusal, which is precisely what gap 2 is.
+
+1. **`TestToken_Refresh_ChildOfATerminatedGrantIsBornRejected`, both ways round.**
+   Status: **Done**
+   Landed at `test/child-born-rejected`, three cases in one ceremony as written.
+   In `token_refresh_concurrent_test.go`, on one offline grant from `createOfflineGrant`, terminated
+   through the real admin `DELETE` with `createAdminClientWithToken` and `makeAPIRequest`, so the
+   termination is the shipped action rather than a helper call. Expectations written before running
+   them:
+
+   | Case | Expected | Which gate answers it, or what it proves |
+   |---|---|---|
+   | the grant rotates once before the termination | 200 with a replacement refresh token, whose row carries `refresh_token_type` `Offline`, an **empty** `session_identifier` of its own, and the **parent's** `code_id` | the attribution control, plus decision 4's load-bearing property that a descendant inherits `code_id`. The Offline and empty-sid assertions are what stop this case being the benign member of its class: a session-bound child would be refused below by `validator/session-branch` whatever the marker did, and the case would prove nothing |
+   | that child presented after the session is ended, its own row revoked by the termination sweep | 400 `invalid_grant`, `error_description` "The refresh token is invalid because the associated session has expired or been terminated." | the child issued **before** the termination. The description names the gate: the marker is read in the validator, ahead of the handler's revoked-row branch, so it answers even for a child the sweep also revoked. A refusal by the row alone would read "This refresh token has been revoked." Incidentally also evidence that termination did not advance the user's generation, which would answer with `invalidGenerationMessage` instead (section 4.6) |
+   | the same child with its own `revoked` column cleared, which is the row state a child inserted after the sweep has | 400 `invalid_grant`, the same description, no `access_token`, no `refresh_token`, and the code's family gains no row | **keep this row.** It is gap 2's actual evidence: the row is live, so removing the marker lets the handler's compare-and-set claim succeed and rotation mint a working replacement. Every other case in the run merely changes which refusal you get. Mutation 15 |
+
+   The reconstruction is named in the test's own comment rather than left to be noticed, with what is
+   real about it: the JWT is server-minted, the row was written by rotation, the code was marked by
+   the real endpoint, and the single cleared column is the one bit the interleaving decides. The
+   alternative, hand-building a signed refresh token and its row, would prove less, because the shape
+   would then be the test's invention rather than rotation's.
+2. **`TestToken_Refresh_RacingATermination_LeavesNoUsableDescendant`, the genuine race.**
+   Status: **Done**
+   Landed at `test/refresh-races-termination`, and it reaches the window rather than merely
+   approaching it: see the as-built note and the measurement in the run log.
+   The same file, mirroring `TestToken_Refresh_ConcurrentDoubleSpend_IssuesOnlyOnce`: eight
+   presentations of one offline refresh token and the admin `DELETE`, all released together off one
+   channel. The `DELETE` runs in its own goroutine through a non-asserting `concurrentDelete` beside
+   `concurrentTokenPost`, for the reason that helper exists: `require` from a goroutine is not safe.
+   Expectations written before running them:
+
+   | Case | Expected | What it proves |
+   |---|---|---|
+   | eight refresh presentations released together with the termination | at most one carries a replacement token, and every request that did not is not a 200 and carries no `access_token` | rotation's own invariant survives a termination racing it, on four engines under real contention |
+   | every replacement token the race handed out, presented afterwards | `invalid_grant`, no `access_token` | goal 3 at the highest seam that can observe it. Whichever gate answers, no descendant of a terminated grant is usable |
+   | the pre-race parent, presented afterwards | `invalid_grant`, no `access_token` | the presented token is consumed either way, so this cannot be the case that passes by accident |
+   | the termination itself | 200, and the session row gone before the invariant above is asserted | without it the case could pass because nothing was terminated |
+
+   **What it cannot force, stated in the test as `token_refresh_concurrent_test.go` already does for
+   its own case:** which interleaving occurred. A race whose `DELETE` commits first refuses all eight
+   at the marker and proves only that nothing was minted; the interesting interleaving, a validation
+   that read the code live and an insert that landed after the sweep, cannot be *guaranteed* from
+   outside and is what step 1 reconstructs. So the count of replacements is logged rather than
+   asserted, and so is whether the sweep saw each one, which makes a vacuous run visible in the log
+   rather than silently green. **Measured, it is not vacuous:** every engine produced a replacement,
+   and on mssql and sqlite that replacement was still live in storage, which is gap 2's own
+   interleaving reached end to end. The run log carries the per-engine reading.
+
+   **The termination goroutine sleeps 5 milliseconds after the release, which is a probability knob
+   and not a synchronization point.** Added after measuring that a simultaneous release consistently
+   produced no replacement at all on sqlite: the termination commits before any presentation has
+   finished verifying an RSA signature, so the race had nothing to hand out and the assertions had
+   nothing to chew on. Every assertion holds at any value including zero, which is what keeps it a
+   knob, and the log line says what the chosen value produced.
+
+   **Contention with rotation can legitimately fail the termination transaction** on the server
+   engines, as a lock timeout or a deadlock. That is not what this case is about, so a non-200 is
+   logged and the `DELETE` retried once sequentially, and the invariant is asserted only against a
+   session verified gone. Tolerating it is not weakening the case: every refusal path leaves no usable
+   descendant, and a 500 mints nothing.
+3. **Verify.** Status: **Done**
+   `check-anchors.sh` PASS on 82 rows, then `where.sh test --type integration` across all four
+   engines, in the foreground, exit 0 with 4768 passing test lines and zero `FAIL`. That tier is the
+   whole stage. No modules run and no data run, for the reason in the header: no file outside
+   `tests/integration` changes, and neither tier compiles that package. `gofmt -l` silent and
+   `go vet ./tests/integration/` clean on the one changed file.
+
+**As built.** All three steps landed. Two anchor rows added to section 0, none moved. The predicted
+case tables shipped unchanged, which is worth saying plainly because the last four stages each
+changed a row at expansion: here the expectations written first were the ones measured, on all four
+engines. Four things worth naming beyond the steps.
+
+1. **The stagger in step 2 is a deviation from the step as first written**, and it is recorded rather
+   than absorbed because the reason is a measurement. Released at the same instant, the race
+   consistently produced zero replacements on sqlite, so the case asserted only that nothing was
+   minted and its interesting loop never ran. Five milliseconds makes a replacement appear on every
+   engine. The step now says so, including that no assertion depends on the value.
+2. **The race reaches gap 2's own interleaving, which the sketch did not expect and the step only
+   hoped for.** On mssql and sqlite the replacement the race handed out was **still live** in storage,
+   so the sweep never saw it and the marker was the only thing refusing it, which is exactly the state
+   step 1 reconstructs. On mysql and postgres it landed before the sweep and was revoked. Both are
+   legitimate and neither is asserted; the log says which happened. Mutation 15 makes the difference
+   consequential rather than cosmetic: without the marker read, that live replacement is a **working
+   grant**.
+3. **The two refusals are engine-independent in the one way that matters.** All four engines answered
+   the terminated grant with the marker's description, including the two where the row was also
+   revoked, which is the ordering claim in the preamble measured rather than reasoned. Across the
+   racers, 25 of 28 refusals read "This refresh token has been revoked." and 3 read the marker's
+   message, so both gates fire in one run and the spread is the interleaving made visible.
+4. **The termination never needed its retry.** No engine logged the sequential retry path, so the
+   contention tolerance in step 2 is unexercised on this hardware. It stays, because a lock timeout
+   under contention is a property of the engine and the load rather than of this test, and the
+   alternative is a red run that says nothing about #129.
 
 ---
 
@@ -3809,6 +3958,168 @@ there is no finding whose fix a later round would need to see.
 **Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
 `Decided`, and section 9 its four follow-ups. Stage 7 is committed with this document following it.
 Next: stage 8, gap 2's evidence, still a sketch and the last stage.
+
+### Stage 8, 2026-08-05
+
+Written before the review, because this session may be the last one that knows what happened.
+
+**Expansion.** The sketch had the shape and the seam right, and expanding against the code changed
+what the stage is *worth* rather than what it does. Three findings, all written into the stage header:
+the two refusals are different gates with different messages and the marker's answers first, which is
+what makes the sequential case discriminating; no interleaving lets a racing child escape, so the race
+case can assert an unconditional invariant rather than a probability; and the window cannot be forced
+from outside the server, so the case that matters is reconstructed rather than raced.
+
+**What landed.** Two integration tests in `token_refresh_concurrent_test.go`, `test/child-born-rejected`
+and `test/refresh-races-termination`, plus a `concurrentDelete` helper beside `concurrentTokenPost` and
+one `terminatedGrantMessage` const. **No production line changed**, which is the whole stage: gap 2 was
+closed structurally by stages 1 and 2, because a rotated child inherits its parent's `code_id`, and
+decision 1 asked for the proof before the issue closes. Two anchor rows added to section 0, none moved.
+
+**Tiers.** Integration green on **all four engines** in one pass, `where.sh test --type integration`
+exit 0, 4768 passing test lines, zero `FAIL` (62.9s mysql, 67.7s postgres, 89.0s mssql, 45.6s sqlite),
+with both new tests passing once per engine. `check-anchors.sh` passes all **82** rows. `gofmt -l`
+silent and `go vet ./tests/integration/` clean on the one changed file. **Modules and data not run and
+not claimed**, and the reason is stronger than "not applicable": this stage changes one file under
+`tests/integration`, and neither tier compiles that package, so a run there would exercise nothing
+this stage wrote.
+
+**What the race measured, per engine, which is the part the sketch could not predict.** Every engine
+produced exactly one replacement token, and every replacement was refused. On **mssql and sqlite** the
+replacement was still **live** in storage when it was presented, so the termination's sweep never saw
+it and the marker was the only thing standing between it and a working grant: that is gap 2's own
+interleaving reached end to end through HTTP, not merely approached. On **mysql and postgres** the
+replacement landed before the sweep and was revoked by it, and the marker still answered first. Across
+the seven refused racers per engine, 25 of 28 read "This refresh token has been revoked." and 3 read
+the marker's message, so both gates fire inside one run. No engine needed the sequential retry the case
+tolerates.
+
+**Mutation evidence, two mutations, each applied to the real code, run on sqlite, and reverted in this
+session. What stayed green under them is the point.**
+
+15. **The marker read dropped**, `validator/refresh-code-revoked` disabled. Stage 4's headline case
+    `test/terminate-offline-endpoint` **passed**, so nothing already in the suite can see this. Both
+    stage 8 tests failed, and they failed by printing gap 2: the swept child's description flipped to
+    "This refresh token has been revoked."; the live child was answered **200 with an access token, an
+    id token and a fresh refresh token**, and the code's family grew from 2 rows to 3; and the race's
+    live replacement was likewise answered 200, immediately after the log line saying the sweep never
+    saw it. That is a working grant on a terminated session, which is the defect this stage exists to
+    disprove.
+16. **The marker write dropped**, `RevokeCodesBySessionIdentifier` removed from
+    `revoke/terminate-session` with the token sweep left in place. Stage 4's headline case **passed**
+    and so did stage 6's `test/consent-window-no-code`, because both are satisfied by the sweep alone.
+    Both stage 8 tests failed the same way as under mutation 15. So the marker's *write* is load
+    bearing at the integration tier and only this stage's cases observe it, which is the mirror of 15
+    and the reason both were run rather than one.
+
+**A third mutation was considered and deliberately not run:** moving the marker read inside the
+`Refresh` branch of the `typ` switch, which is the plausible tidy-up that would file it beside the
+other session check and make it unreachable for an offline grant. Stage 2's unit table already refuses
+it, because its refresh fixtures carry `typ: Offline` deliberately, so running it here would measure
+stage 2's coverage rather than stage 8's.
+
+**One thing checked rather than assumed, because a test writes through a production path.** Step 1's
+reconstruction clears the child's `revoked` column with `UpdateRefreshToken`, which works only because
+that column is not tagged `dont-update` the way `Code.Revoked` and `RefreshToken.AuthStateGeneration`
+are. That looked like it might be a defect of the same class, a stale full-row write regressing a
+revocation, so it was traced: `UpdateRefreshToken` has exactly one production caller,
+`revoke/refresh-tokens`, and it is the sweep that sets the flag true. Nothing in production writes a
+whole refresh token row for any other purpose, so there is no clobber to find and no follow-up to
+draft.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`, and section 9 its four follow-ups. The evidence agrees with what stages 4 to 6 documented,
+which is the one outcome that would have made this a blocking decision rather than a stage.
+
+**Where the stage is.** Both tests implemented, green on all four engines, and **uncommitted** at the
+point this was written, with `.review/request.md` carrying round 1. The trace is here rather than in
+the mailbox because the mailbox does not survive the next gate, which is stage 3's lesson.
+
+### Stage 8 round 1, 2026-08-05: clean, and the last stage closes
+
+**Review, round 1, clean.** `gpt-5.6-sol`, effort high, `type: code-review`, request
+`129-20260805T190122Z`. All three axes read `reviewed`, verdict `clean`, **zero findings, zero
+follow-ups and zero bookkeeping**. The scope is recorded rather than summarised, for the reason stage
+7's entry gives: zero findings in a narrow scope reads exactly like zero findings in a thorough one.
+
+**The reviewed tree is the committed tree, and this one is provable rather than argued.**
+`.review/before.sha` held `f51d8c916c26…`, `git diff | sha256sum` at this gate returns the same value,
+and the request named that hash as the ask. So the reviewer touched no tracked file and nothing moved
+after it looked, which stage 7 could only establish from mtimes because its `before.sha` was stale.
+
+**What it ran**, its own list: the full diff and the surrounding refresh, validation, termination,
+persistence and harness code; `where.sh test --type integration`, passing on mysql, postgres, mssql and
+sqlite; `check-anchors.sh` at all 82 rows; `go vet ./tests/integration/` in the dev container;
+`gofmt -l` on the changed file; `git diff --check`; and `git diff | sha256sum` compared against the
+requested hash. Its 35 shell commands are in `.review/events-codex.jsonl`, and they are reading and
+running rather than agreeing: it read the agreement in 17 slices, then the validator's `refresh_token`
+case, `handler_token.go`, `commondb/code.go`, `token_issuer.go`, `models/refresh_token.go`, the
+offline-grant harness in `credential_change_revocation_test.go` and the helpers in `utils_test.go`.
+
+**What it answered, question by question**, since the request asked five and a clean verdict is worth
+only what it covered.
+
+1. **The reconstruction is faithful, and it checked the fields the request named.** `UpdateRefreshToken`
+   excludes `CreatedAt` and `AuthStateGeneration` through `dont-update`, so clearing `Revoked` leaves a
+   row whose `UpdatedAt` is later and whose `CreatedAt` is earlier than a genuine late insert's, and it
+   traced that **neither validation nor rotation reads either field**, so the divergence is invisible to
+   the path under test. The parent state and the family columns match the real interleaving.
+2. **The description assertion identifies the gate, on the code.** The marker is read after client
+   ownership and before the `typ` switch; the asserted row is `Offline` with an empty session
+   identifier, so it cannot reach the `Refresh` branch's session lookup that shares the message; the
+   handler's revoked-row gate runs later and uses the distinct text. It found **no third reachable gate**
+   on this fixture that produces the asserted description, which is what the request asked it to look
+   for.
+3. **The racing case is a real test.** It confirmed the invariant is unconditional under the design and
+   that the case claims nothing about which interleaving occurred.
+4. **Neither the 5 millisecond delay nor the retry can mask a failure.** The delay changes only the
+   likelihood of a replacement, and every assertion holds when there is none. The retry still requires a
+   200 **and** independently requires the session row to be gone, so it cannot turn a failed termination
+   into a passing assertion; it can only make a run less concurrent, which the test says. And it cannot
+   paper over a missing marker read or write, because the deterministic case fails under either.
+5. **No third mutation is owed.** A lost `code_id` inheritance is caught by the parent-child equality
+   assertion; moving the marker read into the `Refresh` branch is already caught by stage 2's `Offline`
+   fixtures, which is the reason the run gave for not running it.
+
+It also took the sceptical pass the request asked for on the long comments, since the diff is mostly
+prose, and confirmed their substantive claims: which gate answers first, why `offline_access` is
+required rather than incidental, what the reconstruction is faithful to, and what the race cannot force.
+Three earlier gates in this run found a comment or a claim that was false, so this was asked for
+explicitly.
+
+**Its own run reached the same measurement**, independently: one replacement per engine, still live
+after the sweep on mssql and sqlite and refused by the marker anyway, the before-sweep ordering on mysql
+and postgres, and no sequential termination retry. **One honesty note about verifying that.** Codex's
+captured output for the run truncates the middle, `... 3548864 bytes omitted ...`, so what the capture
+itself proves is the run spanning mysql through sqlite, zero `FAIL`, one
+`ok github.com/leodip/goiabada/authserver/tests/integration 44.139s` for the last engine and
+`All tests completed successfully.`, which `run-tests.sh` prints only when every engine passed. The
+per-engine race reading for postgres and mssql could not be re-read from the capture, so the per-engine
+table in the stage entry stands on **this run's own** measurement rather than on the reviewer's
+agreement with it. The two agree; the point is which one carries the claim.
+
+**Its `unchecked` list holds nothing the gate depended on.** The modules and data tiers, correctly not
+applicable to a stage whose one changed file is in a package neither tier compiles, with the stage
+entry's reasoning independently restated: no production method, query, migration, schema or model
+change. Unchanged PKCE, redirect matching, signature and audience validation, session lifecycle, rate
+limiting, template escaping and secret comparison, none of which this diff reaches. And the run's two
+source mutations, assessed statically because a reviewer may not edit source under review, which is the
+same limitation recorded at every earlier gate.
+
+**Tiers at the gate.** No re-run, and the reason is the hash rather than convenience: the tree being
+committed is byte-identical to the tree that went green twice, once in the implementation session
+(exit 0, 4768 passing test lines, zero `FAIL`, both new tests passing once per engine) and once in the
+reviewer's independent run above. `check-anchors.sh` re-run here, PASS on all **82** rows.
+`git diff --stat` is two files, 538 insertions, 13 deletions.
+
+**No round 2, and the gate passes on one round.** All three axes reviewed, zero findings, the one tier
+the stage claims executed by the reviewer as well as by the run, and nothing changed after the reviewed
+tree. That is the clean case the reviewer reference describes.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`, and section 9 its four follow-ups. Stage 8 is committed with this document following it, and
+it is the last: next is the run's closing pass, the full suite across every tier, sections 8 and 9 onto
+the pull request, and the PR marked ready for review.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -6,17 +6,17 @@
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
 **Run state:** stages 1 to 5 committed, 2026-08-05. Stage 6, the `/auth/issue` liveness check and the
-compensating revoke, is expanded, implemented and green on all three tiers, but **halted and
-uncommitted** on decision 16, raised by its round 1 code review on 2026-08-05 and awaiting the user on
-PR #138. The finding: the new refusal restarts level 1 unconditionally, so a `prompt=none` ceremony
-whose session ends in the redirect hop is shown a password form instead of being returned
-`login_required`, which contradicts the no-UI contract this repository documents and implements
-everywhere else. Decision 6 says restart level 1 for this case and explicitly rejected
-`login_required`, so reconciling the two is the user's call. Expanding the stage also found that the
-terminated ceremony reaches `/auth/issue` with an **empty** session identifier rather than a dead one,
-because the session middleware clears it first, and that an empty identifier alone makes the resulting
-grant offline; the stage entry in section 6 carries the reasoning. Next after stage 6: stages 7 and 8,
-both still sketches.
+compensating revoke, is expanded, implemented and green on all three tiers, and **uncommitted pending
+review round 2**. Its round 1 review raised decision 16, which the user answered on PR #138 on
+2026-08-05 with option A: a `prompt=none` ceremony whose session ends in the redirect hop is returned
+`login_required` rather than being restarted into a password form it is forbidden to display, and
+every other ceremony still restarts level 1. That branch, its unit row, its integration ceremony and a
+docs sentence are now in the tree, so the diff round 1 read no longer exists and the stage goes back
+for round 2 rather than to its gate. Section 3 has zero `Open` items. Expanding the stage also found
+that the terminated ceremony reaches `/auth/issue` with an **empty** session identifier rather than a
+dead one, because the session middleware clears it first, and that an empty identifier alone makes the
+resulting grant offline; the stage entry in section 6 carries the reasoning. Next after stage 6:
+stages 7 and 8, both still sketches.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -129,6 +129,8 @@ log can cite it the same way. Nothing above the line changed.
 | `test/revoke-code-gone-tx` | `src/authserver/tests/data/code_test.go` | `TestRevokeCodeIfSessionGone_TransactionAndFailurePath` | `a code revoked inside a rolled-back transaction` | stage 6, the two questions a mock cannot answer |
 | `test/issue-liveness` | `src/authserver/internal/handlers/handler_auth_issue_test.go` | `TestHandleIssueGet` | `t.Run("No session identifier in the context, restarts level 1"` | stage 6, seam 7's gate row; the three other new rows sit below it |
 | `test/consent-window-no-code` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedOnConsentScreen_NoCodeIsIssued` | `the ended session must not be recreated by a ceremony waiting on the consent screen` | stage 6, the third of the file's paired ceremonies |
+| `issue/prompt-none-refusal` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `if authContext.HasPromptValue("none") {` | stage 6, decision 16 option A's branch, inside `issue/liveness-restart` |
+| `test/prompt-none-login-required` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired` | `"prompt=none must not be restarted into the interactive flow")` | stage 6, decision 16's integration case, the fourth ceremony in the file |
 | `middleware/session-identifier` | `src/authserver/internal/middleware/middleware_session_identifier.go` | `MiddlewareSessionIdentifier` | `ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)` | **pre-existing code, not written by the run.** The row exists because stage 6 and decision 16 cite this label three times each and it was declared nowhere, so the citations resolved to nothing. The locator is the only line that puts the identifier in the request context, which is the fact both cite |
 
 Counts in this document carry their command:
@@ -447,7 +449,7 @@ Verified as owing nothing, stated because silence reads the same as forgetting:
 
 ## 3. Open questions and decisions
 
-Sixteen items, fifteen `Decided` and **one `Open`**, which is item 16 and is what halts the run.
+Sixteen items, **all `Decided`**. Nothing is open, so nothing here halts the run.
 Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual at `/auth/issue`
 that the registry design did not have, which is item 12. The
 reconciliation pass of 2026-08-04 added two more: tracing which endpoints the "End session" buttons
@@ -456,7 +458,8 @@ documentation sweep found three confirmation modals whose copy this change makes
 Item 15 was raised by the run during stage 5, when the code review found that decision 6's gate is
 satisfied by OTP alone; it halted the run until the user answered it on PR #138 on 2026-08-05, and it
 keeps the question it was escalated with rather than being trimmed to its answer. Item 16 was raised
-the same way at stage 6's gate, and is the second and last of the two decision 6 has now cost.
+the same way at stage 6's gate, halted the run until the user answered it on 2026-08-05, and is the
+second and last of the two decision 6 has now cost.
 Numbers are never reused, and decision 4 records its own reversal rather than being rewritten silently.
 
 1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
@@ -1167,10 +1170,46 @@ Numbers are never reused, and decision 4 records its own reversal rather than be
     Answering C when A was right leaves explicit termination defeatable by an in-flight ceremony, which
     is the defect #129 exists to close, on a path a stolen cookie reaches.
 
-16. **What does `/auth/issue` do when the liveness check fails and the ceremony carries
-    `prompt=none`?** Status: **Open** Raised by: reviewer, raised during stage 6
+16. **`prompt=none` is returned `login_required`. Every other ceremony still restarts level 1.**
+    Status: **Decided** Raised by: reviewer, raised during stage 6
 
-    **The question.** Stage 6 built `issue/liveness-restart` exactly as decision 6 words it: when the
+    Answered by the user on PR #138, 2026-08-05, in full: "Let's go with option A again." That is
+    option A below, the recommended one, taken over B, C and D with no amendment, so the run applied
+    it as written: one branch at `issue/prompt-none-refusal` reading `authContext.HasPromptValue("none")`
+    inside the existing refusal, calling `redirToClientWithError` with `constants.ErrorLoginRequired`
+    and then `ClearAuthContext`, copying the `id_token_hint` branch a few lines above it in the same
+    function.
+
+    What the answer settles, beyond the branch: decision 6's rejection of `login_required` is
+    **scoped to interactive ceremonies** rather than reversed. Its stated reason, that failing to the
+    client "costs the user a round trip through the client to arrive at the same password form",
+    describes a ceremony that has a password form to arrive at. A `prompt=none` client does not and is
+    forbidden from rendering one, so the reason does not reach it. The rejection stands everywhere it
+    applies, which is what `test/consent-window-no-code` still asserts and what option D would have
+    reversed.
+
+    The error description is `handlePromptNone`'s own wording for this condition, "User
+    authentication is required", chosen rather than invented: the condition really is the same one
+    arriving a redirect hop later, so the client sees a response it cannot distinguish from the
+    ordinary no-session case and does not need to. That also leaves
+    `concepts/prompt-parameter.mdx`'s `login_required` row ("No valid session, session expired ...")
+    accurate without an edit, which is the docs cost option B would have carried.
+
+    **What lost.** B, keeping stage 6 as built and documenting a carve-out in
+    `concepts/prompt-parameter.mdx`, which would have shipped an authorization server rendering a
+    login form in response to a request that forbids one. C, minting the code and letting the
+    compensating statement handle it, ruled out rather than weighed because the identifier is empty on
+    this path and `db/revoke-code-if-session-gone` refuses an empty identifier, so it answers 500. D,
+    returning `login_required` for every ceremony, which discards a ceremony that could have completed
+    correctly and reddens `test/consent-window-no-code`; mutation 8 in the run log is exactly that
+    option applied, and it is what fails.
+
+    The question as it was escalated is kept below, because the reasoning is what makes the answer
+    reviewable.
+
+    ---
+
+    **The original question.** Stage 6 built `issue/liveness-restart` exactly as decision 6 words it: when the
     ceremony's bound session identifier no longer resolves to a session row, refuse to mint a code, set
     `AuthStateRequiresLevel1` and redirect to `/auth/level1`. Decision 6 names `prompt=none` as reaching
     this same place. But `/auth/level1` sends the browser on to `/auth/pwd`, which renders a password
@@ -2108,7 +2147,8 @@ Tiers: unit (three modules), data (four engines), integration (dev container). D
 where stage 5 said it did not: this stage adds an interface method and a statement no other tier
 runs against mysql, postgres, mssql and sqlite.
 Docs: the second sentence held back from stage 4's concepts section, the consent-screen window, in
-`concepts/user-sessions.mdx`.
+`concepts/user-sessions.mdx`, plus a third on the silent-renewal outcome once decision 16 was
+answered.
 
 Decision 6's second half plus decision 12. Gap 3's remaining exposure is a ceremony that passed
 `/auth/completed` while its session was alive, sat on the consent screen, and reaches `/auth/issue`
@@ -2185,6 +2225,16 @@ what proves it: every existing ceremony in the suite goes through this handler.
    `issuer/grant-is-offline`, so refusing it is not belt-and-braces; and that this is deliberately a
    **liveness** check rather than a validity one, so it asks whether the row resolves and leaves
    idle timeout and max age to `/auth/completed`, which has already applied them.
+
+   **One predicate, two outcomes** (decision 16, answered after round 1 found the second one
+   missing). A ceremony carrying `prompt=none` cannot be restarted, because `/auth/level1` leads to
+   `/auth/pwd` and that request forbids UI; nothing between the two reads the prompt, so it would be
+   handed a login page and no error at all. `issue/prompt-none-refusal` sits first inside the refusal
+   and returns `login_required` through `redirToClientWithError`, then `ClearAuthContext`, copying the
+   `id_token_hint` branch above it. The description is `handlePromptNone`'s own wording for this
+   condition, "User authentication is required", so the client cannot tell this from the ordinary
+   no-session refusal one hop earlier. Every other ceremony still restarts level 1, which is decision
+   6 unchanged.
 3. **The compensating revoke, immediately after the insert.** Status: **Done**
    Decision 12. `RevokeCodeIfSessionGone(nil, code.Id, sessionIdentifier)` directly after
    `issue/create-code`'s error check, ahead of the `AuditCreatedAuthCode` entry. On a database error,
@@ -2221,6 +2271,7 @@ what proves it: every existing ceremony in the suite goes through this handler.
    |---|---|---|
    | no session identifier in the request context | 302 to `/auth/level1`, saved context reading `requires_level_1`, and no code created | the liveness check on the shape the middleware actually produces. "No code created" is enforced rather than asserted: the strict `mocks_oauth.CodeIssuer` carries no `CreateAuthCode` expectation |
    | a sid resolving to no session row | the same | the other half of the same predicate, for the narrow race where the middleware saw the session live |
+   | the same empty identifier, with `prompt=none` on the context | 302 to the client's redirect URI carrying `error=login_required` and the request's `state`, no `code`, no `/auth/level1`, and `SaveAuthContext` never called | decision 16 option A. The two rows above are its negative control, since they carry no prompt and must still restart; a branch applied unconditionally reddens both, which is mutation 8 |
    | the session lookup fails | 500, no code created | a database fault must not read as a terminated session, and must not read as a live one either |
    | a live session | code issued as before, and `RevokeCodeIfSessionGone` called with that code's id and that sid | decision 12's statement is issued. Whether it **works** is seam 4's, per section 5 |
    | the compensating revoke fails | 500, and the client is not redirected with a code | the fail-closed direction of step 3 |
@@ -2234,6 +2285,19 @@ what proves it: every existing ceremony in the suite goes through this handler.
    for someone deciding whether ending a session is enough, so it says the outcome rather than the
    mechanism, and it does not describe the residual interleaving, which is follow-up 1's and reads
    to a user as doubt about the feature.
+
+   **A third sentence landed with decision 16's answer**, in the same section: an application renewing
+   quietly with `prompt=none` meets the same check and is told rather than shown, getting
+   `login_required` back and never a login page. The two sentences beside it both say "sent back to
+   the login page", which is the outcome a reader would otherwise generalize to a background renewal,
+   and it is the outcome decision 16 rejected for that shape. It links to
+   `concepts/prompt-parameter.mdx` rather than restating it.
+
+   **Verified as owing nothing, stated because silence reads the same as forgetting.**
+   `concepts/prompt-parameter.mdx` keeps its `login_required` row, "No valid session, session expired
+   (idle or max lifetime), or `max_age` exceeded", because option A's response is byte-identical to
+   the no-session case that row already describes, down to the `error_description` the page prints in
+   its own example. That page needing an edit was option B's cost, not A's.
 7. **The mid-flight integration case, in `session_deletion_test.go`.** Status: **Done**
    `TestSessionEndedOnConsentScreen_NoCodeIsIssued`, the third of the file's paired ceremonies and
    the one that varies the window rather than the credential: the session is alive through
@@ -2245,6 +2309,7 @@ what proves it: every existing ceremony in the suite goes through this handler.
    | Case | Expected | What it proves |
    |---|---|---|
    | session ended on the consent screen, then consent submitted | `/auth/consent` posts to `/auth/issue` as always, and `/auth/issue` redirects to `/auth/level1` and then `/auth/pwd`, with no code reaching the client and no session recreated | gap 3's second half at the highest seam that can see it. The consent POST succeeding first is deliberate: it is what makes `/auth/issue` the load-bearing hop rather than an incidental one |
+   | session ended between `handlePromptNone`'s 302 and the browser following it | back to the client's redirect URI with `error=login_required` and the request's `state`, no `code`, nothing on `/auth/level1`, and no session recreated | decision 16, added after round 1. Same window through the other door, and the outcome is the one thing that differs, so it sits beside the consent-screen case rather than replacing it. `createSessionWithAcrLevel1` supplies the live session, and the termination goes between `assertRedirect` and `loadPage`, which is the whole window a silent ceremony has |
    | `test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` | unchanged and green | the pair decision 6 rests on. This stage's check is the one that could redden the first: a code flow whose session vanished is exactly #46's shape one hop later |
 
    The ordinary ceremony is the control, and it is named rather than duplicated: `createOfflineGrant`
@@ -2258,8 +2323,11 @@ what proves it: every existing ceremony in the suite goes through this handler.
    load bearing at this gate rather than routine: this stage puts a new refusal in front of every
    authorization code the suite issues.
 
-**As built.** All eight steps landed. Eight anchor rows added to section 0, and no sealed row moved.
-Four things worth naming beyond the steps.
+**As built.** All eight steps landed. Ten anchor rows added to section 0, and no sealed row moved.
+Eight of the ten landed with the first pass; `issue/prompt-none-refusal` and
+`test/prompt-none-login-required` landed with decision 16's answer, which is also what put a second
+outcome in step 2 and a row in each of step 5's and step 7's tables. Five things worth naming beyond
+the steps.
 
 1. **The empty-sid finding is the stage, not a detail of it.** The sketch's predicate, "resolves to no
    session row", never fires on the path gap 3's second half actually takes, because
@@ -2282,6 +2350,12 @@ Four things worth naming beyond the steps.
    target session gone while an unrelated session row exists" are one call, because the fixture's live
    session is still in the table while it runs and a shared test database always holds other sessions
    anyway. The property both rows were for is intact and is what mutation 6 kills.
+5. **The refusal has two outcomes, not one, and the second was missing until the review.** Decision 6
+   fixes the predicate and the run applied it as written; what its text does not settle is what a
+   ceremony forbidden from seeing UI should be handed once the predicate fires. Decision 16 settles
+   that, and the shape of the fix is worth keeping: the branch is keyed on the prompt rather than
+   replacing the restart, so the interactive outcome decision 6 chose is untouched. Mutations 7 and 8
+   in the run log are the two ways to get that wrong, and their failure sets are disjoint.
 
 ### Stage 7: reaping unused revoked codes
 Status: **Not started**
@@ -3219,6 +3293,60 @@ built inside stage 6 rather than a later one: under option A that is one branch 
 its `loadPage`. Step 2 of the stage and both of its case tables gain the row, and the stage then needs a
 round 2 on the new branch rather than a fresh gate.
 
+### Stage 6 continued, 2026-08-05: decision 16 answered
+
+**The answer.** "Let's go with option A again," on PR #138 at 17:09Z. Recorded in decision 16 with the
+user's words, and what lost is recorded beside it: B, C and D, with D's cost measurable rather than
+argued, since mutation 8 below is exactly option D applied to the code.
+
+**Landed, inside stage 6 as the escalation said it would.** `issue/prompt-none-refusal`, one branch at
+the head of the existing refusal: when the ceremony carries `prompt=none`, `redirToClientWithError`
+with `constants.ErrorLoginRequired` and then `ClearAuthContext`, copying the `id_token_hint` branch a
+few lines above it in the same function. Every other ceremony still restarts level 1, untouched. Plus
+an eighth row at `test/issue-liveness`, `test/prompt-none-login-required` at the integration tier, and
+a third docs sentence in `concepts/user-sessions.mdx`. Two anchor rows added, and the stage's step 2,
+step 5 table, step 6 and step 7 table all carry the new outcome.
+
+**One judgement inside the answer, and it is recorded rather than silent.** The error description is
+`handlePromptNone`'s own wording for this condition, "User authentication is required", rather than
+something naming the mid-flight termination. Local and reversible under decisions.md section 1: it is
+one string in one branch, changes no interface and no persisted shape, and a test pins it. It is also
+the better answer on its own terms, since the client genuinely cannot act differently on the two cases
+and a distinct description would only tell a caller which internal hop refused it. The side effect is
+that `concepts/prompt-parameter.mdx` stays accurate unedited, down to the `error_description` in its
+own worked example, which is checked rather than assumed.
+
+**Tiers, all re-run in full on the amended tree rather than narrowed to the change.** Modules green on
+all three modules. Data green on all four engines run separately, with `TestRevokeCodeIfSessionGone`
+and its transaction sibling passing on each; the data layer is untouched by this amendment, and
+re-running it is what makes "the stage is green" a statement about the tree rather than about the
+diff. Integration green on **all four engines**, 889 passing test lines per engine and zero `FAIL`,
+with all four of `session_deletion_test.go`'s ceremonies passing once per engine. `check-anchors.sh`
+passes all **74** rows. `gofmt -l` silent, `npm run build` in `site` at 42 pages.
+
+**Mutation evidence, two more mutations, applied to the real code, run, and reverted in this session.
+Their failure sets are disjoint, and between them they pin that the branch is keyed on the prompt
+rather than replacing the refusal.**
+
+7. **The `prompt=none` branch removed**, which is stage 6 exactly as round 1 reviewed it and is option
+   B. At the unit tier exactly one row failed, the new one. At the integration tier on sqlite exactly
+   `test/prompt-none-login-required` failed, while `test/consent-window-no-code`,
+   `test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` stayed green. So the finding
+   reproduces against the code the review read, and the new case is what closes it.
+8. **The branch made unconditional**, which is option D: `login_required` for every ceremony. At the
+   unit tier the two interactive rows failed and the `prompt=none` row passed. At the integration tier
+   `test/consent-window-no-code` failed and the new case passed. That is the cost decision 16 priced
+   for D, measured rather than predicted, and it is why the branch reads the prompt.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 now has sixteen items, all
+`Decided`, and section 9 keeps its three follow-ups: the amendment surfaced no new one, and the
+question it answers was already tracked as a decision rather than as a defect.
+
+**Still uncommitted, deliberately.** The branch the review found missing is now present, so round 1's
+verdict no longer describes this tree. Stage 6 goes back through review for round 2 on the amended
+diff, as decision 15's answer did at stage 5, and the code commit follows that. This agreement is
+committed now, carrying decision 16 `Decided` and this entry.
+
 ---
 
 ## 8. Deferred decisions
@@ -3227,8 +3355,7 @@ Nothing deferred. Stages 1 to 6 met no question that was safe to postpone on a s
 judgement calls stages 5 and 6 made each resolved under section 3 (recorded in their run log entries),
 and the two questions the run could not answer were both in authentication territory, which
 decisions.md forbids deferring. Those are decisions 15 and 16, which halted the run rather than sitting
-here. Decision 15 was answered by the user on 2026-08-05; decision 16 is `Open` and is what the run is
-currently waiting on.
+here. Both were answered by the user on 2026-08-05, and both answers are built.
 
 This section stays in the document even while empty, because the closing PR comment reports it and an
 absent section reads the same as a forgotten one.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,14 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** stages 1 to 6 committed, 2026-08-05. Section 3 has zero `Open` items. Stage 6 cost two
+**Run state:** stages 1 to 7 committed, 2026-08-05. **Stage 7 closed on a clean round 1**: one predicate
+extension so codes revoked while still unredeemed do not accumulate (decision 8), green on the modules
+tier and on the data tier across all four engines, with five mutations measured. Its expansion found
+that where the `NOT IN` subquery sits decides whether the whole extension works at all under #130, and
+that `fk_refresh_tokens_code` is `ON DELETE CASCADE`, which is what the keep-this retention row really
+guards. The review re-derived the built SQL on all four flavors and traced every production writer of
+`used` and of `code_id` to show the new branch cannot reach a code with a live descendant, and this
+session re-derived the SQL again before committing. Section 3 has zero `Open` items. Stage 6 cost two
 escalations and three review rounds, and all three are recorded in section 7. Its round 1 raised
 decision 16, answered by the user on PR #138 with option A: a `prompt=none` ceremony whose session ends
 in the redirect hop is returned `login_required` rather than being restarted into a password form it is
@@ -15,7 +22,7 @@ the fix plus two assertions that can observe a committed response landed inside 
 clean. Expanding the stage also found that the terminated ceremony reaches `/auth/issue` with an
 **empty** session identifier rather than a dead one, because the session middleware clears it first,
 and that an empty identifier alone makes the resulting grant offline; the stage entry in section 6
-carries the reasoning. Next: stages 7 and 8, both still sketches.
+carries the reasoning. Next: stage 8, gap 2's evidence, still a sketch and the last stage.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -134,6 +141,9 @@ log can cite it the same way. Nothing above the line changed.
 | `issue/prompt-none-clear-first` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `err := authHelper.ClearAuthContext(w, r)` | stage 6 round 2, the clear ahead of the client response. The `:=` is what makes this line unique in the function; the other two clears assign to an existing `err` |
 | `test/prompt-none-clear-committed` | `src/authserver/internal/handlers/handler_auth_issue_test.go` | `TestHandleIssueGet` | `assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),` | stage 6 round 2, the unit row that reads the committed response rather than the live header map |
 | `test/prompt-none-context-cleared` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired` | `"the refusal must clear the auth context in the browser, so a replayed /auth/issue has no ceremony left")` | stage 6 round 2, the replayed `/auth/issue` that observes the clear through a real cookie jar |
+| `db/reap-revoked-unused` | `src/core/data/commondb/code.go` | `DeleteUsedCodesWithoutRefreshTokens` | `deleteBuilder.Equal("revoked", true),` | stage 7, decision 8's second branch. `db/delete-used-codes` above still resolves, to the first branch's `used = true` term, which the extension leaves in place |
+| `test/reap-revoked-unused` | `src/authserver/tests/data/code_test.go` | `TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnused` | `must outlive it, and deleting the code would cascade the descendant away` | stage 7, seam 3's keep-this row, the only case in the suite that fails when the `used = false` term is dropped |
+| `test/reap-ropc-null-code-id` | `src/authserver/tests/data/code_test.go` | `TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnusedWithRopcTokenPresent` | `a refresh token with a NULL code_id exists` | stage 7, the row that fails if the `NOT IN` subquery is hoisted out of the used branch, which is the mutation that ships the whole extension inert |
 
 Counts in this document carry their command:
 
@@ -2382,17 +2392,23 @@ same two tables. Six things worth naming beyond the steps.
    is the old order, and it fails exactly those two assertions and nothing else.
 
 ### Stage 7: reaping unused revoked codes
-Status: **Not started**
-Detail: **sketch**
-
-Decision 8's one predicate extension, so a code revoked while still unredeemed does not accumulate
-forever: `revoked = true AND used = false AND created_at < cutoff`, which is safe with a short cutoff
-because an unused code has no refresh tokens by definition and is unredeemable after 60 seconds
-anyway. Seam 3, whose load-bearing row is the **retention** one: a revoked code with a live refresh
-token must survive, because decision 8's whole safety argument is that the marker outlives its
-descendants, and that row's value is invisible once the design is right. Tier: data, four engines.
-Docs: to confirm at expansion; the sweep of section 2 found no page describing the reapers, and
-`concepts/audit-log.mdx` points at `constants.go` rather than enumerating events.
+Status: **Done**
+Seams: 3, extending `TestDeleteUsedCodesWithoutRefreshTokens`'s neighbourhood in `code_test.go` rather
+than adding a sibling file, which is where seam 3's method already has two tests.
+Tiers: data (four engines) and unit (three modules). Data is the tier that owns this stage: the change
+is one SQL predicate and nothing above the data layer moves. The unit run is a regression run rather
+than new coverage, and step 5 says why nothing new belongs there. Integration not applicable: no
+endpoint changes, and the rows this reaps are invisible from any endpoint by the time it reaps them.
+Docs: **none, and this is verified rather than assumed.** Two searches. `grep -rin
+'cleanup\|reap\|housekeep\|background worker\|purge' site/src/content/docs/` finds four pages that
+describe background cleanup, and all four are about something else: `concepts/tokens.mdx` on refresh
+token growth, `concepts/audit-log.mdx` and `integration/rest-api.mdx` on audit retention, and
+`oauth2-flows/client-credentials.mdx` on daemons. No page describes the `codes` table, its growth or
+its reaper, so none is falsified. And nothing a client can observe changes: a code this branch reaps
+is already unredeemable, both because `db/mark-code-used` refuses a revoked row and because the code
+expired 60 seconds after it was issued, and `ValidateTokenRequest` answers a code it cannot find with
+the same `invalid_grant`, "Code is invalid." that it answers a revoked one with. The row's absence is
+therefore indistinguishable from its presence at every seam a user reaches.
 
 **Extend `DeleteUsedCodesWithoutRefreshTokens` itself. No second method and no second worker call.**
 The first draft of this sketch offered the choice, which reopened something the seal had settled:
@@ -2401,6 +2417,123 @@ would add an unconfirmed data seam plus an interface method, four wrappers, rege
 own wiring in `worker/perform-task`. The method keeps its name, and its doc comment states the widened
 contract, since renaming it would touch the interface, four wrappers, the mocks and the call site for
 no behavioural gain.
+
+**One statement, not two, and the `created_at` term is what decides it.** Both branches are bounded by
+the same cutoff, so one statement states the cutoff once and two statements state it twice, which is
+where the two drift apart when somebody later changes what the cutoff means. It also keeps the method's
+single error path single, which is the path seam 3 does not re-cover because this is not a new method.
+The shape, verified as building correctly on all four flavors before being written here:
+
+```sql
+DELETE FROM codes WHERE created_at < ?
+  AND ((used = true AND id NOT IN (SELECT code_id FROM refresh_tokens))
+       OR (revoked = true AND used = false))
+```
+
+**Where the `NOT IN` sits is load bearing, and it is the one thing in this stage that can ship inert.**
+`x NOT IN (…, NULL)` is UNKNOWN rather than TRUE, and ROPC refresh tokens carry `code_id = NULL`, which
+is #130. So the existing branch already matches nothing once any ROPC token exists, which decision 8's
+note records and section 2 leaves to #130. Keeping the subquery **inside** the used branch is what stops
+that spreading: `UNKNOWN OR TRUE` is TRUE, so the new branch reaps regardless. Hoisting the `NOT IN`
+beside the cutoff, which reads as the tidier factoring, would make the whole predicate UNKNOWN and the
+extension would do nothing at all on any deployment that has ever issued a ROPC token, silently. Step
+4's ROPC row is what fails if that happens.
+
+**The new branch carries no refresh-token term, and `used = false` is what stands in for one.** An
+unused code has no refresh tokens by definition, because `db/mark-code-used` is the gate every
+redemption passes before a token is inserted, and after stage 1 it refuses a revoked row outright. So
+the term decision 8 words is sufficient. It is also the term the retention argument rests on, and its
+consequence is sharper than it looks: `fk_refresh_tokens_code` is `ON DELETE CASCADE`, so a branch that
+reached a used code with a live refresh token would not merely delete the marker, it would delete the
+descendant the marker exists to reject. That is why step 4's keep-this row asserts the survival of the
+code **and** names the cascade.
+
+1. **The predicate extension, at `db/delete-used-codes` and `db/reap-revoked-unused`.**
+   Status: **Done**
+   One statement in the shape above, built with `Or` over two `And` groups so the subquery stays inside
+   the used branch. The doc comment gains three things a later reader needs: that the method now reaps
+   two disjoint classes and why they share one cutoff, that the subquery's position is what keeps the
+   new branch alive under #130 rather than a formatting choice, and that `used = false` is what keeps
+   the sweep away from a live descendant through the cascade.
+2. **The interface doc comment, in `data/database.go`.** Status: **Done**
+   The widened contract, in the same voice as the existing paragraph: both classes named, the cutoff's
+   role for each stated separately, since for the used branch it is the foreign-key race and for the
+   revoked branch it is the 60 second code lifetime. Plus one sentence the first draft did not have,
+   that a revoked code which **was** redeemed is deliberately out of reach while any refresh token still
+   references it, because that is the contract a caller could otherwise assume away.
+3. **The worker's cutoff comment, at `worker/perform-task`'s `usedCodeCleanupGrace`.**
+   Status: **Done**
+   One sentence, because that constant's comment currently explains the cutoff entirely in terms of the
+   used-code race and now bounds a second class as well. The value does not change: five minutes is
+   already comfortably past the 60 second code lifetime, which is the bound the revoked branch needs.
+4. **Data cases at seam 3, in `code_test.go`, all four engines.** Status: **Done**
+   **Two** new tests beside the method's two existing ones, not one: `test/reap-revoked-unused` carries
+   the table and `test/reap-ropc-null-code-id` carries the last row alone, for the reason under the
+   table. Both follow the shape of `TestDeleteUsedCodesWithoutRefreshTokens_AgeCutoff`: vary the cutoff
+   rather than the row, since `Code.CreatedAt` is tagged `dont-update` and cannot be aged through the
+   ORM. Expectations written before running them, and every row measured on all four engines:
+
+   | Case | Expected | Which term answers it, or what it proves |
+   |---|---|---|
+   | a revoked, unused code, future cutoff | deleted | decision 8's job, the whole point of the extension. Mutation 13 |
+   | a revoked, **used** code with an unrevoked refresh token descended from it, future cutoff | survives | **keep this row.** It is the regression guard for decision 4's retention argument, whose value is invisible once the design is right: the marker must outlive every descendant that could present it. The descendant is deliberately unrevoked, which makes it gap 2's racing child, the one the termination's own token sweep never saw and that the code's marker is the only thing rejecting. The `used = false` term is what answers it, and the stake is higher than retention alone, since `fk_refresh_tokens_code` is `ON DELETE CASCADE` and deleting the code would delete the very descendant the marker exists to reject. Mutation 11, which nothing else in the suite catches |
+   | an **unrevoked**, unused code, future cutoff | survives | the `revoked = true` term. The negative control: without it the sweep reaps every abandoned code. Mutation 10 |
+   | a revoked, unused code, the cutoff the **worker** passes | survives | the shared `created_at` term. Every other row uses a future cutoff, so this is the only one that fails if the extension states the cutoff per branch and forgets the new branch's copy. Mutation 14 |
+   | a revoked, **used** code with no refresh token, future cutoff | deleted | the pre-existing branch, unchanged, and the proof that adding `used = false` to the new branch did not narrow the old one |
+   | a revoked, unused code with a ROPC refresh token (`code_id = NULL`) in the table, future cutoff | deleted | the subquery's **position**, and it lives in its own test. `x NOT IN (…, NULL)` is UNKNOWN, so hoisting the `NOT IN` beside the cutoff makes the whole predicate UNKNOWN and the extension inert on any deployment that has ever issued a ROPC token. Mutation 12, which nothing else in the suite catches |
+   | `TestDeleteUsedCodesWithoutRefreshTokens` and `_AgeCutoff`, untouched | unchanged | the old branch is untouched. Both drive unrevoked codes, so the new branch cannot reach their rows, which is what makes this stage additive at the data tier |
+
+   **Why the ROPC row could not sit in the same test, which the first draft of this step had it doing.**
+   The NULL row changes what the *other* rows can prove while it is present: with the used branch
+   evaluating to UNKNOWN, a revoked and redeemed code with no refresh token is no longer reaped either,
+   so the fifth row above would have to expect the opposite of what it expects. That is #130 behaving as
+   its own issue describes rather than a defect here, and the honest way to write it is two tests, one
+   with the NULL row absent and one with it present. The second registers a `t.Cleanup` that deletes the
+   ROPC token, so it cannot change what a later test in the package proves about this sweep.
+
+   **No transaction or failure-path case, deliberately.** Testing reference section 4 asks those two
+   questions of every **new** method, and seams 1 and 4 answer them for stage 1's and stage 6's. This is
+   an existing method whose predicate widens: it gains no new error path, no new `RowsAffected` read and
+   no new return value, which is also the second reason the extension is one statement rather than two.
+   `transaction_test.go` already owns the pool-versus-transaction question for the shape. Stated because
+   the absence would otherwise read as an oversight.
+5. **Verify.** Status: **Done**
+   `check-anchors.sh` PASS on 80 rows, then `where.sh test --type modules` and `where.sh test --type
+   data` across all four engines, all in the foreground. The modules run is the regression check: the
+   mocks are unchanged because the signature is unchanged, so `background_worker_test.go`'s expectations
+   still stand, and the run is what proves it rather than the reasoning.
+
+**As built.** All five steps landed. Three anchor rows added to section 0, none moved. Four things worth
+naming beyond the steps.
+
+1. **The step 4 table shipped as two tests rather than one, and the reason is #130 rather than tidiness.**
+   The ROPC row and the fifth row want opposite expectations from the same database state, because a
+   single `code_id = NULL` row anywhere in `refresh_tokens` makes the used branch UNKNOWN for every row.
+   Splitting is what lets both be asserted. The step now says so, and the correction is here rather than
+   absorbed because the first draft's single test would have had to drop one of the two properties.
+2. **The keep-this row's descendant is unrevoked, which is stronger than the sketch's wording.** The
+   sketch says "a revoked code with a live refresh token must survive". Built with a **revoked**
+   descendant the row would be nearly vacuous, since a revoked token is already rejected on its own
+   terms and the marker adds nothing to it. Built with an unrevoked one it is gap 2's racing child, the
+   token that exists precisely because the termination's sweep could not see it, and the code's marker is
+   the only thing standing between it and a working grant. That is the row decision 4's property (a) is
+   about, so it is the row that was written.
+3. **The `ON DELETE CASCADE` on `fk_refresh_tokens_code` raises the stake on this stage and was not in
+   the sketch.** A reaper that reached a used code with a live descendant would not merely lose the
+   marker, it would delete the descendant, and the grant would stop being rejected because it stopped
+   existing. That does not change the predicate decision 8 words, since `used = false` already excludes
+   the case, but it changes what the keep-this row is guarding and it is now stated in the comment, the
+   table and the assertion message.
+4. **Five mutations, each failing exactly one row and nothing else.** Run on sqlite, since the predicate
+   is one statement and the four engines had already agreed on it:
+
+   | Mutation | What fails | Reading |
+   |---|---|---|
+   | 10, drop `revoked = true` from the new branch | the unrevoked-unused control, plus the pre-existing `TestDeleteUsedCodesWithoutRefreshTokens`, whose own unused row is reaped | the term is guarded twice, once deliberately and once by inheritance |
+   | 11, drop `used = false` from the new branch | the keep-this row, alone | the retention guard is the only thing holding the design, which is what a keep-this note means |
+   | 12, hoist the `NOT IN` beside the cutoff | the ROPC test, alone | the mutation that ships the extension inert on any real deployment while every other test stays green. The single most valuable row here |
+   | 13, the whole new branch removed, back to the pre-stage-7 predicate | both deletion rows | the stage does what it claims |
+   | 14, the cutoff moved inside the used branch, so the new branch has none | the worker-cutoff survival row, alone | the shared `created_at` term is load bearing, and the row that proves it is the one that uses the worker's own cutoff |
 
 ### Stage 8: gap 2's evidence
 Status: **Not started**
@@ -3533,6 +3666,149 @@ four engines, with all four of `session_deletion_test.go`'s ceremonies, includin
 `Decided`, and section 9 its four follow-ups. Stage 6 is committed as
 `feat(sessions): refuse to mint a code for a session that is gone`, with this document following it.
 Next: stage 7, reaping unused revoked codes, still a sketch.
+
+### Stage 7, 2026-08-05
+
+Written before the review, because this session may be the last one that knows what happened.
+
+**Expansion.** The sketch already settled the shape, so expanding it added detail rather than reversing
+anything: extend `DeleteUsedCodesWithoutRefreshTokens`, one predicate, no second method and no second
+worker call. Three things the expansion learned from the code that the sketch could not have.
+
+1. **The `NOT IN` subquery's position is the whole risk in this stage.** ROPC refresh tokens carry
+   `code_id = NULL`, so `x NOT IN (…, NULL)` is UNKNOWN, and the existing branch already matches nothing
+   on any deployment that has issued one. That is #130, out of scope per section 2, and decision 8's own
+   note records that the disk saving is latent until it lands. What the expansion adds is that the
+   *correctness* of the new branch depends on where the subquery sits: inside the used branch, `UNKNOWN
+   OR TRUE` is TRUE and the revoked branch reaps regardless; hoisted beside the cutoff, which is the
+   tidier-looking factoring, the whole predicate goes UNKNOWN and the extension does nothing at all,
+   silently, on every real deployment. Mutation 12 is that, and one test row is the only thing between it
+   and a green suite.
+2. **`fk_refresh_tokens_code` is `ON DELETE CASCADE`.** So the failure mode of a predicate that reached a
+   used code with a live descendant is not "the marker is lost", it is "the descendant is deleted", and
+   the grant stops being rejected because it stopped existing. Decision 8's `used = false` term already
+   excludes the case, so the predicate is unchanged by this, but it is what the keep-this row is actually
+   guarding and it is now said in the comment, the table and the assertion message.
+3. **The stage is one statement rather than two, and the shared cutoff is what decides it.** Both classes
+   are bounded by the same `created_at`, so one statement states it once. Two statements would state it
+   twice and give the two copies somewhere to drift, and would split the method's single error path,
+   which is the path seam 3 does not re-cover because this is not a new method.
+
+**What landed.** Five steps, all `Done`. The predicate at `db/delete-used-codes` and
+`db/reap-revoked-unused`, the interface doc comment, one sentence in the worker's `usedCodeCleanupGrace`
+comment, and two data tests at `test/reap-revoked-unused` and `test/reap-ropc-null-code-id`. No
+migration, no interface signature change, no new method, so no regenerated mocks and no engine wrappers.
+Three anchor rows added to section 0, none moved.
+
+**Two deviations from the steps as expanded, both recorded in the as-built note.** The step 4 table
+shipped as two test functions rather than one, because the ROPC row and the revoked-and-redeemed row
+want opposite expectations from the same database state. And the keep-this row's descendant is
+**unrevoked** rather than the sketch's "live", because a revoked descendant makes the row nearly vacuous
+while an unrevoked one is gap 2's racing child, which is the token decision 4's property (a) exists for.
+
+**Docs: nothing owed, verified rather than assumed.** Two searches, both recorded in the stage entry.
+`grep -rin 'cleanup\|reap\|housekeep\|background worker\|purge' site/src/content/docs/` finds four pages
+describing background cleanup and all four are about something else, and no page describes the `codes`
+table or its reaper. And nothing observable changes: a code this branch reaps was already unredeemable,
+both because `db/mark-code-used` refuses a revoked row and because it expired 60 seconds after issuance,
+and `ValidateTokenRequest` answers a code it cannot find with the same `invalid_grant`, "Code is
+invalid." it answers a revoked one with, so the row's absence is indistinguishable from its presence at
+every seam a user reaches.
+
+**Tiers.** `check-anchors.sh` PASS on all **80** rows. Modules green on all three modules. Data green on
+**all four engines** run in one pass, with `TestDeleteUsedCodesWithoutRefreshTokens`, `_AgeCutoff`,
+`_RevokedUnused` and `_RevokedUnusedWithRopcTokenPresent` each passing once per engine, confirmed from
+the per-engine logs rather than from the summary line. Integration not run and not claimed: this stage
+changes one background sweep and no endpoint, and the rows it reaps are unreachable from any endpoint by
+the time it reaps them.
+
+**Mutation evidence, five mutations applied to the real predicate, run on sqlite, each reverted.** The
+table is in the stage's as-built note. Each failed exactly the row the table names and nothing else,
+with two worth restating: mutation 11, dropping `used = false`, is caught by the keep-this row **alone**,
+and mutation 12, hoisting the subquery, is caught by the ROPC test **alone**. Both are the mutations
+whose whole danger is that they leave a plausible-looking green suite.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`, and section 9 its four follow-ups: nothing new was found that belongs to another change.
+
+### Stage 7 round 1, 2026-08-05: clean, and the stage closes
+
+**Review, round 1, clean.** `gpt-5.6-sol`, effort high, `type: code-review`, request
+`129-20260805T182359Z`. All three axes read `reviewed`, verdict `clean`, **zero findings and zero
+follow-ups**. The scope is recorded rather than summarised, because zero findings in a narrow scope
+reads exactly like zero findings in a thorough one, and because this gate passed on one round.
+
+**What it ran**, its own list: `where.sh test --type modules` passing all three modules,
+`where.sh test --type data` passing on mysql, postgres, mssql and sqlite, generated-SQL inspection for
+all four flavors through its own scratch program against the repository's `sqlbuilder` version,
+`check-anchors.sh` at all 80 rows, `git diff --check`, `gofmt` on the four changed Go files, and a
+documentation sweep with `rg` under `site/src/content/docs`.
+
+**What it answered, question by question**, since the request asked four and a clean verdict is worth
+only what it covered.
+
+1. **The grouping is what the code intends, on all four flavors.** It built the statement
+   independently rather than reading the Go, and got
+   `created_at < ? AND ((used = ? AND id NOT IN (SELECT code_id FROM refresh_tokens)) OR (revoked = ?
+   AND used = ?))` on SQLite, MySQL, PostgreSQL and SQL Server. The subquery is confined to the used
+   branch, so a ROPC row's NULL `code_id` cannot make the new branch UNKNOWN. **Re-derived by this
+   session at the gate** rather than taken on the reviewer's word, running the same scratch program
+   from `src/core`: identical output on all four, differing only in placeholder syntax. That is the one
+   claim in this stage whose failure ships the extension inert, so it is the one worth reproducing.
+2. **The sweep cannot reach a code it must not.** It traced every production `CreateRefreshToken` call
+   and the only production `MarkCodeAsUsed` call: authorization-code issuance claims the code before
+   inserting its first refresh token, rotation copies the already-used originating code id, ROPC
+   creates no code reference, and no production `UpdateCode` caller can reset `used`. So
+   `revoked = true AND used = false` is unreachable for a code with a descendant, which is what keeps
+   the `ON DELETE CASCADE` on `fk_refresh_tokens_code` away from a live one.
+3. **The shared cutoff is safe for the new class.** Five minutes is beyond the 60 second redemption
+   lifetime, so a revoked unused code past it can no longer become used or gain a descendant, and no
+   path needs it for rejection, auditing or the reuse cascade's evidence: redemption answers a code it
+   cannot find with the same generic `invalid_grant`, `Code is invalid.` it answers a revoked one with.
+4. **The coverage claims hold, including the two load-bearing rows.** The keep-this retention row fails
+   only when `used = false` is dropped, and the ROPC row fails only when the subquery is hoisted. It
+   confirmed no transaction or failure-path case is owed, on the stated grounds: one parameterised
+   DELETE through the existing `ExecSql(tx, ...)` path, one error return, no new `RowsAffected`
+   contract. It found no sixth mutation, which the request had named as a finding if one existed.
+
+It also took the sceptical pass the request asked for on the long comments, and confirmed their three
+substantive claims against the production paths: the subquery's position contains #130, the new class
+is bounded by the 60 second lifetime, and `used = false` excludes every auth-code-derived descendant
+because `MarkCodeAsUsed` is the only production claim path and now refuses revoked rows. It declined to
+reopen #130 or decision 8, which the request had marked settled.
+
+**Its `unchecked` list holds nothing the gate depended on.** The integration tier, correctly not
+applicable to a stage that changes one background sweep and no endpoint, with the stage entry's own
+reasoning independently confirmed: a reaped row is indistinguishable from a present one at every seam a
+user reaches. Unchanged cryptography, signature validation, PKCE, redirect matching, endpoint
+authorization and rate limiting, none of which this diff reaches. And the run's five source mutations,
+assessed statically because a reviewer may not edit source under review, which is the same limitation
+recorded at every earlier gate.
+
+**The reviewer changed no tracked file.** `.review/before.sha` still held stage 5's `40b6dacd…`, so the
+usual hash comparison was unavailable and mtimes were used instead: every file in the diff was last
+written between 18:15 and 18:23:54Z and the request was created at 18:23:59Z, so nothing was touched
+during the review. Its only artefact is the untracked scratch program above. Recorded because a stale
+`before.sha` is exactly the kind of thing that reads as a passed check when it is an absent one.
+
+**Tiers, re-run in full by this session on the tree being committed rather than carried forward from
+the implementation session, both in the foreground.** Modules green on all three modules, 2721 passing
+test lines, zero `FAIL`, exit 0. Data green on **all four engines** in one pass, exit 0, with
+`TestDeleteUsedCodesWithoutRefreshTokens`, `_AgeCutoff`, `_RevokedUnused` and
+`_RevokedUnusedWithRopcTokenPresent` each passing once per engine, read from the per-engine sections of
+the log rather than from the summary line. `check-anchors.sh` passes all 80 rows, `gofmt -l` is silent
+on all four changed files, `git diff --check` is clean. Integration not run and not claimed, for the
+reason above. No `site` build: this stage touches no page, which the docs searches in the stage entry
+establish.
+
+**No round 2, and the gate passes on one round.** All three axes reviewed with the two tiers the stage
+claims actually executed by the reviewer as well as by the run, zero findings, and nothing changed
+after the reviewed tree. That is the clean case the reviewer reference describes, and unlike stage 6
+there is no finding whose fix a later round would need to see.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`, and section 9 its four follow-ups. Stage 7 is committed with this document following it.
+Next: stage 8, gap 2's evidence, still a sketch and the last stage.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -4,7 +4,7 @@
 **Issue state:** open (labels: bug, security)
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
-**Agreement sealed:** 2026-08-04
+**Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
 **Run state:** not started
 **PR:** none
 
@@ -12,9 +12,21 @@
 work sits next to. #128 (closed) built the atomic refresh claim and family containment. #77
 (closed) built the atomic code claim. #127 (closed, not planned) proposed a grant entity. #130
 (open) owns the used-code cleanup NULL bug this issue's body flagged. #131 and #132 (open) are
-residuals of #106 and #128 in the same code. #133, #134, #135 and #137 (open) were filed out of an
+residuals of #106 and #128 in the same code. #109 (open) owns the RP-initiated logout surface this
+work deliberately does not touch, per decision 13. #133, #135 and #137 (open) were filed out of an
 earlier, discarded attempt at this issue and cite decision numbers from a document that no longer
-exists; see "Prior attempt" below. None of them blocks this work.
+exists; see "Prior attempt" below. #134 came from that attempt too and was **closed as not planned**
+on 2026-08-04, because it tracked the retention of a terminated-session registry and decision 4
+builds none. None of them blocks this work.
+
+**Amended after sealing.** Sections 1 to 5 are meant to be frozen at the seal, so the edits of
+2026-08-04 are recorded rather than absorbed. The skill's references gained a four-surface
+documentation sweep and a follow-ups section after this document was written, and running both found
+work the first pass missed: a falsified sentence in `concepts/tokens.mdx`, three confirmation modals
+whose copy is now incomplete (decision 14), and the fact that interactive logout writes nothing to
+the database (decision 13). Section 2 gained `Documentation owed` and a sixth goal, section 9 is new,
+sections 0, 1, 3 and 5 carry marked corrections, and no sealed decision was reversed. The seal holds
+because section 3 still has zero `Open` items.
 
 **Prior attempt.** An earlier `/leo-spec` plus `/leo-run` cycle for #129 reached stage 4 and was
 discarded by `git reset --hard origin/main` on 2026-08-04. The user chose to start over from zero.
@@ -32,6 +44,8 @@ exists and will need reconciling against this document's section 3.
 | `admin/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go` | `HandleAPIUserSessionDelete` | `err = database.DeleteUserSession(nil, sessionId)` | termination site 1, bare delete, no revocation |
 | `account/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go` | `HandleAPIAccountSessionDelete` | `if err := database.DeleteUserSession(nil, sessionId); err != nil {` | termination site 2, ownership checked, bare delete |
 | `logout/last-client-delete` | `src/authserver/internal/handlers/handler_account_logout.go` | `handleExistingSessionOnLogout` | `if len(userSession.Clients) == 1 {` | termination site 3, deletes the session only when the last client logs out |
+| `logout/basic-post-fork` | `src/authserver/internal/handlers/handler_account_logout.go` | `HandleAccountLogoutPost` | `if hint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint"); len(hint) > 0 {` | without a hint the handler clears the cookie and writes nothing to the database |
+| `catalog/end-session-modal` | `src/core/i18n/catalogs/active.en.toml` | `n/a` | `adminconsole.account.sessions.modal_confirm_body_prefix` | one of three end-session modals; decision 14 adds a key beside each |
 | `completed/start-new-session` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `newSession, err := userSessionManager.StartNewUserSession(` | gap 3: reached unconditionally, no proof anyone authenticated |
 | `completed/really-authenticated` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `userReallyAuthenticated := authContext.AuthenticatedAt != nil` | computed, then read only inside the valid-session branch |
 | `completed/set-acr-level` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `err = authContext.SetAcrLevel(targetAcrLevel, userSession)` | runs after the branch, on the ambient session, whoever it belongs to |
@@ -67,7 +81,14 @@ exists and will need reconciling against this document's section 3.
 
 Counts in this document carry their command:
 
-- 3 termination sites (`admin/session-delete`, `account/session-delete`, `logout/last-client-delete`).
+- 3 termination sites (`admin/session-delete`, `account/session-delete`, `logout/last-client-delete`),
+  the third reachable only with an `id_token_hint`, per the correction in section 1.
+- 3 admin console pages end sessions, through 2 API endpoints
+  (`grep -c 'http.NewRequest("DELETE"' src/adminconsole/internal/apiclient/user_session_client.go`
+  returns 3, of which `DeleteUserSessionById` and `DeleteAccountSession` are the session ones and
+  `DeleteUserConsent` is not).
+- 1263 keys in each catalog, at parity
+  (`grep -c '^"' src/core/i18n/catalogs/active.en.toml src/core/i18n/catalogs/active.pt-BR.toml`).
 - 3 subtests reach `StartNewUserSession`
   (`grep -c 'StartNewUserSession", rr, req' src/authserver/internal/handlers/handler_auth_completed_test.go`).
 - Next free migration number is **000026** on all four engines
@@ -79,18 +100,46 @@ Counts in this document carry their command:
 
 ### The three termination sites
 
-All three delete the `user_sessions` row and revoke nothing. Each passes `nil` for the
-transaction, so none of them is a boundary against anything running concurrently.
+All three reach `DeleteUserSession` and revoke nothing. Each passes `nil` for the transaction, so
+none of them is a boundary against anything running concurrently.
 
 | Site | What it does | Revokes tokens? |
 |---|---|---|
 | `DELETE /api/v1/admin/user-sessions/{id}` (`admin/session-delete`) | deletes the `UserSession` | no |
 | `DELETE /api/v1/account/sessions/{id}` (`account/session-delete`) | deletes the `UserSession`, ownership checked | no |
-| `GET/POST /auth/logout` (`logout/last-client-delete`) | deletes one `UserSessionClient`, and the `UserSession` when it was the only one | no |
+| `/auth/logout` **with an `id_token_hint`** (`logout/last-client-delete`) | deletes one `UserSessionClient`, and the `UserSession` when it was the only one | no |
 
 The logout case is per-client and only incidentally ends a session. The predicate is
 `len(userSession.Clients) == 1`, evaluated after the client row is deleted, so the session dies
 exactly when the departing client was the sole one on it.
+
+Above them sit three admin console pages, all funnelling into the two API endpoints rather than
+adding a fourth site: the account sessions page through `DeleteAccountSession`, and both the admin
+users and admin clients session pages through `DeleteUserSessionById`. Those are the only two
+`DELETE` methods in `apiclient/user_session_client.go`
+(`grep -c 'http.NewRequest("DELETE"' src/adminconsole/internal/apiclient/user_session_client.go`
+returns 3, the third being `DeleteUserConsent`). Decision 14 owns their copy.
+
+> **Correction, made on the reconciliation pass of 2026-08-04.** The table above originally listed
+> the logout site as `GET/POST /auth/logout` without qualification. That overstates it, and the real
+> behaviour matters because decision 3 pins it with tests.
+>
+> `handleExistingSessionOnLogout` is reachable **only** through `doLogoutWithIdToken`, so only when
+> an `id_token_hint` is supplied, and per #109 item 1 only when `post_logout_redirect_uri` is
+> supplied too, since that parameter is wrongly treated as required and its check returns before the
+> teardown. The ordinary interactive path does not reach it at all: `logout_consent.html` posts back
+> with only a csrf field, so `HandleAccountLogoutPost` takes the no-hint branch at
+> `logout/basic-post-fork`, clears the cookie, audits `AuditLogout`, redirects, and **writes nothing
+> to the database**.
+>
+> So after an ordinary logout the `user_sessions` row survives with every client still attached.
+> Session-bound refresh tokens keep working at `validator/session-branch`, access tokens keep passing
+> `middleware/session-check`, and the row is orphaned from the browser, since the cookie no longer
+> carries the sid. It still appears as an active session on the user's own sessions page, endable
+> only by clicking "End session".
+>
+> Decision 13 records why this stays out of scope. It is drafted onto #109 in section 9, whose
+> divergence B describes the same asymmetry one path over.
 
 ### Gap 1: an offline grant outlives its session
 
@@ -238,12 +287,24 @@ On the refresh path, `validator/refresh-generation` likewise sits ahead of
 
 ### Documentation
 
-`site/src/content/docs/concepts/user-sessions.mdx` documents credential changes and live sessions
-for #106 and says nothing about explicit termination. `site/src/content/docs/integration/rest-api.mdx`
-describes the admin endpoint as "Terminates a user session by ID" and the account one as "Terminate
-session", with no claim about tokens. Nothing in the docs is falsified by this change, but the word
-"terminates" currently overpromises, and the gap that makes it overpromise is what this issue
-closes.
+`concepts/user-sessions.mdx` documents credential changes and live sessions for #106 and says
+nothing about explicit termination. `integration/rest-api.mdx` describes the admin endpoint as
+"Terminates a user session by ID" and the account one as "Terminate session", with no claim about
+tokens. The word "terminates" currently overpromises, and the gap that makes it overpromise is what
+this issue closes.
+
+The falsified sentence is in `concepts/tokens.mdx`, under offline refresh tokens: "Offline refresh
+tokens are not linked to a user session", and further down, an offline token "keeps working after the
+browser session that created it has gone". Both stay true of a session **expiring**, which is the
+feature per decision 2, and both become false of an explicit termination. Section 2 lists what each
+page owes.
+
+> **Correction, made on the reconciliation pass of 2026-08-04.** This subsection previously concluded
+> "Nothing in the docs is falsified by this change". That was wrong on `concepts/tokens.mdx` above,
+> and it rested on a sweep of one surface. The message catalogs and the templates were never searched,
+> and they carry three "End session" confirmation modals whose copy this change makes incomplete,
+> which is now decision 14. The four-surface sweep is the one in the skill's documentation reference;
+> the earlier pass did not run it.
 
 ### Failure direction
 
@@ -265,6 +326,8 @@ termination is attempted.
 4. Whatever durable state is introduced has a stated retention position, whether that is a reaper
    or a defended decision to keep the rows.
 5. The behaviour of ordinary RP-initiated logout is a recorded decision rather than an accident.
+6. Someone about to end a session is told, at the point of clicking, that it disconnects the
+   applications that session authorized, in both locales.
 
 ### Out of scope
 
@@ -280,14 +343,64 @@ termination is attempted.
 - Third-party resource servers accepting an already-issued access token by signature alone. Inherent
   to stateless tokens and already documented.
 - Reaping anything that exists today. `user_sessions` and its two existing reapers are untouched.
+- **#109**, the RP-initiated logout surface: the wrongly required `post_logout_redirect_uri`, the
+  URL construction, the non-standard `sid`, and its divergence B on the cookie-versus-database
+  asymmetry. Also the interactive logout path that writes nothing to the database at all, per
+  decision 13, which section 9 drafts onto #109.
+
+  **Not a landing-order constraint, and this is worth stating because it looks like one.** #109 and
+  #129 touch the same file, `handler_account_logout.go`, and nothing else. #129 does not modify that
+  file: decision 3 leaves logout unchanged, and its only presence there is the pinning tests at seam
+  9. Those pin behaviour #109 will deliberately change, so they must drive logout through request
+  shapes #109 is not rewriting, which seam 9 now spells out. Either issue can land first.
+
+### Documentation owed
+
+From the four-surface sweep. Each item names the behaviour that falsifies it rather than a stage
+number, because section 6 does not exist yet; the plan attaches each to the stage that changes the
+behaviour, never to a tidy-up stage at the end.
+
+- **`concepts/tokens.mdx`, offline refresh tokens.** Says offline tokens "are not linked to a user
+  session" and that one "keeps working after the browser session that created it has gone".
+  Falsified by decision 2. The distinction to draw is the one decision 4 rests on: a session
+  **expiring** still leaves an offline grant working, a session **explicitly ended** does not.
+- **`concepts/user-sessions.mdx`.** Has no section on ending a session. Needs a new one, next to
+  "Credential changes and live sessions", covering what the two endpoints now revoke (decision 2),
+  that an in-flight ceremony cannot recreate the session (decision 6), and the limit from decision
+  11: an access token already issued for an offline grant keeps working until it expires, because it
+  carries no `sid` for `middleware/session-check` to check. Without that last sentence a reader
+  generalizes the credential-change bullet, "Goiabada's own endpoints reject a token from a
+  superseded session on the very next request", to termination, and is wrong.
+- **`integration/rest-api.mdx`, both endpoints.** "Terminates a user session by ID" and the bare
+  "Terminate session" heading. Each gains a sentence on what termination revokes, linking to the new
+  concepts section.
+- **`reference/security.mdx`, "Authentication security".** Its "Session management" bullet covers
+  only configurable timeouts. Gains a durable-termination bullet in the shape of the existing
+  "Replay containment" one, which is the precedent for how a security property gets summarized here.
+- **Message catalogs, both.** Three new keys in `active.en.toml` and three in `active.pt-BR.toml`,
+  per decision 14, plus a line in each of the three templates it names.
+
+Verified as owing nothing, stated because silence reads the same as forgetting:
+
+- **`concepts/audit-log.mdx`.** Does not enumerate event identifiers, it points at
+  `src/core/constants/constants.go`. So decision 9's second event falsifies no page.
+- **`integration/endpoints.mdx`, `/auth/logout`.** Decision 3 leaves logout unchanged, and decision
+  13 leaves the interactive path's defect to #109. The page's description stays accurate, including
+  "Immediately logs out the user", which describes the cookie effect it always described.
+- **`CLAUDE.md` and `AGENTS.md`.** Byte identical (`diff AGENTS.md CLAUDE.md`, empty). Neither
+  enumerates migrations, the `codes` table, nor the test tiers this change adds to, so migration
+  000026 and `codes.revoked` owe them nothing. Any future edit goes to both.
 
 ---
 
 ## 3. Open questions and decisions
 
-Twelve items. Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual at
-`/auth/issue` that the registry design did not have, which is item 12. Numbers are never reused, and
-decision 4 records its own reversal rather than being rewritten silently.
+Fourteen items. Opened at eleven; decision 4's reversal onto a code-level marker exposed a residual
+at `/auth/issue` that the registry design did not have, which is item 12. The reconciliation pass of
+2026-08-04 added two more: tracing which endpoints the "End session" buttons reach found that
+interactive logout writes nothing to the database (item 13), and the four-surface documentation sweep
+found three confirmation modals whose copy this change makes incomplete (item 14). Numbers are never
+reused, and decision 4 records its own reversal rather than being rewritten silently.
 
 1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
 
@@ -368,6 +481,17 @@ decision 4 records its own reversal rather than being rewritten silently.
    session-bound grant belonging to the client that just logged out **keeps working** while other
    clients remain on the session, because neither `validator/session-branch` nor
    `middleware/session-check` reads `UserSessionClient` at all.
+
+   > **Amended on the reconciliation pass of 2026-08-04.** The paragraph above is true of the
+   > `id_token_hint` path and describes only that path, which flatters the current behaviour. On the
+   > ordinary interactive path (`logout_consent.html` posting back with only a csrf field, taking the
+   > no-hint branch at `logout/basic-post-fork`) the session row is not deleted at all, so a
+   > session-bound grant keeps working whether or not other clients remain. The correction sits in
+   > section 1 and decision 13 records why it stays out of scope.
+   >
+   > This does not disturb the reasoning here. The dividing line is still intent, and a path that
+   > performs no termination is not evidence about what termination should mean. It does change what
+   > seam 9 pins, which is why the amendment is recorded rather than left as a detail.
 
    **Rejected:** sweeping sid-wide on logout. `handleExistingSessionOnLogout` is per-client, so this
    revokes grants belonging to clients that never logged out.
@@ -799,8 +923,101 @@ decision 4 records its own reversal rather than being rewritten silently.
 
     > **Residual, stated rather than implied.** The interleaving above is not closed. It belongs to the
     > same class as #131 and #132: ordering a write against a sweep portably across four engines. The
-    > run should record it in section 7 and it is a candidate follow-up, but it does not block this
-    > issue.
+    > run should record it in section 7, and it is drafted as follow-up 1 in section 9, but it does not
+    > block this issue.
+
+13. **The interactive logout path stays out of scope, and #129 does not touch logout.**
+    Status: **Decided** Raised by: user
+
+    Found on the reconciliation pass, by tracing which endpoint each "End session" button reaches.
+    `logout_consent.html` posts back carrying only a csrf field, so the ordinary logout takes the
+    no-hint branch at `logout/basic-post-fork`, clears the cookie, audits, redirects, and writes
+    nothing to the database. The session row survives with every client attached. Section 1 carries
+    the full correction.
+
+    **Why this is not #129's problem, which is the whole argument.** #129 makes termination
+    **durable**. This path performs no termination at all, so there is nothing for `codes.revoked` to
+    mark and no durability to add: the marker is written by the shared helper in decision 5, which
+    this path never calls. Fixing it means first deciding what interactive logout should do, whole
+    session or per-client, and that is exactly the model question #109 divergence B raises. Answering
+    it here would settle #109's design from inside an issue about something else.
+
+    Decision 3's reasoning is untouched. The dividing line is intent, and a path that terminates
+    nothing is not evidence about what termination means.
+
+    **Rejected: a stage making the no-hint POST delete the session, still without revoking.** It
+    would make logout stop lying for one line of code, which is tempting. Rejected because it edits
+    `handler_account_logout.go`, the one file #109 rewrites, and because "delete the whole session"
+    prejudges #109-B against the per-client model already in `handleExistingSessionOnLogout`. #129
+    modifies no logout code; its only presence in that file is seam 9's pinning tests.
+
+    **Rejected: treating interactive logout as a termination.** Reverses decision 3, and contradicts
+    the OIDC Core section 11 reading that decision 3 rests on.
+
+    **Consequence for seam 9.** The pinning tests must drive logout through request shapes #109 is
+    not rewriting, and must not encode #109's defects as intended behaviour. Seam 9 spells this out.
+
+    Drafted onto #109 as follow-up 2 in section 9, rather than as a new issue, because #109 already
+    owns this surface and divergence B is the same asymmetry one path over.
+
+14. **Yes, all three confirmation modals say what ending a session disconnects, in both locales.**
+    Status: **Decided** Raised by: user
+
+    Found by the four-surface sweep, which the earlier pass never ran past the docs site. Three admin
+    console pages carry an "End session" button, and all three funnel into the two endpoints decision
+    5 names, so all three inherit the new consequence: ending a session disconnects the long-lived
+    integrations that session authorized.
+
+    Today each modal promises only that a session on a device ends, plus a conditional warning that
+    ending your own logs you out. Nobody clicking it can discover the rest, and for an administrator
+    it is the fact that decides whether ending the whole session is even the right control, given
+    that the narrower capability is #135 and does not exist yet.
+
+    **What lands.** Three new keys in `active.en.toml` and three in `active.pt-BR.toml`, following
+    the per-surface prefix convention that already gives "End session" three separate keys, plus one
+    `msg +=` line in each of the three templates:
+
+    | Surface | Template | New key |
+    |---|---|---|
+    | account | `account_user_sessions.html` | `adminconsole.account.sessions.modal_revocation_note` |
+    | admin users | `admin_users_sessions.html` | `adminconsole.admin_users.sessions.modal_revocation_note` |
+    | admin clients | `admin_clients_usersessions.html` | `adminconsole.admin_clients.usersessions.modal_revocation_note` |
+
+    Two wordings, not one, because person differs. The account page is the user acting on their own
+    session; the two admin pages act on somebody else's:
+
+    - account, second person: `" <br /><br />Applications you authorized from this session, including
+      ones that keep working in the background, will need to sign in again."`
+    - admin, third person: `" <br /><br />Applications the user authorized from this session,
+      including ones that keep working in the background, will need to sign in again."`
+
+    pt-BR drafts, in the register of the neighbouring strings, which use "aplicativos" and
+    "autentique-se novamente": `" <br /><br />Os aplicativos que você autorizou nesta sessão,
+    incluindo os que continuam funcionando em segundo plano, precisarão se autenticar novamente."` and
+    the same with "que o usuário autorizou". The run treats these as drafts to refine, not sealed
+    wording, and must not ship English in the pt-BR catalog. The English is the user's chosen wording
+    and the pt-BR follows it rather than paraphrasing.
+
+    **Two mechanical constraints, verified, because getting either wrong breaks the page silently.**
+    The string is interpolated into a JavaScript double-quoted literal inside `endSessionClick`, so it
+    may contain **no double quote**, which is why the existing modal strings use
+    `<span class='text-accent'>` with single quotes. And it is appended unconditionally, placed
+    **before** the `if (isCurrent)` append so the immediate-logout warning stays last.
+
+    **Left alone deliberately:** the pre-existing key-name inconsistency, where two surfaces use
+    `modal_current_warning` and `admin_users` uses `modal_confirm_current_warning`. Renaming is not
+    this change's job, and the new keys use one consistent suffix rather than copying the divergence.
+
+    **Rejected: only the account modal.** The admin surfaces would stay silent about a consequence
+    that changes which control an admin should reach for, and an admin ending a contractor's session
+    to cut off access needs to know it also disconnects that person's background integrations.
+
+    **Rejected: the docs site only.** `concepts/user-sessions.mdx` carries the full semantics either
+    way, per section 2, but a reader at the decision point is in a modal, not on the docs site.
+
+    **Rejected: one shared key for all three surfaces.** It would be less churn, and it is against the
+    established convention here, where identical strings like "End session" and "Are you sure?" each
+    carry three per-surface keys. Mixing a shared key into a per-surface scheme is what review flags.
 
 ---
 
@@ -1015,11 +1232,30 @@ an existing test file**, and the only new artefacts are two data methods.
    - both `DELETE` endpoints revoke, with ownership still enforced on the account one;
    - `/auth/logout` behaviour is **unchanged**, decision 3, including that a logged-out client's
      session-bound refresh token keeps working while other clients share the session. This pins
-     today's behaviour so #135 has to change it deliberately;
+     today's behaviour so #135 has to change it deliberately.
+
+     **Drive it through request shapes #109 is not rewriting**, per decision 13, or these tests
+     encode #109's defects as intended behaviour and its author has to delete them. Concretely: the
+     path that reaches `logout/last-client-delete` needs both `id_token_hint` and
+     `post_logout_redirect_uri`, because #109 item 1 is that the second is wrongly required and its
+     check returns before the teardown. Assert what #129 cares about, that no grant was revoked, and
+     assert nothing about whether the parameter was required or how the redirect was built. If a case
+     covers the no-hint POST at `logout/basic-post-fork`, it asserts only that #129 revoked nothing
+     there; the surviving session row is #109's business, not a #129 expectation to lock in;
    - the mid-flight ceremony, gap 3, driven on one HTTP client so the cookie is shared: begin an SSO
      ceremony, terminate the session before it completes, and assert no usable code is issued. Plus
      the #46 case, `test/fresh-ceremony-after-delete`, still green, which is the pair that proves
      decision 6 chose the right predicate rather than merely a strict one.
+
+### Catalog, host
+
+10. **`src/core/i18n/catalog_hygiene_test.go`** (existing suite). Decision 14's six new keys need
+    **no new test code**, and that is the finding rather than an omission: `TestCatalog_ParityEnPtBR`
+    already fails in both directions when a key exists in one catalog and not the other, and
+    `TestCatalog_NoEmptyValues` already fails on a key present with an empty value, which go-i18n
+    otherwise renders as the raw key in the UI. Adding the keys to both files is what makes the
+    existing guard cover them. The step that adds them states this explicitly, so a reviewer does not
+    read the absence of new cases as the copy being untested.
 
 **Rejected seams**
 
@@ -1036,7 +1272,78 @@ an existing test file**, and the only new artefacts are two data methods.
   seam 1's rolled-back-transaction case plus seam 9 carry the atomicity.
 - **A new test file for the termination helper.** `revocation_test.go` already exists beside it and
   owns this shape.
+- **A render test for the three session templates.** `internal/rendertest` covers account phone,
+  address and profile only, so the session pages would need new harness setup to assert that one
+  `msg +=` line reaches a JavaScript string. That proves the template compiles, which the existing
+  build already proves, and it is the padding testing.md warns about. Seam 10 covers what can
+  actually regress: a key missing from one catalog, or present and empty.
 
 > **Obligation for the run.** Per section 5 of the testing reference, every table above is executed in
 > the scratchpad before it is written into section 6, and re-run after any revision. Counts are never
 > carried forward across a change.
+
+---
+
+## 9. Follow-ups
+
+Both found while grounding, both verified against code, both outside this change under section 2, and
+neither is a way to avoid work #129 owes. The run appends here as it finds more, and never files
+anything.
+
+1. **A code insert can still land between a termination's `UPDATE` and its `COMMIT`.**
+   `bug`, `security`, `go`. Found while settling decision 12. Status: **Drafted**
+
+   Decision 12 closes gap 3's fail-open window with two sweepers that cover each other: termination
+   marks codes that already exist, and `/auth/issue` marks its own code when the session is already
+   gone. One interleaving escapes both. If the code insert commits after the termination transaction's
+   `RevokeCodesBySessionIdentifier` statement has read `codes` but before that transaction commits,
+   the compensating statement's `NOT EXISTS` still sees the session row, so neither marks it. What
+   survives is an offline refresh token, for up to `RefreshTokenOfflineMaxLifetimeInSeconds`.
+
+   Verified at `db/mark-code-used` and `issue/create-code`: nothing orders the insert against the
+   sweep, and the window is between two bounded statements rather than the unbounded handler stall the
+   read-only check leaves, which is why decision 12 accepted it.
+
+   Out of scope here because closing it needs the same primitive #131 and #132 want, a portable way to
+   order a write against a sweep across SQLite, MySQL, PostgreSQL and SQL Server, and whichever of the
+   three lands first should establish it. #134 held the previous version of this residual and was
+   closed as moot when decision 4 moved the marker off a session-keyed registry, so nothing tracks it
+   now.
+
+   Searched `gh issue list --state open --search "serialization boundary sweep"` and the full open
+   list: #131 and #132 are the rotation residuals of #106 and #128, neither covers code issuance.
+
+   **Body:** #129 marks a terminated session's authorization codes revoked, and `/auth/issue` runs a
+   compensating `UPDATE ... WHERE NOT EXISTS (SELECT 1 FROM user_sessions ...)` immediately after
+   inserting a code, so a code created after the termination is marked even when the termination could
+   not see it. The remaining window is an insert committing after the termination's `UPDATE` has read
+   `codes` and before that transaction commits: the compensating statement still observes the session
+   as present, so the code carries no marker, and redeeming it yields an offline refresh token good
+   for up to the configured offline maximum lifetime. Closing it needs issuance ordered against the
+   revocation sweep, which is the same missing primitive as #131 and #132. Scope the three together.
+
+2. **Add to #109: the interactive logout path writes nothing to the database.**
+   `bug`, `go`, `security`. Found on the reconciliation pass of 2026-08-04. Status: **Drafted**
+
+   A comment on #109 rather than a new issue, because #109 already owns the RP-initiated logout
+   surface and its divergence B is this same asymmetry on the neighbouring path. Filing separately
+   would split one design question across two issues.
+
+   Verified at `logout/basic-post-fork`: `HandleAccountLogoutPost` takes the no-hint branch, clears
+   the cookie, audits `AuditLogout`, redirects, and never calls `handleExistingSessionOnLogout`.
+   `logout_consent.html` posts back with only a csrf field, so this is the path every interactive
+   logout takes. Decision 13 records why #129 leaves it alone.
+
+   **Body:** Divergence B notes that the cookie is wiped unconditionally while the database teardown
+   is per-client. There is a path where the teardown does not happen at all. `POST /auth/logout`
+   without an `id_token_hint` clears the cookie session, writes an `AuditLogout` entry, redirects, and
+   never touches `user_sessions`. Since `logout_consent.html` posts back carrying only a csrf field,
+   that is the path taken by every logout a person performs in a browser, and by the admin console's
+   account menu.
+
+   The row therefore survives with every client still attached. Session-bound refresh tokens keep
+   working, access tokens keep passing `RequireValidSession`, and the row is orphaned from the browser
+   because the cookie no longer carries the session identifier. The user still sees it listed as an
+   active session on that device and can only end it with the "End session" button. Whatever B decides
+   about per-client versus whole-session teardown, this path should reach the same code as the
+   `id_token_hint` path rather than bypassing it.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,11 +5,11 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** stage 5 awaiting review round 2, 2026-08-05. Stages 1 to 4 are committed. Decision 15
-was answered on PR #138 ("Let's go with option A"), and stage 5 now carries that answer: the gate reads
-a dedicated level 1 proof on the `AuthContext` rather than `AuthenticatedAt`. Still **uncommitted**,
-because the gate has not passed a review round since it changed. Modules and integration are green on
-the amended tree.
+**Run state:** stages 1 to 5 committed, 2026-08-05. Stage 5 passed its gate at review round 2, whose
+one quality finding (a lost negative case for `userReallyAuthenticated`'s pre-existing `!IsZero()`
+term) was resolved inside the stage. Decision 15 was answered on PR #138 ("Let's go with option A"), so
+the gate reads a dedicated level 1 proof on the `AuthContext` rather than `AuthenticatedAt`. Next:
+stage 6, the `/auth/issue` liveness check and the compensating revoke, still a sketch.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -114,6 +114,7 @@ log can cite it the same way. Nothing above the line changed.
 | `pwd/level1-proof` | `src/authserver/internal/handlers/handler_auth_pwd.go` | `HandleAuthPwdPost` | `authContext.Level1AuthCompleted = true` | stage 5, the only writer of that field |
 | `test/completed-gate-otp` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and only OTP authenticated this ceremony, restarts level 1"` | stage 5, decision 15's unit row, the one that fails against the round 1 gate |
 | `test/otp-alone-no-recreate` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession` | `"the ended session must not be recreated by a ceremony that only verified OTP")` | stage 5, decision 15's integration case, paired with `test/fresh-ceremony-after-delete` in the same file |
+| `test/completed-authtime-zero` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("Successful flow, existing session, zero AuthenticatedAt does not refresh AuthTime"` | stage 5 round 2, the valid-session row covering `userReallyAuthenticated`'s pre-existing `!IsZero()` term, which the gate does not read |
 
 Counts in this document carry their command:
 
@@ -1848,7 +1849,7 @@ stated reason.
    pin, and decision 13 leaves the path itself to #109, where it is drafted as follow-up 2.
 
 ### Stage 5: the `/auth/completed` gate
-Status: **In progress**
+Status: **Done**
 Seams: 6 (`HandleAuthCompletedGet`, in the existing `handler_auth_completed_test.go`), plus, per
 decision 15's answer, one assertion each in the existing `handler_auth_pwd_test.go` and
 `handler_auth_otp_test.go` subtests, which are the only seams that can see who writes the new field.
@@ -1926,12 +1927,15 @@ into `StartNewUserSession`; it is verified and drafted as follow-up 3 in section
    | the three existing subtests reaching `StartNewUserSession` gain `Level1AuthCompleted` and a non-nil `AuthenticatedAt` | outcomes unchanged: 302 to `/auth/issue` or `/auth/consent`, `StartNewUserSession` called with the same arguments | **keep these as the positive control.** They are `test/fresh-ceremony-after-delete`'s shape at the unit tier, session gone and the user really did level 1, and they fail against a gate keyed on the session alone. Both fields are set because `pwd/level1-proof` sets both, so the row stays a shape the code can actually produce. This is the non-additive cost section 1 recorded |
    | the three existing subtests with a valid session and nothing authenticated, untouched | unchanged: SSO reuse still bumps and proceeds | the gate is confined to the else branch. These fail if it is hoisted above `if hasValidUserSession`, which is the natural-looking tidy-up |
    | the existing re-auth subtest: valid session, `AuthenticatedAt` set, `Level1AuthCompleted` false, untouched | unchanged: bumps, refreshes `AuthTime`, proceeds | the legitimate step-up by OTP on a live session, which option A must not disturb. It was already in the file and needed no amendment, and it is the fourth row that fails if the gate is hoisted |
+   | valid session, `AuthenticatedAt` non-nil but **zero** | bumps, does **not** call `UpdateUserSession`, and the session's own `AuthTime` reaches the saved context unchanged | `userReallyAuthenticated`'s `!IsZero()` term, which this gate does not read but the valid-session branch still does. Added in round 2, see below |
 
-   **Amended per decision 15.** The zero-time `AuthenticatedAt` row was replaced by the OTP row rather
-   than kept beside it. It existed to pin the `!IsZero()` spelling of a discriminator this gate no
-   longer reads, and the OTP row catches the same mistake, a gate falling back to `AuthenticatedAt`,
-   through a shape the code can actually reach. `userReallyAuthenticated`'s own `!IsZero()` term is
-   pre-existing and still covered by the re-auth subtest, which is where it belongs.
+   **Amended per decision 15, then corrected in round 2.** The zero-time `AuthenticatedAt` row was
+   first replaced by the OTP row rather than kept beside it, on the reasoning that it pinned the
+   `!IsZero()` spelling of a discriminator this gate no longer reads and that the re-auth subtest still
+   covered that term. The second half of that was **wrong**, and round 2 of the review caught it: the
+   re-auth subtest supplies a *nonzero* timestamp, which satisfies both spellings, so deleting
+   `!IsZero()` left the whole file green. The row is back, in the shape the finding asked for, and both
+   rows now stand: the OTP row for the gate, this one for the discriminator the branch above it reads.
 
    No new audit event, no new mock method and no new fixture: the gate reads one bool off the auth
    context and writes a state the router already knows.
@@ -1967,17 +1971,19 @@ into `StartNewUserSession`; it is verified and drafted as follow-up 3 in section
    are existing `SaveAuthContext` matchers in existing subtests, one line each, at handler seams
    section 1 already named.
 
-**As built.** All six steps landed, the first five as written once decision 15's amendments are read
-into them. Six anchor rows added in total: `completed/level1-restart` and `test/completed-gate` when the
-stage was first built, then `authcontext/level1-proof`, `pwd/level1-proof`, `test/completed-gate-otp`
-and `test/otp-alone-no-recreate` when option A landed. One row needed re-sweeping,
+**As built.** All six steps landed, the first five as written once decision 15's amendments and round
+2's correction are read into them. Seven anchor rows added in total: `completed/level1-restart` and
+`test/completed-gate` when the stage was first built, then `authcontext/level1-proof`,
+`pwd/level1-proof`, `test/completed-gate-otp` and `test/otp-alone-no-recreate` when option A landed,
+then `test/completed-authtime-zero` at round 2. One row needed re-sweeping,
 `completed/level1-restart`, because option A replaced the predicate it cites; no sealed row moved.
 
 Three things worth naming beyond the steps.
 
 1. **The predicted case table shipped unchanged when first built**, and decision 15's answer then
-   replaced one of its rows rather than adding one, so the file stays at twelve subtests where `main`
-   has ten (`grep -c 't.Run(' handler_auth_completed_test.go`). The three amended
+   replaced one of its rows rather than adding one; round 2 put that row back beside the replacement,
+   so the file ends at thirteen subtests where `main` has ten
+   (`grep -c 't.Run(' handler_auth_completed_test.go`). The three amended
    positive controls still pass with their original assertions, including the `StartNewUserSession`
    argument expectations, because the handler overwrites `AuthenticatedAt` from the new session before
    saving and the amendment therefore cannot be observed downstream of the gate.
@@ -2693,6 +2699,86 @@ section 9 and in the stage's as-built note.
 after round 1 read it and no review round has seen the current tree. `.review/request.md` carries round
 2, whose ask is the whole stage 5 diff with the decision 15 answer applied. The tiers above were green
 on exactly that tree.
+
+### Stage 5 round 2, 2026-08-05: the gate closes
+
+**Review, round 2.** `gpt-5.6-sol`, effort high, request `129-20260805T152741Z`. All three axes read
+`reviewed`. It ran the modules tier (green, three modules), the integration tier (green on mysql,
+postgres, mssql and sqlite), `check-anchors.sh` (63 rows), `npm run build` in `site` (42 pages),
+`gofmt -l` on the changed Go files, `git diff --check`, and `git diff | sha256sum` before and after its
+own verification, both `32a49f32`, so it reviewed the diff the request named and touched nothing.
+
+**What it found sound**, recorded because a clean axis needs a stated scope. Conformance: option A is
+implemented as chosen, `Level1AuthCompleted` is on the `AuthContext`, `pwd/level1-proof` is the only
+source writer, the OTP handler does not set it, the gate reads it, and an older cookie decodes the
+absent bool as false. Security: it searched for every path that sets
+`AuthStateAuthenticationCompleted` and redirects to `/auth/completed`, found three (level 1 completion,
+optional level 2 completion, OTP completion), and confirmed none of them provides a second writer;
+`prompt=none` goes straight to `/auth/issue`; and the auth context is JSON inside the encrypted,
+HMAC-authenticated Gorilla cookie, so a request parameter cannot inject the bool. Quality: the paired
+integration cases prove both directions, and the two writer assertions pin the asymmetry.
+
+Not reached: the data tier, correctly, this stage adds no data-layer behaviour; the five mutations,
+assessed statically because a reviewer may not modify source under review; and unchanged
+authentication, token-validation, endpoint-authorization and rate-limiter internals outside the stage.
+
+One finding, on the quality axis.
+
+1. **Replacing the zero-time row removed the only negative coverage of a separate guard.**
+   `Raised by: reviewer`, minor, confidence high, `needs_human: true`. Status: **Resolved**
+
+   **Confirmed against the code, and the run's own round 1 evidence already said so.**
+   `completed/really-authenticated` reads
+   `AuthenticatedAt != nil && !AuthenticatedAt.IsZero()`, and `git diff` shows that line unchanged, so
+   the `!IsZero()` term is pre-existing. After the decision 15 amendment every non-nil
+   `AuthenticatedAt` fixture in the file carried `time.Now().UTC()`: the SSO rows cover nil, which
+   short-circuits before `!IsZero()` is evaluated, and the re-auth row covers nonzero, which satisfies
+   both spellings. So step 3's amendment note claiming the term was "still covered by the re-auth
+   subtest" was **false**, and the first stage 5 entry's mutation 2 had already demonstrated exactly
+   that: dropping the term failed only the zero-time row, "without that row this mutation ships". The
+   amendment then deleted the row and carried the claim forward without re-running the mutation.
+
+   **Resolved rather than escalated, and the reasoning matters because the verdict asked for a human.**
+   The finding is on the **quality** axis, so reviewer.md's rule that a security finding is never
+   settled by the run alone does not reach it. What it asks for is a test row: no production code
+   changes, no interface, no schema, no wire format, no persisted shape and no security property, which
+   is decisions.md's "local and reversible" exactly. And there is no question left to put to anyone,
+   which is what an escalation would be for: the reviewer's recommendation, the code, and the run's own
+   mutation 2 agree on which term is uncovered and what covers it. leo-run is explicit that coverage
+   the plan missed is added and named rather than escalated, and spending an escalation on "may we add a
+   test row" would burn the budget decisions.md section 5 treats as a signal.
+
+   **What landed.** `test/completed-authtime-zero`, a valid-session subtest carrying a non-nil zero
+   `AuthenticatedAt`, asserting the ordinary bump, **no** `UpdateUserSession`, and the session's own
+   `AuthTime` reaching the saved context unchanged. Two independent things fail if the term is dropped:
+   the strict `mocks_data.Database` carries no `UpdateUserSession` expectation, and the
+   `SaveAuthContext` matcher pins the carried-forward timestamp. The comment says why nothing else in
+   the file can cover it. Step 3's table gained the row, its amendment note now records the false claim
+   rather than absorbing it, and the block comment above the two gate subtests no longer says the
+   zero-time row was replaced.
+
+   **Mutation, applied to the real handler, run and reverted in this session.**
+   `userReallyAuthenticated := authContext.AuthenticatedAt != nil`, the term dropped, which is round
+   1's mutation 2 re-run against the amended file. Exactly one subtest failed,
+   `test/completed-authtime-zero`, and nothing else moved. Before this row the same mutation shipped
+   green, which is the whole finding.
+
+**Tiers, re-run in full on the tree that is being committed, both in the foreground.** Modules green,
+all three modules, 2760 passing test lines, zero `FAIL`, `TestHandleAuthCompletedGet` at **13**
+subtests where `main` has 10. Integration green on **all four engines**, 4756 passing test lines, zero
+`FAIL`, with `test/otp-alone-no-recreate` and `test/fresh-ceremony-after-delete` each passing once per
+engine. `check-anchors.sh` passes all 64 rows, `gofmt -l` is silent, `git diff --check` is clean. Still
+no data tier, and still correctly: a bool on a struct persisted as JSON in a cookie is not a schema.
+
+**Bookkeeping, from the reviewer's own section.** Round 2's request described the diff as nine Go files
+and one mdx file. `git diff ee400e1` is eight Go files, one mdx file and this document; the
+uncommitted stage tree alone is eight Go files and one mdx file. The count in the request was wrong,
+the 582-insertion total was right once the committed agreement amendment is included, and the request
+is throwaway so the correction lives here.
+
+**Nothing deferred, nothing contested, nothing new raised.** Section 3 keeps its fifteen items, all
+`Decided`. Round 2 was the second and last round at this gate, its one finding is resolved rather than
+carried, so the gate is passed and the stage is committed.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,18 +5,17 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** stages 1 to 5 committed, 2026-08-05. Stage 6, the `/auth/issue` liveness check and the
-compensating revoke, is expanded, implemented and green on all three tiers, and **uncommitted pending
-review round 2**. Its round 1 review raised decision 16, which the user answered on PR #138 on
-2026-08-05 with option A: a `prompt=none` ceremony whose session ends in the redirect hop is returned
-`login_required` rather than being restarted into a password form it is forbidden to display, and
-every other ceremony still restarts level 1. That branch, its unit row, its integration ceremony and a
-docs sentence are now in the tree, so the diff round 1 read no longer exists and the stage goes back
-for round 2 rather than to its gate. Section 3 has zero `Open` items. Expanding the stage also found
-that the terminated ceremony reaches `/auth/issue` with an **empty** session identifier rather than a
-dead one, because the session middleware clears it first, and that an empty identifier alone makes the
-resulting grant offline; the stage entry in section 6 carries the reasoning. Next after stage 6:
-stages 7 and 8, both still sketches.
+**Run state:** stages 1 to 6 committed, 2026-08-05. Section 3 has zero `Open` items. Stage 6 cost two
+escalations and three review rounds, and all three are recorded in section 7. Its round 1 raised
+decision 16, answered by the user on PR #138 with option A: a `prompt=none` ceremony whose session ends
+in the redirect hop is returned `login_required` rather than being restarted into a password form it is
+forbidden to display, and every other ceremony still restarts level 1. Round 2 found that branch
+clearing the auth context **after** committing the client response, so the clear reached nothing, and
+the fix plus two assertions that can observe a committed response landed inside the stage. Round 3 was
+clean. Expanding the stage also found that the terminated ceremony reaches `/auth/issue` with an
+**empty** session identifier rather than a dead one, because the session middleware clears it first,
+and that an empty identifier alone makes the resulting grant offline; the stage entry in section 6
+carries the reasoning. Next: stages 7 and 8, both still sketches.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -2141,7 +2140,7 @@ Three things worth naming beyond the steps.
    the user really does enter a password, which is the shape follow-up 3 already describes.
 
 ### Stage 6: the `/auth/issue` liveness check and the compensating revoke
-Status: **In progress**
+Status: **Done**
 Seams: 4 (the compensating revoke, in `code_test.go` on four engines) and 7 (`HandleIssueGet`,
 extending `TestHandleIssueGet` in the existing `handler_auth_issue_test.go`), plus the mid-flight
 ceremony in `session_deletion_test.go`, which is where stage 5 put its pair and where #46's guard
@@ -3463,6 +3462,77 @@ neither visible to the tiers as they stood. Committing on "the fix is obvious" a
 reviewer having seen the fix, is the failure mode an unattended run is most likely to reach. The wall
 clock is 24 of 240 minutes, so the round is affordable. If round 3 is clean the stage commits; if it
 finds something, that is the answer to whether the cap should have applied.
+
+### Stage 6 round 3, 2026-08-05: clean, and the stage closes
+
+**The review.** `codex`, request `129-20260805T175118Z`, all three axes `reviewed`, **no findings**. It
+weighted the round on the fix and what the fix could have broken, which is what the request asked for.
+It re-ran the module tier, ran the `prompt=none` integration ceremony on mysql, postgres, mssql and
+sqlite, ran `check-anchors.sh` at 77 rows, `git diff --check` and `gofmt -l`, and verified the source
+diff hash afterwards at `cf47c584…`, unchanged, so it edited nothing.
+
+Deliberately not re-run, and it said so rather than leaving it implied: the untouched data tier and the
+`site` build, both green in rounds 1 and 2 on files this round did not move. That is the right call on
+an unchanged subtree and it is recorded so a later reader does not read the narrower run as a narrower
+result.
+
+**What it verified, since a clean verdict is only worth what it covered.** The four numbered questions
+of the request, each answered on evidence rather than by reading the diff:
+
+1. **The clear reaches the browser in all three response modes.** It wrote its own scratch
+   reproduction against the real `CookieStore` and `AuthHelper`: clearing first leaves one committed
+   `Set-Cookie` on a query redirect, on a fragment redirect and on a `form_post` render; clearing after
+   a query redirect leaves **zero** committed cookies while the recorder's live header map still shows
+   one, which is round 2's defect reproduced independently. That is the claim the fix rests on,
+   established by a third party against the real store rather than against a stub.
+2. **The refusal itself still behaves.** `login_required`, the original `state`, no code, no
+   interactive redirect, and a failed clear now reaching `InternalServerError` before any client
+   response is written.
+3. **Both new assertions bite for the right reason.** `rr.Result()` snapshots the header as committed,
+   so the unit row fails under the reversed order while `rr.Header()` would pass either way; the
+   integration replay can reach the account profile only when the context is actually absent from the
+   jar. It agreed the two are complementary rather than redundant, the unit row isolating the ordering
+   and the integration row exercising the real cookie store and middleware.
+4. **Follow-up 4 is correctly scoped out.** Its seven sites predate this branch, need their own
+   reachability analysis, and change none of the OAuth response parameters decision 16's
+   indistinguishability claim is about. It restated that `handlePromptNone`'s own cleanup defect is a
+   real follow-up and not a reason to widen this fix into seven handlers, which is the run's position
+   at the foot of the round 2 entry, reached independently.
+
+On security it confirmed the branch stays fail-closed at every exit, the moved call adds no lookup
+keyed by user input, no route, no scope or audience change and no token or PKCE change, and that the
+reordering pre-empts no termination audit event and lets no attacker replay a refused ceremony.
+
+**So the third round was worth taking, and the record should say which way.** The reasoning for
+exceeding reviewer.md's two-round cap was that this gate kept finding real defects in the same branch,
+not that a third round was likely to find a third. It did not, and that is the outcome that closes the
+question rather than one that argues the cap should have applied: the two rounds that found something
+each found it in code no earlier round had seen.
+
+**One bookkeeping finding, fixed here.** The reviewer noted the header still described stage 6 as
+pending round 2 while the run log and the request were both round 3. Correct, and it is the same class
+of drift as the file count corrected at round 1 and the request miscount at stage 5 round 2. The header
+now describes the committed state.
+
+**Tiers, re-run in full by this session on the tree being committed rather than carried forward from
+round 2.** Modules green on all three modules. Data green on all four engines run separately, with
+`TestRevokeCodeIfSessionGone` and its transaction sibling passing on each. Integration green on all
+four engines, with all four of `session_deletion_test.go`'s ceremonies, including
+`test/fresh-ceremony-after-delete`, passing once per engine. `check-anchors.sh` passes all 77 rows.
+`gofmt -l` silent, `git diff --check` clean, `npm run build` in `site` at 42 pages.
+
+> **One red run happened first and it was not the code.** The first invocation of the tier script in
+> this session was piped into `head`, which killed the reading end but not the script: it kept running
+> inside the dev container and held port 19090, so the next run's server contended with it and the
+> mysql integration tier failed broadly across tests this change does not touch. Killing the orphan and
+> re-running gave the green above on the identical tree. Recorded because a stray red in a gate's logs
+> is exactly what a later reader would take for a flake in this stage, and because the cause is a run
+> hygiene rule worth carrying: never pipe the tier script into a pager.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`, and section 9 its four follow-ups. Stage 6 is committed as
+`feat(sessions): refuse to mint a code for a session that is gone`, with this document following it.
+Next: stage 7, reaping unused revoked codes, still a sketch.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -132,6 +132,9 @@ log can cite it the same way. Nothing above the line changed.
 | `issue/prompt-none-refusal` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `if authContext.HasPromptValue("none") {` | stage 6, decision 16 option A's branch, inside `issue/liveness-restart` |
 | `test/prompt-none-login-required` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired` | `"prompt=none must not be restarted into the interactive flow")` | stage 6, decision 16's integration case, the fourth ceremony in the file |
 | `middleware/session-identifier` | `src/authserver/internal/middleware/middleware_session_identifier.go` | `MiddlewareSessionIdentifier` | `ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)` | **pre-existing code, not written by the run.** The row exists because stage 6 and decision 16 cite this label three times each and it was declared nowhere, so the citations resolved to nothing. The locator is the only line that puts the identifier in the request context, which is the fact both cite |
+| `issue/prompt-none-clear-first` | `src/authserver/internal/handlers/handler_auth_issue.go` | `HandleIssueGet` | `err := authHelper.ClearAuthContext(w, r)` | stage 6 round 2, the clear ahead of the client response. The `:=` is what makes this line unique in the function; the other two clears assign to an existing `err` |
+| `test/prompt-none-clear-committed` | `src/authserver/internal/handlers/handler_auth_issue_test.go` | `TestHandleIssueGet` | `assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),` | stage 6 round 2, the unit row that reads the committed response rather than the live header map |
+| `test/prompt-none-context-cleared` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired` | `"the refusal must clear the auth context in the browser, so a replayed /auth/issue has no ceremony left")` | stage 6 round 2, the replayed `/auth/issue` that observes the clear through a real cookie jar |
 
 Counts in this document carry their command:
 
@@ -2230,11 +2233,21 @@ what proves it: every existing ceremony in the suite goes through this handler.
    missing). A ceremony carrying `prompt=none` cannot be restarted, because `/auth/level1` leads to
    `/auth/pwd` and that request forbids UI; nothing between the two reads the prompt, so it would be
    handed a login page and no error at all. `issue/prompt-none-refusal` sits first inside the refusal
-   and returns `login_required` through `redirToClientWithError`, then `ClearAuthContext`, copying the
-   `id_token_hint` branch above it. The description is `handlePromptNone`'s own wording for this
+   and clears the auth context at `issue/prompt-none-clear-first`, then returns `login_required`
+   through `redirToClientWithError`. The description is `handlePromptNone`'s own wording for this
    condition, "User authentication is required", so the client cannot tell this from the ordinary
    no-session refusal one hop earlier. Every other ceremony still restarts level 1, which is decision
    6 unchanged.
+
+   **The order of those two calls is the fix round 2 found**, and it is not cosmetic.
+   `ClearAuthContext` persists the deletion only through a `Set-Cookie` on `w`, and
+   `redirToClientWithError` commits the response in every response mode, so clearing afterwards leaves
+   the header on a response already written and the browser keeps a context reading
+   `ready_to_issue_code`. The clear therefore goes first, which is also the order the success path at
+   the foot of the same function already used. Failing the clear is a 500 rather than a refusal the
+   browser cannot record. The `id_token_hint` branch a few lines above still has the two calls the
+   other way round; that is pre-existing, is a different condition, and is drafted as follow-up 4
+   rather than fixed here.
 3. **The compensating revoke, immediately after the insert.** Status: **Done**
    Decision 12. `RevokeCodeIfSessionGone(nil, code.Id, sessionIdentifier)` directly after
    `issue/create-code`'s error check, ahead of the `AuditCreatedAuthCode` entry. On a database error,
@@ -2272,6 +2285,7 @@ what proves it: every existing ceremony in the suite goes through this handler.
    | no session identifier in the request context | 302 to `/auth/level1`, saved context reading `requires_level_1`, and no code created | the liveness check on the shape the middleware actually produces. "No code created" is enforced rather than asserted: the strict `mocks_oauth.CodeIssuer` carries no `CreateAuthCode` expectation |
    | a sid resolving to no session row | the same | the other half of the same predicate, for the narrow race where the middleware saw the session live |
    | the same empty identifier, with `prompt=none` on the context | 302 to the client's redirect URI carrying `error=login_required` and the request's `state`, no `code`, no `/auth/level1`, and `SaveAuthContext` never called | decision 16 option A. The two rows above are its negative control, since they carry no prompt and must still restart; a branch applied unconditionally reddens both, which is mutation 8 |
+   | the same row, reading the **committed** response's `Set-Cookie` | the sentinel the `ClearAuthContext` stub writes is present | added in round 2 at `test/prompt-none-clear-committed`. That the mock was called says nothing about whether the clear reaches the browser, because a header set after the redirect writes the status line is dropped; `rr.Result()` is the only view that can tell the two orderings apart, since `rr.Header()` shows the sentinel either way. Mutation 9 |
    | the session lookup fails | 500, no code created | a database fault must not read as a terminated session, and must not read as a live one either |
    | a live session | code issued as before, and `RevokeCodeIfSessionGone` called with that code's id and that sid | decision 12's statement is issued. Whether it **works** is seam 4's, per section 5 |
    | the compensating revoke fails | 500, and the client is not redirected with a code | the fail-closed direction of step 3 |
@@ -2310,6 +2324,7 @@ what proves it: every existing ceremony in the suite goes through this handler.
    |---|---|---|
    | session ended on the consent screen, then consent submitted | `/auth/consent` posts to `/auth/issue` as always, and `/auth/issue` redirects to `/auth/level1` and then `/auth/pwd`, with no code reaching the client and no session recreated | gap 3's second half at the highest seam that can see it. The consent POST succeeding first is deliberate: it is what makes `/auth/issue` the load-bearing hop rather than an incidental one |
    | session ended between `handlePromptNone`'s 302 and the browser following it | back to the client's redirect URI with `error=login_required` and the request's `state`, no `code`, nothing on `/auth/level1`, and no session recreated | decision 16, added after round 1. Same window through the other door, and the outcome is the one thing that differs, so it sits beside the consent-screen case rather than replacing it. `createSessionWithAcrLevel1` supplies the live session, and the termination goes between `assertRedirect` and `loadPage`, which is the whole window a silent ceremony has |
+   | the same `/auth/issue` requested a second time on the same jar | 302 to the account profile, and not to the client again | added in round 2 at `test/prompt-none-context-cleared`. The clear reaches this jar only if it ran before the redirect was committed, so the wrong order answers `login_required` twice from a context still reading `ready_to_issue_code`. Measured under mutation 9, which is exactly what it printed |
    | `test/fresh-ceremony-after-delete` and `test/otp-alone-no-recreate` | unchanged and green | the pair decision 6 rests on. This stage's check is the one that could redden the first: a code flow whose session vanished is exactly #46's shape one hop later |
 
    The ordinary ceremony is the control, and it is named rather than duplicated: `createOfflineGrant`
@@ -2323,11 +2338,13 @@ what proves it: every existing ceremony in the suite goes through this handler.
    load bearing at this gate rather than routine: this stage puts a new refusal in front of every
    authorization code the suite issues.
 
-**As built.** All eight steps landed. Ten anchor rows added to section 0, and no sealed row moved.
-Eight of the ten landed with the first pass; `issue/prompt-none-refusal` and
+**As built.** All eight steps landed. Thirteen anchor rows added to section 0, and no sealed row
+moved. Eight landed with the first pass; `issue/prompt-none-refusal` and
 `test/prompt-none-login-required` landed with decision 16's answer, which is also what put a second
-outcome in step 2 and a row in each of step 5's and step 7's tables. Five things worth naming beyond
-the steps.
+outcome in step 2 and a row in each of step 5's and step 7's tables; and
+`issue/prompt-none-clear-first`, `test/prompt-none-clear-committed` and
+`test/prompt-none-context-cleared` landed with round 2's fix, which put a second row in each of those
+same two tables. Six things worth naming beyond the steps.
 
 1. **The empty-sid finding is the stage, not a detail of it.** The sketch's predicate, "resolves to no
    session row", never fires on the path gap 3's second half actually takes, because
@@ -2356,6 +2373,14 @@ the steps.
    that, and the shape of the fix is worth keeping: the branch is keyed on the prompt rather than
    replacing the restart, so the interactive outcome decision 6 chose is untouched. Mutations 7 and 8
    in the run log are the two ways to get that wrong, and their failure sets are disjoint.
+6. **The refusal's two calls had to be in the other order, and no tier could see it until round 2
+   said so.** `ClearAuthContext` persists through a `Set-Cookie`, and every response mode of
+   `redirToClientWithError` commits the response, so the clear the branch promised never reached the
+   browser. The unit row asserted that the mock was called, which the wrong order satisfies, and the
+   integration ceremony stopped at the first error response, which the wrong order also satisfies.
+   Both were extended to observe the committed response rather than the call: `rr.Result()` at the
+   unit tier, and a replayed `/auth/issue` on the same cookie jar at the integration tier. Mutation 9
+   is the old order, and it fails exactly those two assertions and nothing else.
 
 ### Stage 7: reaping unused revoked codes
 Status: **Not started**
@@ -3347,6 +3372,98 @@ verdict no longer describes this tree. Stage 6 goes back through review for roun
 diff, as decision 15's answer did at stage 5, and the code commit follows that. This agreement is
 committed now, carrying decision 16 `Decided` and this entry.
 
+### Stage 6 round 2, 2026-08-05: the clear that reached nothing
+
+**The review.** `codex`, request `129-20260805T172848Z`, all three axes `reviewed`. It re-ran
+`TestHandleIssueGet` at the unit tier and `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired` at
+the integration tier on all four engines, built `site` at 42 pages, ran `check-anchors.sh` at 74 rows,
+`git diff --check` and `gofmt -l`, and verified the diff hash afterwards. It also wrote a scratch
+reproduction against the real `CookieStore` and `AuthHelper`, which is what produced its finding.
+Not re-run, and stated by it: the untouched data method and the broad integration suite, which round
+1 had verified on the same code across all four engines.
+
+**Found sound, so a later round does not re-derive it.** Decision 16 option A's outcome selection:
+the branch is keyed on `authContext.HasPromptValue("none")` and the two interactive rows still restart
+level 1; the error code, description, redirect URI and state match `handlePromptNone`'s own no-session
+response; no code is minted on either outcome; a lookup error is still a 500 rather than a refusal;
+the shared description creates no new termination oracle; nothing new is logged or returned; mutations
+7 and 8 have complementary failure sets; and the documentation is accurate.
+
+**One finding, conformance, `significant`, `needs_human`. Confirmed against the code and fixed inside
+the stage.**
+
+> The branch writes the client response before `ClearAuthContext` saves the clearing cookie, so the
+> `Set-Cookie` never reaches the browser and it retains an auth context in `ready_to_issue_code`,
+> although decision 16 requires the cleanup.
+
+Verified rather than accepted, on three facts read from the source. `AuthHelper.ClearAuthContext`
+persists the deletion only through `sessionStore.Save(r, w, sess)`, which writes a header.
+`redirToClientWithError` commits the response in all three response modes, `http.Redirect` for query
+and fragment and `t.Execute(w, m)` for `form_post`. And Go snapshots the header map at the status
+line, in `net/http` and identically in `httptest.ResponseRecorder`, so a header set afterwards is
+dropped. The two tests could not see it: the unit row asserted that the mock was called, which the
+wrong order satisfies, and the integration ceremony stopped at the first error response, which the
+wrong order also satisfies.
+
+**Fixed rather than escalated, and the distinction from decision 16 is the point.** Decision 16 was a
+question decision 6 had already answered the other way, so overriding it was the user's call. This is
+not a question at all: it is decision 16's own answer failing to take effect, and the ordering is
+forced by the same function's success path, which has cleared before `issueAuthCode` since long
+before #129. `issue/prompt-none-clear-first` is the clear moved ahead of the response, with the 500
+on a failed clear now preceding any client response rather than following one.
+
+**Both tests were extended to observe the committed response rather than the call**, which is the
+seam the finding actually exposed. `test/prompt-none-clear-committed` gives the `ClearAuthContext`
+stub a `Run` that writes a sentinel `Set-Cookie` and asserts it survives into `rr.Result()`, the only
+view that distinguishes the orderings since `rr.Header()` shows it either way.
+`test/prompt-none-context-cleared` requests the same `/auth/issue` a second time on the same cookie
+jar and asserts the account profile rather than a second answer to the client.
+
+**Tiers, re-run in full on the fixed tree rather than narrowed to the change.** Modules green on all
+three modules. Data green on all four engines run separately, `TestRevokeCodeIfSessionGone` and its
+transaction sibling passing on each. Integration green on **all four engines**, 889 passing test lines
+per engine and zero `FAIL`, with all four `session_deletion_test.go` ceremonies passing once per
+engine. `check-anchors.sh` passes all **77** rows, three added for this fix. `gofmt -l` silent,
+`git diff --check` clean.
+
+**Mutation evidence, one more mutation, applied to the real code, run at two tiers, and reverted.**
+
+9. **The two calls swapped back**, which is the tree round 2 reviewed. At the unit tier exactly the
+   `prompt=none` row failed, on the committed `Set-Cookie` being empty, and no other row moved. At the
+   integration tier on sqlite exactly `TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired`
+   failed, and it failed by printing the finding: the replayed `/auth/issue` answered
+   `...?error=login_required&error_description=User+authentication+is+required&state=...` a second
+   time instead of the account profile. `TestSessionEndedOnConsentScreen_NoCodeIsIssued` and
+   `TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession` stayed green.
+
+**One follow-up, and it is the finding's real extent.** Chasing the ordering across the repository
+found the same inversion at **seven** pre-existing call sites, in `handler_authorize.go` twice
+(including `handlePromptNone`'s own `redirectWithError`, so every silent refusal), in
+`handler_auth_completed.go` twice, in `handler_consent.go` twice, and at `HandleIssueGet`'s
+`id_token_hint` mismatch. The success paths in the same files have it right, which is what makes it a
+copied idiom: #129's branch was written the wrong way round precisely by copying the `id_token_hint`
+one beside it. Drafted as follow-up 4 with all seven sites and the labels, and deliberately not fixed
+here: each site needs its own reachability analysis, and #129 is session termination rather than
+response-ordering hygiene. Stage 6's step 2 no longer claims to copy that branch.
+
+**Worth stating so a later round does not read it as an inconsistency.** After this fix, `/auth/issue`
+clears the context on its silent refusal and `handlePromptNone` does not clear it on the byte-identical
+refusal one hop earlier. Decision 16's indistinguishability claim is about what the **client** receives,
+which is unchanged; the difference is in the browser's cookie, and `/auth/issue` is the side that is
+correct. `handlePromptNone` is site 2 of follow-up 4.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its sixteen items, all
+`Decided`. Section 9 now has four follow-ups.
+
+**A third round, deliberately, and the reasoning is recorded because reviewer.md caps a gate at two.**
+That cap is on rounds of *disagreement*, and no finding at this gate has been contested: round 1's was
+accepted and became decision 16, round 2's was accepted and is fixed above. What the two rounds
+actually show is that this gate keeps finding real defects, both of them in the same branch and
+neither visible to the tiers as they stood. Committing on "the fix is obvious" after that, with no
+reviewer having seen the fix, is the failure mode an unattended run is most likely to reach. The wall
+clock is 24 of 240 minutes, so the round is affordable. If round 3 is clean the stage commits; if it
+finds something, that is the answer to whether the cap should have applied.
+
 ---
 
 ## 8. Deferred decisions
@@ -3364,9 +3481,10 @@ absent section reads the same as a forgotten one.
 
 ## 9. Follow-ups
 
-The first two were found while grounding, the third while building stage 5. All three are verified
-against code, all three are outside this change under section 2, and none is a way to avoid work #129
-owes. The run appends here as it finds more, and never files anything.
+The first two were found while grounding, the third while building stage 5, and the fourth at stage
+6's second review round. All four are verified against code, all four are outside this change under
+section 2, and none is a way to avoid work #129 owes. The run appends here as it finds more, and
+never files anything.
 
 1. **A code insert can still land between a termination's `UPDATE` and its `COMMIT`.**
    `bug`, `security`, `go`. Found while settling decision 12. Status: **Drafted**
@@ -3481,3 +3599,66 @@ owes. The run appends here as it finds more, and never files anything.
    and the new session records `pwd otp`. Clearing the inherited methods when the ceremony no longer
    has the session it inherited them from looks like the fix, but it is a claim-semantics change and
    wants its own decision.
+
+4. **Every error response to a client clears the auth context after the response is already
+   committed, so the clear reaches nothing.**
+   `bug`, `security`, `go`. Found at stage 6 round 2. Status: **Drafted**
+
+   `ClearAuthContext` persists the deletion only by writing a `Set-Cookie` through
+   `sessionStore.Save(r, w, sess)`. `redirToClientWithError` commits the response in all three
+   response modes, `http.Redirect` for query and fragment and `t.Execute(w, m)` for `form_post`, and
+   Go snapshots the header map when the status line is written. Every call site orders the two the
+   wrong way round, so the browser keeps the auth context the code believes it deleted.
+
+   **Seven sites, each read rather than inferred**, all of the shape `redirToClientWithError(...)`
+   then `authHelper.ClearAuthContext(w, r)`:
+
+   - `handler_authorize.go`, `HandleAuthorizeGet`'s local `redirToClientWithError` closure, which
+     every request-validation failure goes through.
+   - `handler_authorize.go`, `handlePromptNone`'s `redirectWithError` closure, which every silent
+     refusal goes through, `login_required` included.
+   - `handler_auth_completed.go`, the disabled-user refusal, and the no-authorized-scopes refusal.
+   - `handler_consent.go`, both consent-denied refusals.
+   - `handler_auth_issue.go`, the `id_token_hint` subject mismatch.
+
+   The success paths have it right, which is what makes this look like an idiom rather than a
+   decision: `HandleIssueGet` clears before `issueAuthCode`, and `handleImplicitFlow` clears before
+   `issueImplicitTokens`. #129's own `issue/prompt-none-clear-first` was written the wrong way round
+   for exactly that reason, by copying the `id_token_hint` branch beside it, and its fix is the
+   evidence this behaves as described: with the calls reversed, a replayed `/auth/issue` on the same
+   cookie jar answered the client `login_required` a second time from a context still reading
+   `ready_to_issue_code`, and reversing them back sent it to the account profile instead. That is
+   `test/prompt-none-context-cleared` under mutation 9 in section 7.
+
+   **No bypass is claimed, and each site needs its own analysis**, which is the reason this is one
+   issue rather than seven and is out of scope here under section 2. What is demonstrable is that a
+   defensive cleanup silently does nothing everywhere it is written, and that one of the seven leaves
+   a context in `ready_to_issue_code`, the state that mints codes, with nothing but the re-run of the
+   same checks between it and a replay.
+
+   Searched `gh issue list --state open --search "id_token_hint"`,
+   `--search "ClearAuthContext cookie"` and the full open list of 33: nothing covers it. #109 and
+   #133 are the nearest neighbours and are both about session binding rather than response ordering.
+
+   **Body:** `AuthHelper.ClearAuthContext` deletes the auth context from the cookie session and
+   persists that deletion through `sessionStore.Save(r, w, sess)`, which writes a `Set-Cookie`
+   header. Seven handlers call it immediately *after* `redirToClientWithError`, which has already
+   committed the response: `http.Redirect` for the query and fragment response modes, and
+   `t.Execute(w, m)` for `form_post`. Go snapshots the header map when the status line is written, so
+   the `Set-Cookie` is dropped and the browser keeps the auth context.
+
+   The sites are `HandleAuthorizeGet`'s validation-error closure and `handlePromptNone`'s
+   `redirectWithError` closure in `handler_authorize.go`; the disabled-user and no-authorized-scopes
+   refusals in `handler_auth_completed.go`; both consent-denied refusals in `handler_consent.go`; and
+   the `id_token_hint` subject mismatch in `HandleIssueGet`. The success paths in the same files do it
+   in the right order, clearing before writing the response, so this reads as a copied idiom rather
+   than an intended difference.
+
+   No bypass is claimed for any single site: replaying a retained ceremony re-runs the same checks.
+   The defect is that a cleanup written seven times never happens, and that the `id_token_hint` site
+   leaves the browser holding a context in `ready_to_issue_code`. The fix is to clear before writing
+   the response at each site, returning a 500 if the clear fails rather than committing a client
+   response that cannot be recorded. A mock expectation cannot catch a regression here, since it
+   proves only that the method was called; the assertion has to read the committed response, either
+   `httptest.ResponseRecorder.Result()` at the unit tier or a second request on the same cookie jar at
+   the integration tier.

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,10 +5,11 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** blocked on decision 15, 2026-08-05. Stages 1 to 4 done, so the behaviour change has
-landed. Stage 5, the `/auth/completed` gate, is implemented and reviewed but **uncommitted**: round 1
-found a blocking security finding, the run confirmed it against the code, and the question it raises is
-decision 15, escalated on PR #138. The run resumes when that is answered.
+**Run state:** stage 5 awaiting review round 2, 2026-08-05. Stages 1 to 4 are committed. Decision 15
+was answered on PR #138 ("Let's go with option A"), and stage 5 now carries that answer: the gate reads
+a dedicated level 1 proof on the `AuthContext` rather than `AuthenticatedAt`. Still **uncommitted**,
+because the gate has not passed a review round since it changed. Modules and integration are green on
+the amended tree.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -107,8 +108,12 @@ log can cite it the same way. Nothing above the line changed.
 | `test/terminate-offline-endpoint` | `src/authserver/tests/integration/api_users_sessions_test.go` | `TestAPIUserSessionDelete_TerminatesTheOfflineGrantsOfThatSession` | `THE SURVIVOR IS THE HALF THAT CARRIES THIS TEST` | stage 4, seam 8's headline claim and its same-user control |
 | `test/second-offline-grant` | `src/authserver/tests/integration/credential_change_revocation_test.go` | `secondOfflineGrantForSameUser` | `func secondOfflineGrantForSameUser(t *testing.T, base *offlineGrant, password string) *offlineGrant {` | stage 4, the one new harness helper |
 | `test/logout-revokes-nothing` | `src/authserver/tests/integration/api_account_logout_request_test.go` | `TestLogout_WithIdTokenHint_RevokesNoGrants` | `logout must revoke nothing, decision 3` | stage 4, decision 3 pinned |
-| `completed/level1-restart` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `if !userReallyAuthenticated {` | stage 5, decision 6's gate, inside the else branch and ahead of `completed/start-new-session` |
-| `test/completed-gate` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and this ceremony did not authenticate, restarts level 1"` | stage 5, the gate's own row; the zero-time sibling sits directly below it |
+| `completed/level1-restart` | `src/authserver/internal/handlers/handler_auth_completed.go` | `HandleAuthCompletedGet` | `if !authContext.Level1AuthCompleted {` | stage 5, decision 6's gate, inside the else branch and ahead of `completed/start-new-session`. **Locator re-swept when decision 15 was answered**, which replaced the `userReallyAuthenticated` predicate this row used to cite |
+| `test/completed-gate` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and this ceremony did not authenticate, restarts level 1"` | stage 5, the gate's own row; `test/completed-gate-otp` sits directly below it |
+| `authcontext/level1-proof` | `src/core/oauth/auth_context.go` | `n/a` | `Level1AuthCompleted bool` | stage 5, decision 15 option A's field, next to the `AuthenticatedAt` it deliberately does not reuse |
+| `pwd/level1-proof` | `src/authserver/internal/handlers/handler_auth_pwd.go` | `HandleAuthPwdPost` | `authContext.Level1AuthCompleted = true` | stage 5, the only writer of that field |
+| `test/completed-gate-otp` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("No valid session and only OTP authenticated this ceremony, restarts level 1"` | stage 5, decision 15's unit row, the one that fails against the round 1 gate |
+| `test/otp-alone-no-recreate` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession` | `"the ended session must not be recreated by a ceremony that only verified OTP")` | stage 5, decision 15's integration case, paired with `test/fresh-ceremony-after-delete` in the same file |
 
 Counts in this document carry their command:
 
@@ -426,14 +431,15 @@ Verified as owing nothing, stated because silence reads the same as forgetting:
 
 ## 3. Open questions and decisions
 
-Fifteen items, one of them `Open`. Opened at eleven; decision 4's reversal onto a code-level marker
+Fifteen items, all `Decided`. Opened at eleven; decision 4's reversal onto a code-level marker
 exposed a residual at `/auth/issue` that the registry design did not have, which is item 12. The
 reconciliation pass of 2026-08-04 added two more: tracing which endpoints the "End session" buttons
 reach found that interactive logout writes nothing to the database (item 13), and the four-surface
 documentation sweep found three confirmation modals whose copy this change makes incomplete (item 14).
 Item 15 was raised by the run during stage 5, when the code review found that decision 6's gate is
-satisfied by OTP alone; it is the only `Open` item and it halts the run. Numbers are never reused, and
-decision 4 records its own reversal rather than being rewritten silently.
+satisfied by OTP alone; it halted the run until the user answered it on PR #138 on 2026-08-05, and it
+keeps the question it was escalated with rather than being trimmed to its answer. Numbers are never
+reused, and decision 4 records its own reversal rather than being rewritten silently.
 
 1. **All three gaps land in #129, with gap 2 staged last.** Status: **Decided** Raised by: user
 
@@ -1052,12 +1058,35 @@ decision 4 records its own reversal rather than being rewritten silently.
     established convention here, where identical strings like "End session" and "Are you sure?" each
     carry three per-surface keys. Mixing a shared key into a per-surface scheme is what review flags.
 
-15. **Does decision 6's gate require level 1 authentication in this ceremony, or is OTP enough?**
-    Status: **Open** Raised by: reviewer, raised during stage 5
+15. **Level 1 in this ceremony is required. A dedicated proof on the `AuthContext` carries it.**
+    Status: **Decided** Raised by: reviewer, raised during stage 5
 
-    Escalated on PR #138. The run cannot answer it: decisions.md never auto-resolves anything in
-    authentication or session territory, and reviewer.md never lets the run alone settle a security
-    finding.
+    Answered by the user on PR #138, 2026-08-05, in full: "Let's go with option A." That is option A
+    below, the recommended one, taken over B, C and D with no amendment, so the run applied it as
+    written: a new field on the `AuthContext` set only by `pwd/level1-proof`, read by the gate at
+    `completed/level1-restart`, with `AuthenticatedAt` keeping its existing job of deciding whether to
+    refresh the session's `AuthTime` on a step-up.
+
+    What the answer settles, beyond the gate expression: the two sealed passages that disagreed are
+    reconciled in section 1's favour, so **the discriminator is level 1 authentication in this
+    ceremony**, and decision 6's supporting note calling both `AuthenticatedAt` writers "real
+    authentication" is true of the field but not of the gate. Section 5's seam 6 table grew two rows
+    and one integration case landed in `session_deletion_test.go`, as option A's costing said it
+    would.
+
+    **What lost.** B, the liveness read in the OTP handler, on the reasoning in its bullet: it leaves
+    the gate reading a field that does not mean what it says and puts the reasoning in two handlers.
+    C, accepting the limit, which the run did not recommend because the enrollment sub-case makes it a
+    fail-open reachable with a stolen cookie alone. D, a follow-up, ruled out rather than weighed.
+
+    The question as it was escalated is kept below, because the reasoning is what makes the answer
+    reviewable.
+
+    ---
+
+    **The original question.** Escalated on PR #138. The run could not answer it: decisions.md never
+    auto-resolves anything in authentication or session territory, and reviewer.md never lets the run
+    alone settle a security finding.
 
     **The question.** Decision 6 fixes the gate as `!hasValidUserSession && !userReallyAuthenticated`,
     and stage 5 shipped exactly that, reading `completed/really-authenticated`. But
@@ -1820,7 +1849,10 @@ stated reason.
 
 ### Stage 5: the `/auth/completed` gate
 Status: **In progress**
-Seams: 6 (`HandleAuthCompletedGet`, in the existing `handler_auth_completed_test.go`).
+Seams: 6 (`HandleAuthCompletedGet`, in the existing `handler_auth_completed_test.go`), plus, per
+decision 15's answer, one assertion each in the existing `handler_auth_pwd_test.go` and
+`handler_auth_otp_test.go` subtests, which are the only seams that can see who writes the new field.
+Named in step 6 with the reasoning, since section 5 does not enumerate them.
 Tiers: unit (three modules) and integration (dev container). Data not applicable: no query, no
 migration, no interface method, no model change.
 Docs: the first of the two sentences held back from stage 4's concepts section, that a ceremony in
@@ -1828,9 +1860,15 @@ flight cannot complete into a recreated session.
 
 Decision 6's first half. The else branch of `HandleAuthCompletedGet` reaches
 `completed/start-new-session` today with no proof anyone authenticated; after this stage it reaches it
-only when this ceremony did. The discriminator is already computed at
-`completed/really-authenticated` and is consulted only inside the valid-session branch, where it
-decides whether to refresh `AuthTime`.
+only when this ceremony performed level 1.
+
+> **Amended on 2026-08-05, after decision 15 was answered.** The stage as first written read the
+> discriminator off `completed/really-authenticated`, which the handler already computes and consults
+> only inside the valid-session branch. Round 1 of the code review found that `AuthenticatedAt` has two
+> writers, so OTP alone satisfied that predicate, and the user answered decision 15 with option A: a
+> dedicated level 1 proof on the `AuthContext`. Step 6 below is that answer, steps 1 to 3 are amended
+> where it changed them, and the amendments are marked rather than absorbed because the run log's first
+> stage 5 entry describes the earlier version.
 
 **The integration tier is an addition to the sketch, and `test/fresh-ceremony-after-delete` is the
 reason.** The sketch said unit only and left the integration run to stage 6. Expanding against the
@@ -1849,39 +1887,54 @@ into `StartNewUserSession`; it is verified and drafted as follow-up 3 in section
 
 1. **The gate, at the top of the else branch in `HandleAuthCompletedGet`.** Status: **Done**
    Landed at `completed/level1-restart`, inside the else branch as written.
-   When `!userReallyAuthenticated`, set `AuthStateRequiresLevel1`, save the auth context, redirect to
-   `/auth/level1` and return, before `completed/start-new-session` is reached. Inside the else branch
-   rather than above `if hasValidUserSession`, because `hasValidUserSession` is already false there,
-   so the gate reads as the one condition it adds and the SSO branch is visibly untouched.
+   When `!authContext.Level1AuthCompleted`, set `AuthStateRequiresLevel1`, save the auth context,
+   redirect to `/auth/level1` and return, before `completed/start-new-session` is reached. Inside the
+   else branch rather than above `if hasValidUserSession`, because `hasValidUserSession` is already
+   false there, so the gate reads as the one condition it adds and the SSO branch is visibly untouched.
    Carries the comment decision 6 asks for, three things a later reader needs: that the predicate is
-   deliberately "this ceremony authenticated" rather than "no valid session", because
+   deliberately "this ceremony did level 1" rather than "no valid session", because
    `test/fresh-ceremony-after-delete` is #46's guard over a legitimate case with the second shape;
-   that there is no loop, since the second pass has `AuthenticatedAt` set by `pwd/authenticated-at`;
-   and that `handlePromptNone` is the fragile neighbour, because it *does* set `AuthenticatedAt` from
-   the session it reused and only its current call graph, straight to `/auth/issue` without passing
-   here, keeps the discriminator meaning what it says.
-2. **The two comments this stage falsifies.** Status: **Done**
-   `pwd/authenticated-at` and the OTP handler's matching write both say `AuthenticatedAt` is "used by
-   handler_auth_completed to decide whether to refresh the session's AuthTime". After this stage it
-   also decides whether a session may be created at all, which is the stronger consumer and the one a
-   later reader must not delete by accident. Same class and same reasoning as stage 1's finding 1: the
-   stage that falsifies a comment owns fixing it, because the alternative hands the next reader a
-   wrong contract.
+   that there is no loop, since the second pass has `Level1AuthCompleted` set by `pwd/level1-proof`;
+   and that `handlePromptNone` also sets `AuthenticatedAt`, from the session it reused, so a gate on
+   that field would be satisfied by a ceremony that authenticated nothing.
+   **Amended per decision 15:** the predicate was `!userReallyAuthenticated` as first shipped. The
+   comment gained the reason the field it reads is not the one the handler already computes, and the
+   `handlePromptNone` note flipped direction: under option A that neighbour would be *stopped* by this
+   gate rather than let through, so it is no longer load-bearing fragility.
+2. **The comments this stage falsifies.** Status: **Done**
+   **Amended per decision 15, and the amendment reverses this step's direction.** As first shipped it
+   widened the comments at `pwd/authenticated-at` and its OTP twin to say `AuthenticatedAt` also
+   decides whether a session may be created. Under option A that is false: the gate does not read that
+   field. Both comments are back to their original claim, which is accurate again, and each gained the
+   fact a later reader actually needs. `pwd/level1-proof` says it is the only writer of the level 1
+   proof and why; the OTP handler says it deliberately does **not** set it, because a ceremony can
+   reach OTP by reusing a session rather than by entering a password. That second comment is the one
+   that stops a future reader tidying away the asymmetry, and `handler_auth_otp_test.go` pins it.
+   The third comment, at `completed/really-authenticated`, is the one this stage really did falsify:
+   it claimed the field is "set by the password handler", which is what made this defect easy to
+   reach. It now names both writers and says the field is not proof of level 1.
 3. **Unit cases at seam 6.** Status: **Done**
-   Landed at `test/completed-gate` and its zero-time sibling, with the three positive controls
+   Landed at `test/completed-gate` and `test/completed-gate-otp`, with the three positive controls
    amended. Every row below shipped and was executed.
    In `TestHandleAuthCompletedGet`, extending it rather than adding a sibling, on the same strict mock
    quartet its ten subtests already use. Expectations written before running them:
 
    | Case | Expected | Which gate rejects it, or what it proves |
    |---|---|---|
-   | no valid session, `AuthenticatedAt` nil, which is the terminated-SSO shape | 302 to `/auth/level1`, the saved context reading `requires_level_1`, and `StartNewUserSession` never called | decision 6's gate. "Never called" is enforced rather than asserted: the strict mock carries no `StartNewUserSession` expectation, so reaching it fails the case on its own, and neither audit event is stubbed either |
-   | no valid session, `AuthenticatedAt` non-nil but the zero time | 302 to `/auth/level1` | the `!IsZero()` term of `completed/really-authenticated`. A gate written as `AuthenticatedAt == nil` passes this row, which is the only thing that catches that spelling |
-   | the three existing subtests reaching `StartNewUserSession` gain a non-nil `AuthenticatedAt` | outcomes unchanged: 302 to `/auth/issue` or `/auth/consent`, `StartNewUserSession` called with the same arguments | **keep these as the positive control.** They are `test/fresh-ceremony-after-delete`'s shape at the unit tier, session gone and the user really authenticated, and they fail against a gate keyed on the session alone. This is the non-additive cost section 1 recorded |
-   | the three existing subtests with a valid session and `AuthenticatedAt` nil, untouched | unchanged: SSO reuse still bumps and proceeds | the gate is confined to the else branch. These are the rows that fail if it is hoisted above `if hasValidUserSession`, which is the natural-looking tidy-up |
+   | no valid session, nothing authenticated this ceremony, which is the terminated-SSO shape | 302 to `/auth/level1`, the saved context reading `requires_level_1`, and `StartNewUserSession` never called | decision 6's gate. "Never called" is enforced rather than asserted: the strict mock carries no `StartNewUserSession` expectation, so reaching it fails the case on its own, and neither audit event is stubbed either |
+   | no valid session, `AuthenticatedAt` set by the OTP handler, `Level1AuthCompleted` false | 302 to `/auth/level1` | **decision 15's row, and the only one that fails against the gate as first shipped.** A gate reading `userReallyAuthenticated` recreates the session here. Its `AuthMethods` is `pwd otp`, off the reused session, because that is the shape the five hops in decision 15 produce |
+   | the three existing subtests reaching `StartNewUserSession` gain `Level1AuthCompleted` and a non-nil `AuthenticatedAt` | outcomes unchanged: 302 to `/auth/issue` or `/auth/consent`, `StartNewUserSession` called with the same arguments | **keep these as the positive control.** They are `test/fresh-ceremony-after-delete`'s shape at the unit tier, session gone and the user really did level 1, and they fail against a gate keyed on the session alone. Both fields are set because `pwd/level1-proof` sets both, so the row stays a shape the code can actually produce. This is the non-additive cost section 1 recorded |
+   | the three existing subtests with a valid session and nothing authenticated, untouched | unchanged: SSO reuse still bumps and proceeds | the gate is confined to the else branch. These fail if it is hoisted above `if hasValidUserSession`, which is the natural-looking tidy-up |
+   | the existing re-auth subtest: valid session, `AuthenticatedAt` set, `Level1AuthCompleted` false, untouched | unchanged: bumps, refreshes `AuthTime`, proceeds | the legitimate step-up by OTP on a live session, which option A must not disturb. It was already in the file and needed no amendment, and it is the fourth row that fails if the gate is hoisted |
 
-   No new audit event, no new mock method and no new fixture: the gate reads a field the handler
-   already computes and writes a state the router already knows.
+   **Amended per decision 15.** The zero-time `AuthenticatedAt` row was replaced by the OTP row rather
+   than kept beside it. It existed to pin the `!IsZero()` spelling of a discriminator this gate no
+   longer reads, and the OTP row catches the same mistake, a gate falling back to `AuthenticatedAt`,
+   through a shape the code can actually reach. `userReallyAuthenticated`'s own `!IsZero()` term is
+   pre-existing and still covered by the re-auth subtest, which is where it belongs.
+
+   No new audit event, no new mock method and no new fixture: the gate reads one bool off the auth
+   context and writes a state the router already knows.
 4. **The docs sentence, in `concepts/user-sessions.mdx`.** Status: **Done**
    Into the `## Ending a session` section stage 4 created, and limited to what is true after this
    commit: a sign-in that was riding on the ended session cannot quietly become a replacement session.
@@ -1889,26 +1942,60 @@ into `StartNewUserSession`; it is verified and drafted as follow-up 3 in section
    `/auth/issue` is stage 6 and stays open until then. `reference/security.mdx`'s durable-termination
    bullet is checked and needs no edit: it summarises what termination revokes and claims nothing
    about ceremonies.
+   **Unchanged by decision 15, and worth stating rather than passing over.** The paragraph says the
+   sign-in that cannot become a replacement session is one that was "relying on the session you ended
+   rather than typing a password". That is option A's predicate in plain words. Under the gate as first
+   shipped it was slightly generous, since a step-up that typed an OTP and no password also passed, so
+   the answer made the shipped sentence true rather than obliging an edit.
 5. **Verify.** Status: **Done**
    `check-anchors.sh`, then `where.sh test --type modules` and `where.sh test --type integration`, the
    latter for the reason stated above. Both in the foreground.
+   Re-run in full after decision 15's answer landed, plus the five mutations recorded in the run log,
+   including one at the integration tier: the gate as first shipped reddens
+   `test/otp-alone-no-recreate` and leaves `test/fresh-ceremony-after-delete` green.
+6. **Decision 15's answer: the dedicated level 1 proof.** Status: **Done**
+   Added after the user chose option A on PR #138, so this step exists where the others were amended.
+   `authcontext/level1-proof`, a bool on the `AuthContext` beside the `AuthenticatedAt` it deliberately
+   does not reuse, carrying the comment a later reader needs: why the neighbouring field cannot answer
+   the question, that it is written only where level 1 happens, and that an older cookie unmarshals it
+   as false, which is the safe direction. Written at `pwd/level1-proof` and nowhere else.
+   Two assertions pin the writers, and they are the coverage section 5 does not enumerate, named here
+   rather than left to be noticed: `handler_auth_pwd_test.go`'s successful-authentication subtest
+   requires the field on the saved context, and `handler_auth_otp_test.go`'s two success subtests
+   require its **absence**. Seam 6 cannot reach either, since it stubs the auth context rather than
+   producing it, and testing.md section 8 asks for a case that fails when a decision is reversed. Both
+   are existing `SaveAuthContext` matchers in existing subtests, one line each, at handler seams
+   section 1 already named.
 
-**As built.** All five steps landed as written. Two anchor rows added, `completed/level1-restart` and
-`test/completed-gate`, and no sealed row needed re-sweeping: unlike stage 4 this stage replaces no
-cited call, it only adds a branch above one.
+**As built.** All six steps landed, the first five as written once decision 15's amendments are read
+into them. Six anchor rows added in total: `completed/level1-restart` and `test/completed-gate` when the
+stage was first built, then `authcontext/level1-proof`, `pwd/level1-proof`, `test/completed-gate-otp`
+and `test/otp-alone-no-recreate` when option A landed. One row needed re-sweeping,
+`completed/level1-restart`, because option A replaced the predicate it cites; no sealed row moved.
 
-Two things worth naming beyond the steps.
+Three things worth naming beyond the steps.
 
-1. **The predicted case table shipped unchanged**, which is rare enough in this run to say plainly.
-   Twelve subtests where there were ten, the two new ones passing and the three amended positive
-   controls passing with their original assertions, including the `StartNewUserSession` argument
-   expectations, because the handler overwrites `AuthenticatedAt` from the new session before saving
-   and the amendment therefore cannot be observed downstream of the gate.
-2. **The follow-up this stage found is recorded in section 9 rather than fixed here.** The restart
+1. **The predicted case table shipped unchanged when first built**, and decision 15's answer then
+   replaced one of its rows rather than adding one, so the file stays at twelve subtests where `main`
+   has ten (`grep -c 't.Run(' handler_auth_completed_test.go`). The three amended
+   positive controls still pass with their original assertions, including the `StartNewUserSession`
+   argument expectations, because the handler overwrites `AuthenticatedAt` from the new session before
+   saving and the amendment therefore cannot be observed downstream of the gate.
+2. **Option A widens the gate's reach beyond the ceremony that raised it**, which is the reason it was
+   recommended over the OTP-handler liveness read. Any future route arriving at `/auth/completed`
+   without a password, not only the OTP step-up, is stopped rather than let through, including
+   `handlePromptNone` if its call graph ever changed. The cost is the one the escalation named: an
+   honest user whose session expires mid-step-up enters a password once, which is arguably the correct
+   outcome anyway, and a ceremony already past the password form when the binary is replaced is sent
+   back to login once, because the field is absent from its cookie.
+3. **The follow-up this stage found is recorded in section 9 rather than fixed here.** The restart
    reuses the ceremony's `AuthContext`, which still carries the terminated session's `AuthMethods`, so
    a user who re-authenticates with a password alone can land a new session and a token claiming
    `otp`. Verified reachable, verified pre-existing, and deliberately not this stage's work: decision 6
    fixes what the restart preserves, and `amr` accuracy is neither in a goal nor in any decision.
+   Decision 15's answer does not change it, and narrows it slightly: the OTP step-up route now
+   restarts at level 1 rather than completing, so the stale `pwd otp` reaches a new session only after
+   the user really does enter a password, which is the shape follow-up 3 already describes.
 
 ### Stage 6: the `/auth/issue` liveness check and the compensating revoke
 Status: **Not started**
@@ -2490,7 +2577,10 @@ redirect validation, token validation, unrelated endpoint authorization and rate
 One finding, and it is the security axis.
 
 1. **OTP alone satisfies a gate meant to prove level 1 authentication.** `Raised by: reviewer`,
-   blocking, confidence high, `needs_human: true`. Status: **Open**
+   blocking, confidence high, `needs_human: true`. Status: **Resolved**
+   Resolved on 2026-08-05 by decision 15's answer, option A, applied in the stage 5 continuation entry
+   below. It read `Open` for the four hours the escalation was outstanding, which is what halted the
+   run.
 
    **Confirmed against the code**, not taken on the reviewer's word. `AuthenticatedAt` has two writers
    on the path to `/auth/completed`, and `handler_auth_otp.go` is the second one. The five hops are
@@ -2519,6 +2609,7 @@ One finding, and it is the security axis.
    cookie, option B adds a query to a second handler, and both are defensible, which is a choice and
    not a collision. Decision 15 carries the question, the options and the recommendation.
 
+
 **Where the stage got to, for whoever resumes.** All five steps are implemented and their code is
 **uncommitted**, deliberately: the gate expression is the subject of decision 15 and nothing resting on
 an `Open` decision gets committed. The working tree holds
@@ -2530,14 +2621,87 @@ re-establish that. What it needs to do is read the answer to decision 15 from PR
 OTP-after-termination row, add the `session_deletion_test.go` case if the answer is A or B, re-run
 modules and integration, and open round 2 at this gate.
 
+### Stage 5 continued, 2026-08-05: decision 15 answered
+
+**The answer.** The user replied on PR #138 with "Let's go with option A", the run's recommendation,
+unamended. Decision 15 is flipped to `Decided` with those words and with what the three rejected
+options lost on. Nothing else in the escalation needed interpreting: the options were fully stated in
+the comment and in section 3, so applying it was mechanical rather than a second judgement.
+
+**What landed on top of the earlier stage 5 tree.** `authcontext/level1-proof`, a bool on the
+`AuthContext` written only at `pwd/level1-proof`, and the gate at `completed/level1-restart` now reads
+it instead of `userReallyAuthenticated`. Three comments changed rather than two, and one of those
+changes is a reversal of what the first stage 5 pass did: the widened claim it put on both
+`AuthenticatedAt` writers was false under option A and is now back to its original, accurate wording,
+with the OTP handler additionally saying it deliberately does **not** set the level 1 proof. The
+comment at `completed/really-authenticated`, which claimed the field is "set by the password handler",
+is the one that really was falsified and now names both writers. Unit rows: the zero-time sibling was
+replaced by `test/completed-gate-otp`, the three positive controls carry the new field, and one
+assertion each was added to the existing `handler_auth_pwd_test.go` and `handler_auth_otp_test.go`
+success subtests to pin who writes it and who must not. Integration: `test/otp-alone-no-recreate`, the
+five-hop ceremony from decision 15 driven on one HTTP client. Four anchor rows added, one re-swept.
+
+**What changes for a user, beyond the first stage 5 entry.** A step-up that verifies OTP without a
+password no longer recreates a session that was ended mid-flight. The honest cost, accepted in the
+escalation: a user whose session expires while they are on the OTP form enters a password once. The
+legitimate step-up on a live session is untouched, because it takes the `hasValidUserSession` branch
+and never reaches this gate, which the pre-existing re-auth subtest pins.
+
+**Tiers, re-run in full on the amended tree, both in the foreground.** Modules green, all three
+modules, 2645 passing test lines, zero `FAIL`, `TestHandleAuthCompletedGet` still at 12 subtests where
+`main` has 10, since one row was replaced rather than added
+(`grep -cE "    --- PASS: TestHandleAuthCompletedGet/"` over the run's log). Integration green on **all four engines**, 4752 passing test
+lines, zero `FAIL`, with `test/otp-alone-no-recreate` and `test/fresh-ceremony-after-delete` each
+passing once per engine. `check-anchors.sh` passes all 63 rows and `gofmt -l` is silent on every file
+this stage touches. No data tier, still correctly: no query, no migration, no interface method, no
+model change. A field on a struct persisted as JSON in a cookie is not a persisted schema.
+
+**Mutation evidence, five mutations, each applied to the real code, run, and reverted in this
+session.** The failure sets are disjoint, which is the point, and mutation 1 is the one that answers
+decision 15.
+
+1. **The gate reverted to the round 1 predicate**, `if !userReallyAuthenticated`. Exactly one unit row
+   failed, `test/completed-gate-otp`. Run again at the integration tier on sqlite:
+   `test/otp-alone-no-recreate` failed with the ceremony landing on the client's redirect URI, so a
+   code was issued, and with one session row where it asserts zero, while
+   `test/fresh-ceremony-after-delete` and the three other `TestSession*` cases stayed green. That is
+   the defect reproduced end to end and the fix shown to close it.
+2. **The gate removed**, `if false`. Both no-session rows failed, and only those.
+3. **`pwd/level1-proof` dropped**, the field left false. `TestHandleAuthPwdPost/Successful
+   authentication` failed, and nothing else. Before step 6's assertion was added this mutation shipped
+   green at the unit tier, which is why the assertion is there: without it only the integration tier
+   notices, and it notices by every login looping back to the password form.
+4. **The OTP handler setting the proof**, which is the tidy-up option A invites. Both
+   `TestHandleAuthOtpPost` success subtests failed. This is the mutation that keeps the asymmetry from
+   being "corrected" by a later reader.
+5. **The gate hoisted above `if hasValidUserSession`.** Four valid-session subtests failed, one more
+   than under the round 1 gate, the extra being the re-auth case, which carries `AuthenticatedAt` with
+   no level 1 and is exactly the legitimate step-up option A must not break.
+
+**Deviations from the plan as written.** Two new ones, both named in the stage's amended steps. The
+seam 6 table lost a row rather than only gaining one, with the reasoning in step 3. And two assertions
+landed at seams section 5 does not enumerate, `handler_auth_pwd_test.go` and
+`handler_auth_otp_test.go`, because seam 6 stubs the auth context and so cannot see who writes the
+field; step 6 carries that reasoning. Both are one-line additions to existing matchers in existing
+subtests at handler seams section 1 named, not new files or new harnesses.
+
+**Nothing deferred, nothing contested, nothing new raised.** Section 3 is back to zero `Open` items.
+Follow-up 3 was re-checked against the answer and stands, slightly narrowed, which is recorded in
+section 9 and in the stage's as-built note.
+
+**Where the stage is now.** All six steps implemented, still **uncommitted**, because the gate changed
+after round 1 read it and no review round has seen the current tree. `.review/request.md` carries round
+2, whose ask is the whole stage 5 diff with the decision 15 answer applied. The tiers above were green
+on exactly that tree.
+
 ---
 
 ## 8. Deferred decisions
 
 Nothing deferred. Stages 1 to 5 met no question that was safe to postpone on a stated assumption: the
 one judgement call stage 5 made resolved under section 3 (recorded in its run log entry), and the one
-question stage 5 could not answer was a security finding, which reviewer.md forbids deferring. It is
-decision 15 in section 3, `Open`, and it halts the run rather than sitting here.
+question stage 5 could not answer was a security finding, which reviewer.md forbids deferring. That was
+decision 15, which halted the run rather than sitting here and was answered by the user on 2026-08-05.
 
 This section stays in the document even while empty, because the closing PR comment reports it and an
 absent section reads the same as a forgotten one.
@@ -2640,6 +2804,11 @@ owes. The run appends here as it finds more, and never files anything.
    Searched `gh issue list --state open --search "amr auth methods"` and the full open list: nothing
    tracks it. #133 is the closest neighbour and is a different mechanism, a live session belonging to
    another user rather than a dead session's methods surviving on the context.
+
+   **Re-checked after decision 15's answer, and it stands.** Option A narrows the reachable set rather
+   than closing it: the OTP step-up route now restarts at level 1 instead of completing, so the stale
+   `pwd otp` reaches a new session only once the user really has entered a password. That is exactly
+   the shape described above, so neither the body nor the reproduction changes.
 
    **Body:** An authorization ceremony that reuses an existing session copies that session's
    `AuthMethods` onto its `AuthContext` in `HandleAuthorizeGet`, and nothing clears the copy if the

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,8 +5,8 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** not started
-**PR:** none
+**Run state:** in progress, started 2026-08-04. Stage 1 done, stage 2 next.
+**PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
 work sits next to. #128 (closed) built the atomic refresh claim and family containment. #77
@@ -78,6 +78,17 @@ exists and will need reconciling against this document's section 3.
 | `schema/user-sessions` | `src/core/data/sqlitedb/schema.sql` | `n/a` | `CREATE TABLE user_sessions (` | documentation snapshot, not loaded by Go |
 | `test/fresh-ceremony-after-delete` | `src/authserver/tests/integration/session_deletion_test.go` | `TestSessionDeletedDuringAuthFlow_LoginSucceeds` | `assert.Equal(t, 1, len(userSessions2), "Should have a new session after second login")` | #46's regression guard; the case gap 3's fix must NOT break |
 | `test/completed-new-session` | `src/authserver/internal/handlers/handler_auth_completed_test.go` | `TestHandleAuthCompletedGet` | `t.Run("Successful flow, new session, consent not required", func(t *testing.T) {` | one of three subtests reaching `StartNewUserSession` with a nil `AuthenticatedAt` |
+
+Rows below this line were added **by the run**, for code the run created, so later stages and the run
+log can cite it the same way. Nothing above the line changed.
+
+| Label | File | Function | Locate by | Note |
+|---|---|---|---|---|
+| `model/code-revoked` | `src/core/models/code.go` | `n/a` | `// Revoked records that the session this code was issued through was explicitly` | stage 1, the marker field and its `dont-update` tag |
+| `db/revoke-codes-by-sid` | `src/core/data/commondb/code.go` | `RevokeCodesBySessionIdentifier` | `ub.Equal("session_identifier", sessionIdentifier),` | stage 1, the termination sweep |
+| `migration/000026` | `src/core/data/sqlitedb/migrations/000026_add_code_revoked.up.sql` | `n/a` | `ALTER TABLE codes ADD COLUMN revoked numeric NOT NULL DEFAULT 0;` | stage 1, one of four engines |
+| `test/revoke-codes-data` | `src/authserver/tests/data/code_test.go` | `TestRevokeCodesBySessionIdentifier` | `assertCodeRevoked(t, unrelated.Id, false, "a code of an unrelated session")` | stage 1, seam 1's negative control |
+| `test/migration-000026` | `src/authserver/tests/data/migration_000026_code_revoked_test.go` | `TestMigration000026_CodeRevoked` | `require.NoError(t, h.Migrator.Migrate(25), "roll back 000026")` | stage 1, the down migration case |
 
 Counts in this document carry their command:
 
@@ -1281,6 +1292,382 @@ an existing test file**, and the only new artefacts are two data methods.
 > **Obligation for the run.** Per section 5 of the testing reference, every table above is executed in
 > the scratchpad before it is written into section 6, and re-run after any revision. Counts are never
 > carried forward across a change.
+
+---
+
+## 6. Plan
+
+Eight stages, written by the run on 2026-08-04. The order is chosen so that no intermediate commit
+leaves the tree half live: the column and its sweep exist before anything rejects on them, rejection
+exists before anything writes the marker, and gap 2 lands last per decision 1 while still blocking
+the issue.
+
+**On the two unit test files section 1 says do not exist.** Neither
+`handler_api_users_sessions_test.go` nor `handler_api_account_sessions_test.go` exists, and section 1
+says "whichever stage touches those handlers creates the file". **Stage 4 creates both**, per section
+1, and the history is recorded because the first draft of this plan declined to.
+
+The first draft read section 5's "every seam here is an existing test file" as overriding section 1,
+and cited `testing.md`'s rule against testing at an unconfirmed seam. The plan review refuted that,
+and the refutation is right. Section 5 rejects **mock expectations as the only evidence for the new
+data methods** and rejects **a unit seam as the primary home for the helper's atomicity**. It rejects
+neither a handler test for handler-owned behaviour, and an HTTP handler is a public boundary that
+section 1 named explicitly, so the seam is confirmed rather than invented.
+
+What decided it is that decision 9's contract has no other home. Each handler must emit **both** audit
+events after the termination commits, and **neither** when it fails. The integration tier can observe
+the success half, since `api_settings_audit_logs_test.go` reads `GetAuditLogsPaginated` directly, but
+it cannot force the termination transaction to fail, so nothing there can prove the events are
+suppressed on failure. A mock-based handler test is the only seam that can. `revocation_test.go` still
+owns the transaction threading and seams 8 and 9 still own the observable token rejection, because the
+handler tests do not replace either. Precedent for the harness: `handler_api_account_password_test.go`
+and five siblings, over `test_main_test.go`.
+
+**The obligation above was met before this section was written.** Stage 1's tables were executed
+against all four engines first, and three of its rows changed as a result. What changed is recorded in
+the stage 1 entry of section 7.
+
+### Stage 1: the marker column and its sweep
+Status: **Done**
+Seams: 1 and 2, plus a migration test following the 000024 and 000025 precedent.
+Tiers: unit (three modules), data (four engines). Integration not applicable, no endpoint changes.
+Docs: none, internals only. Verified in section 2 that `CLAUDE.md` and `AGENTS.md` enumerate neither
+migrations nor the `codes` table, and no page on the docs site describes either.
+
+1. Migration `000026_add_code_revoked`, up and down, for all four engines. Types follow
+   `refresh_tokens.revoked` on each: sqlite `numeric`, mysql `tinyint(1)`, postgres `boolean`, mssql
+   `BIT`. Each declares `NOT NULL DEFAULT` false, and mssql names its default constraint
+   `df_codes_revoked` so the down migration can drop the constraint before the column, which is the
+   hazard 000024 documents. **No index**: the sweep is keyed on `session_identifier`, which
+   `idx_codes_session_identifier` from 000024 already covers, and stage 6's reaper scans by
+   `created_at`. Status: **Done**
+2. The four `schema.sql` snapshots gain the column, in the position the migration puts it (after
+   `used`). Documentation only, never loaded by Go. Status: **Done**
+3. `models.Code.Revoked` with `db:"revoked"` and `fieldtag:"dont-update"`, carrying the comment
+   decision 4 requires: an ordinary full-row `UpdateCode` must not be able to write the marker back
+   to false. Mirrors `Code.AuthStateGeneration`. Status: **Done**
+4. `RevokeCodesBySessionIdentifier(tx, sid) (int64, error)` in `commondb/code.go`, its declaration in
+   the `Code` block of `data/database.go`, the one-line wrapper in each of the four engine packages,
+   and regenerated mocks (`authserver/generate-mocks.sh`, run in the dev container). The predicate is
+   `session_identifier = ? AND revoked = false`, the assignment sets `revoked` and `updated_at`, and
+   the return is `RowsAffected`. An empty identifier returns an error rather than being used as a
+   filter. Status: **Done**
+5. `db/mark-code-used` gains `AND revoked = false`, with the comment section 4.3 requires: validation
+   and claiming are separate steps, so without this term a code revoked in between is still claimed.
+   The interface doc comment gains the same note. Status: **Done**
+6. Data cases at **seam 1**, in `code_test.go`, all four engines. Two tests: the sweep's table, and
+   the transaction and failure path a mock cannot answer for. The rows, all executed:
+
+   | Case | Expected | Which gate rejects it, or what it proves |
+   |---|---|---|
+   | two codes on session A, sweep A | count 2, both `Revoked` | the sweep reaches every code of the session |
+   | a code on unrelated session B | stays `Revoked = false` | the negative control; without it a method revoking the whole table passes |
+   | sweep A again | count 0, rows stay revoked | idempotent, and the count means rows transitioned |
+   | unknown identifier | count 0, no error | absence is not an error |
+   | empty identifier | error, nothing swept | the explicit guard, not the `=` predicate |
+   | sweep inside a transaction, then roll back | `Revoked = false` afterwards | it enlisted in the caller's transaction rather than the pool |
+   | sweep on the finished transaction | error, count 0 | the failure path does not collapse into a benign zero |
+
+   **Keep the unrelated-session row and the rolled-back row.** The first is the only case that fails
+   if the sweep is written session-wide by mistake, which would sign out every device of every user.
+   The second is the only case exercising the real implementation's transaction handling; every
+   mock-based test above it passes with the parameter ignored. Status: **Done**
+7. Data cases at **seam 2**, extending `TestMarkCodeAsUsed` rather than adding a sibling: a revoked
+   but unused code is **not** claimable, and stays unused afterwards. **Keep the existing
+   already-used row beside it**, since either row alone still passes with the other term deleted from
+   the predicate. Plus `TestUpdateCode_DoesNotClobberRevoked`, mirroring the four existing
+   `DoesNotClobber` tests, which is the only case that fails if the `dont-update` tag on the model
+   field is dropped. Status: **Done**
+8. `migration_000026_code_revoked_test.go`, following 000024 and 000025: the column is absent at
+   000025, is `NOT NULL` defaulting to false afterwards, a `codes` row that predates it lands
+   `revoked = false`, and the down migration then the re-apply are clean. The pre-existing row is
+   seeded through the ORM at 000026 and carried down to 000025 and back, rather than hand-written at
+   000025, which is what makes the case affordable: `codes` has twenty NOT NULL columns and foreign
+   keys into `clients` and `users`. Status: **Done**
+9. Verify: `check-anchors.sh`, then `where.sh test --type modules` and
+   `where.sh test --type data --db <each of the four>`. Status: **Done**
+
+### Stage 2: rejection at redemption and at refresh
+Status: **Not started**
+Detail: **sketch**
+
+Read the marker at the two sites decision 7 fixes, both from data already loaded, so neither adds a
+query: `codeEntity.Revoked` on the `authorization_code` path, placed after client-secret validation,
+after PKCE and after the `if wasReused` return, and `refreshToken.Code.Revoked` on the
+`refresh_token` path, placed after `validator/client-ownership`. Both carry the comment decision 7
+requires, explaining why the check sits apart from the checks in `validator/authcode-preauth` rather
+than joining them, or a reviewer tidies it back into the block that #137 exists to fix. Seam 5, whose
+four ordering rows are the only testable content of decision 7 and are what stop the drift: a wrong
+verifier, a wrong secret, a reused code and a wrong client each return their own error rather than
+the revoked-code error. Tier: unit. Docs: none, internals only, since nothing is user-visible until
+stage 3 writes a marker. Expand against stage 1's code.
+
+### Stage 3: the termination helper, uncalled
+Status: **Not started**
+Detail: **sketch**
+
+Deliberately inert: the helper exists and nothing calls it, so this commit changes no behaviour and
+owes no user-facing text. A helper in `revocation.go` modelled on `RevokeUserAuthStateTx`, performing
+decision 5's three writes in one transaction (`RevokeCodesBySessionIdentifier`, the sid-scoped refresh
+sweep through `db/refresh-by-sid` and `revoke/refresh-tokens`, then `DeleteUserSession`), returning
+the zero result on any error so a caller cannot audit a half-truth, and reporting the revoked code
+count and the transitioned JTIs decision 9's payload needs. Plus the new `terminated_user_session`
+constant and its entry in the audit event list in `constants.go`. Seam: `revocation_test.go`, which
+owns the transaction threading, the zero result on the error path, and that the three writes are
+issued in decision 5's order. Tier: unit. Docs: none, internals only, because nothing observable
+changes until stage 4 calls it.
+
+### Stage 4: both endpoints terminate, and everything that says so
+Status: **Not started**
+Detail: **sketch**
+
+The activation stage. It carries the endpoint calls **and** every piece of user-facing material about
+them, in one commit, so no deploy can perform the broader security action while a page or a modal
+still describes the narrower one. That pairing is the plan review's second finding and the reason
+stage 3 above is inert.
+
+`admin/session-delete` and `account/session-delete` call the helper, ownership still enforced on the
+account one, and each emits `AuditDeletedUserSession` unchanged plus `terminated_user_session` with
+decision 9's payload, both **after** the commit. Seams: the two new handler test files section 1 asked
+for, covering both events with their payload on success and **neither** event with a 500 on helper
+failure, which is the contract no other tier can reach; seam 8 for the headline claim (authorize with
+`offline_access`, terminate, refresh refused, paired with the assertion that an unrelated session
+still refreshes, without which the test passes against a change that revokes everything); seam 9 for
+both endpoints, the account one's 403, and pinning logout unchanged through request shapes #109 is not
+rewriting. Seam 10 for the catalog keys, which needs no new test code because
+`TestCatalog_ParityEnPtBR` and `TestCatalog_NoEmptyValues` already fail on a key in one catalog only
+or present and empty, and the step says so explicitly so the absence of new cases does not read as
+untested copy. Tiers: unit, integration.
+
+Docs, all of it here: the falsified sentences in `concepts/tokens.mdx`, a new ending-a-session section
+in `concepts/user-sessions.mdx`, both endpoints in `integration/rest-api.mdx`, a durable-termination
+bullet in `reference/security.mdx`, and decision 14's three keys in each catalog plus one `msg +=`
+line in each of `account_user_sessions.html`, `admin_users_sessions.html` and
+`admin_clients_usersessions.html`, placed before the `if (isCurrent)` append so the immediate-logout
+warning stays last and containing no double quote, since the string is interpolated into a JavaScript
+double-quoted literal. Two wordings, second person on the account page and third person on the two
+admin pages.
+
+**The new concepts section is limited to what is true when this lands**: what the two endpoints revoke
+(decision 2) and decision 11's limit, that an offline grant's access token keeps working until it
+expires. It must **not** yet claim that an in-flight ceremony cannot recreate the session, because
+that is stages 5 and 6, and documenting a fail-open path as closed is worse than documenting nothing.
+Those two sentences land with the stages that make them true.
+
+### Stage 5: the `/auth/completed` gate
+Status: **Not started**
+Detail: **sketch**
+
+Decision 6's first half: in `HandleAuthCompletedGet`, reach `completed/start-new-session` only when
+`!hasValidUserSession && !userReallyAuthenticated` is false, otherwise set `AuthStateRequiresLevel1`,
+save, and redirect to `/auth/level1`. The discriminator is already computed at
+`completed/really-authenticated` and today is consulted only in the branch where it does not matter.
+Carries the comment decision 6 asks for about `handlePromptNone` being the fragile neighbour. Seam 6,
+whose new row asserts the redirect and that `StartNewUserSession` is not called, and whose three
+existing subtests gain a non-nil `AuthenticatedAt`, which is the non-additive cost section 1 recorded.
+Tier: unit. Docs: the first of the two sentences held back from stage 4's concepts section, that a
+ceremony in flight cannot complete into a recreated session. Expand against stage 4's code.
+
+### Stage 6: the `/auth/issue` liveness check and the compensating revoke
+Status: **Not started**
+Detail: **sketch**
+
+Decision 6's second half plus decision 12. A liveness read at `/auth/issue`, placed **after** the
+implicit-flow branch so `handleImplicitFlow` is untouched and only `issue/create-code` is guarded:
+when the bound session identifier resolves to no session row, restart level 1 as in stage 5.
+Immediately after the insert, one compensating statement as a new data method on four engines,
+`UPDATE codes SET revoked = true, updated_at = ? WHERE id = ? AND NOT EXISTS (SELECT 1 FROM
+user_sessions WHERE session_identifier = ?)`, so a code that committed after the termination's sweep
+read `codes` is marked by the second sweeper. Seams 4 (the data method, whose "does nothing when a
+session exists" row is the one that matters, since a method that always revoked would pass every
+other assertion) and 7 (the liveness branch, extending `TestHandleIssueGet`). Tiers: unit, data,
+integration for the mid-flight ceremony on one HTTP client, plus the #46 guard still green, which is
+the pair proving decision 6 chose the right predicate rather than merely a strict one. Docs: the
+second sentence held back from stage 4's concepts section, the consent-screen window.
+
+### Stage 7: reaping unused revoked codes
+Status: **Not started**
+Detail: **sketch**
+
+Decision 8's one predicate extension, so a code revoked while still unredeemed does not accumulate
+forever: `revoked = true AND used = false AND created_at < cutoff`, which is safe with a short cutoff
+because an unused code has no refresh tokens by definition and is unredeemable after 60 seconds
+anyway. Seam 3, whose load-bearing row is the **retention** one: a revoked code with a live refresh
+token must survive, because decision 8's whole safety argument is that the marker outlives its
+descendants, and that row's value is invisible once the design is right. Tier: data, four engines.
+Docs: to confirm at expansion; the sweep of section 2 found no page describing the reapers, and
+`concepts/audit-log.mdx` points at `constants.go` rather than enumerating events.
+
+**Extend `DeleteUsedCodesWithoutRefreshTokens` itself. No second method and no second worker call.**
+The first draft of this sketch offered the choice, which reopened something the seal had settled:
+section 4.5 says one predicate is added, and seam 3 names the existing method extended. A new method
+would add an unconfirmed data seam plus an interface method, four wrappers, regenerated mocks and its
+own wiring in `worker/perform-task`. The method keeps its name, and its doc comment states the widened
+contract, since renaming it would touch the interface, four wrappers, the mocks and the call site for
+no behavioural gain.
+
+### Stage 8: gap 2's evidence
+Status: **Not started**
+Detail: **sketch**
+
+Gap 2 closes structurally in stages 1 and 2, since a rotated child inherits its parent's `code_id`
+and so is born already rejected. What is missing is the proof, and decision 1 requires it before the
+issue closes. An integration test mirroring `token_refresh_concurrent_test.go`'s harness: a grant
+whose refresh races a termination leaves no usable descendant, checked both ways round, the child
+issued before termination and the child issued after it, on an `offline_access` grant since a
+session-bound one already dies at `validator/session-branch`. Seam 8. Tier: integration. Docs: none
+unless the evidence contradicts what stage 3 documented, which would be a blocking decision rather
+than a docs edit. Staged last per decision 1.
+
+---
+
+## 7. Run log
+
+Append-only. The run started 2026-08-04T21:34:38Z, after an earlier start the same evening was
+aborted before any stage began.
+
+### Plan, 2026-08-04
+
+**Landed.** Section 6, eight stages, stage 1 in full and the rest as sketches. Five rows added to
+section 0 for the code stage 1 creates, below a line marking them as the run's rather than the seal's.
+Draft PR [#138](https://github.com/leodip/goiabada/pull/138) opened and recorded in the header.
+
+**Sequencing deviation, deliberate.** Stage 1's implementation was written **before** section 6 was.
+Section 5's closing obligation, from `testing.md` section 5, is that every case table is executed
+before it is written into the plan, and a data-tier table cannot be executed without the migration and
+the method existing. So stage 1 was built, its tables were run on all four engines, and only then was
+stage 1 written down. The code sat uncommitted through the plan review, which was told so and used it
+as evidence.
+
+**What executing the tables changed**, which is the return on doing it in that order:
+
+1. The `revoked = false` term in the sweep predicate is load bearing for the **count**, not only for
+   idempotence. MySQL reports changed rows rather than matched rows, and the `updated_at` assignment
+   alone makes an already-revoked row count as changed, so without the term the same call reports 2 on
+   MySQL and 0 on the other three. Decision 9's audit event carries that count.
+2. SQLite declares `codes.code_challenge` and `code_challenge_method` NOT NULL where the other three
+   engines allow NULL, so the migration test's seed passes on three engines and fails on one.
+3. A zero `time.Time` for `authenticated_at` reaches MySQL as `'0000-00-00'`, rejected outright.
+
+**Environment finding, not a code defect, and it cost half an hour.** The shared server test databases
+`goiabada_data` and `goiabada_integration` on mysql, postgres and mssql were left at
+`schema_migrations.version = 26` by the **discarded** earlier attempt at this issue, whose 000026 built
+the `terminated_sessions` registry that decision 4 rejected. golang-migrate therefore reported "no need
+to migrate" and every `codes` test failed with `Unknown column 'revoked'` on those three engines, while
+sqlite was fine because its test database is a fresh file per run. Fixed by rewinding the recorded
+version to 25 in those six databases. The orphaned `terminated_sessions` tables are still present and
+inert; dropping tables was not something to do unattended. `goiabada` on mssql, a dev database rather
+than a test one, is at 23 and clean.
+
+**Review, round 1.** `gpt-5.6-sol`, effort high, `type: plan-review`. Conformance, quality and security
+all reviewed. Ran: the request and the whole agreement, the complete stage 1 diff and its neighbours,
+`check-anchors.sh` (42 anchors pass), `git diff --check`, and an attempt at `where.sh test --type
+modules`.
+
+**Not reached.** The reviewer could not run any test tier: `where.sh test` exited 3 for it, reporting
+the dev container down, although the container is up and the run's own tiers were green from it. The
+reviewer's sandbox cannot reach docker. So the tier results in this document are the run's, verified
+from its own logs, and no review of this work will independently reproduce them. Later code-review
+requests carry the test output in the request rather than expecting the reviewer to re-run it.
+
+**Hash check.** `git diff | sha256sum` mismatched afterwards, which reviewer.md treats as a stop.
+Investigated rather than accepted: every changed file's mtime predates the review except the
+agreement, which the run itself edited at 18:54:30 local to record the PR. Reverting only that header
+edit reproduced the `BEFORE` hash exactly, so the reviewer changed no tracked file. The real lesson is
+procedural: do not edit tracked files while a review is running, or compute `BEFORE` immediately before
+the call.
+
+1. **The plan wrongly declined the two handler test files.** `Raised by: reviewer`, blocking,
+   confidence high. Status: **Resolved**
+   Verified and accepted. Section 5 rejects mock expectations as the only evidence for the **new data
+   methods** and rejects a unit seam as the primary home for the **helper's atomicity**; it rejects
+   neither a handler test for handler-owned behaviour, and section 1 named those two files explicitly,
+   so the seam was confirmed rather than invented. What settles it is that decision 9's contract has no
+   other home: the integration tier can read audit rows (`api_settings_audit_logs_test.go` calls
+   `GetAuditLogsPaginated`) but cannot force the termination transaction to fail, so nothing there can
+   prove both events are suppressed on failure. Stage 4 now creates both files, and the preamble to
+   section 6 records the reversal instead of hiding it. Harness precedent confirmed:
+   `handler_api_account_password_test.go` and five siblings over `test_main_test.go`.
+2. **User-facing material was staged apart from the behaviour it describes.** `Raised by: reviewer`,
+   significant, confidence high. Status: **Resolved**
+   Verified in both directions. Forwards: the original stage 3 called both endpoints while decision
+   14's modal copy waited until stage 4, so one deploy could perform the broader revocation without
+   telling the person clicking, which contradicts goal 6. Backwards: the original stage 3 claimed all
+   of section 2's docs, and section 2's new concepts section includes the in-flight ceremony guarantee,
+   which does not exist until stages 5 and 6, so it would have documented a fail-open path as closed.
+   Fixed by splitting: stage 3 is now an inert helper nobody calls, stage 4 is the activation stage
+   carrying the endpoints, both handler suites, the integration cases, every docs page and all three
+   modals in one commit, and the two ceremony sentences are explicitly held back for stages 5 and 6.
+3. **Stage 7 reopened a seam the seal had settled.** `Raised by: reviewer`, significant, confidence
+   high. Status: **Resolved**
+   Verified: section 4.5 says one predicate is added and seam 3 names
+   `DeleteUsedCodesWithoutRefreshTokens` extended, while the sketch offered "wire a second call or
+   extend the method, whichever is cleaner". That is a design choice the seal removed, and the second
+   option would add an unconfirmed data seam plus an interface method, four wrappers, regenerated mocks
+   and its own worker wiring. Stage 7 now forces extending the existing method, keeping its name and
+   widening its doc comment.
+
+No finding needed the user. All three are conformance findings whose answer the sealed agreement
+already fixes, so escalating them would have asked the user to re-decide what sections 1, 4.5 and 5
+decide. Nothing was deferred and nothing is contested.
+
+### Stage 1, 2026-08-04
+
+**Landed.** Migration 000026 on four engines, the four `schema.sql` snapshots, `model/code-revoked`,
+`db/revoke-codes-by-sid` with its interface declaration and four wrappers, the regenerated `Database`
+mock, and `AND revoked = false` added to `db/mark-code-used`. Tests: `test/revoke-codes-data` and its
+transaction-and-failure sibling, the revoked-but-unused row inside `TestMarkCodeAsUsed`,
+`TestUpdateCode_DoesNotClobberRevoked`, and `test/migration-000026`. Commit `066d289`.
+
+Nothing reads the marker yet, so this commit changes no observable behaviour. Stage 2 adds the
+rejections and stage 4 wires the endpoints that write it.
+
+**Tiers.** Unit green, all three modules. Data green on sqlite, mysql, postgres and mssql, each run
+separately (`where.sh test --type data --db <engine>`), including the stage's five new or extended
+tests on every engine. Integration not applicable: no endpoint, handler or observable flow changes
+here, which the reviewer confirmed independently.
+
+**Deviation 1, the sequencing.** Recorded in the plan entry above: the code preceded section 6 because
+the tables had to be executed before they were written. Nothing else about the stage departs from the
+plan as written.
+
+**Deviation 2, one file the plan did not list.** `handler_token.go` gained a comment rewrite and one
+changed `slog.Debug` message, no behaviour. It is the fix for finding 1 below, and it belongs to this
+stage because this stage is what made the old comment false. The alternative, leaving a comment that
+says every failed claim is reuse, would have handed the next reader a wrong contract.
+
+**Review, round 1.** `gpt-5.6-sol`, effort high, `type: code-review`. Conformance, quality and security
+all reviewed. Ran: the request and the full agreement, the complete stage 1 diff and the neighbouring
+redemption paths, `git diff --check`, `gofmt -d` on the changed Go files, `check-anchors.sh`, and an
+attempt at `where.sh test --type modules`. Hash check clean: `git diff | sha256sum` identical before
+and after, so the reviewer changed no tracked file.
+
+**Not reached.** No test tier, for the container reason in the plan entry. The reviewer read the
+recorded results rather than reproducing them and said so plainly, which is the honest form of a
+partial review. Everything static was reviewed, including a search for any other writer of
+`codes.revoked`, which found none.
+
+1. **The failed-claim contract still said every miss was authorization-code reuse.** `Raised by:
+   reviewer`, minor, confidence high. Status: **Resolved**
+   Correct, and it also refuted a premise in the run's own request. Adding `revoked = false` makes a
+   false return from `db/mark-code-used` mean "no row transitioned", which is now three states rather
+   than one: used, revoked, or missing. The doc comment still said "already used, i.e. a concurrent
+   request redeemed the same code first. Callers treat that as authorization-code reuse", and
+   `handler_token.go`'s branch comment and debug message still said the race had been lost.
+   The runtime was already safe, and the run had verified this before the review returned: the
+   `!claimed` branch answers a generic `invalid_grant` and deliberately does **not** call
+   `revokeAndAuditAuthCodeReuse`, which only the validator's `AuthCodeReusedError` path does, pinned by
+   `TestHandleTokenPost_AuthCode_ConcurrentDoubleSpendLoses`. So the defect was the written contract,
+   which would have invited a later caller to treat a termination race as reuse.
+   Fixed in three places: the `db/mark-code-used` doc comment, its interface declaration, and the
+   handler's branch comment plus its debug message, now "code could not be claimed" rather than "lost
+   the concurrent claim race". Unit tier re-run green afterwards. Bookkeeping class under the
+   reviewer reference's table, prose disagreeing with behaviour, so it does not justify a second round.
+
+**Gate passed on one round.** Zero conformance findings and zero security findings. The reviewer
+confirmed, against the diff rather than from the request, that the stage touches no index, no endpoint,
+`token_validator.go` not at all, and `DeleteUsedCodesWithoutRefreshTokens` not at all, which are the
+four out-of-scope boundaries this stage could plausibly have crossed.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,7 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** in progress, started 2026-08-04. Stage 1 done, stage 2 next.
+**Run state:** in progress, started 2026-08-04. Stages 1 and 2 done, stage 3 next.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -89,6 +89,9 @@ log can cite it the same way. Nothing above the line changed.
 | `migration/000026` | `src/core/data/sqlitedb/migrations/000026_add_code_revoked.up.sql` | `n/a` | `ALTER TABLE codes ADD COLUMN revoked numeric NOT NULL DEFAULT 0;` | stage 1, one of four engines |
 | `test/revoke-codes-data` | `src/authserver/tests/data/code_test.go` | `TestRevokeCodesBySessionIdentifier` | `assertCodeRevoked(t, unrelated.Id, false, "a code of an unrelated session")` | stage 1, seam 1's negative control |
 | `test/migration-000026` | `src/authserver/tests/data/migration_000026_code_revoked_test.go` | `TestMigration000026_CodeRevoked` | `require.NoError(t, h.Migrator.Migrate(25), "roll back 000026")` | stage 1, the down migration case |
+| `validator/code-revoked` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if codeEntity.Revoked {` | stage 2, the redemption rejection, behind client auth, PKCE and the reuse return |
+| `validator/refresh-code-revoked` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if !isROPCToken && refreshToken.Code.Revoked {` | stage 2, the refresh rejection, behind ownership and ahead of the `typ` switch, so it reaches Offline |
+| `test/revoked-code-ordering` | `src/core/validators/token_validator_test.go` | `TestValidateTokenRequest_RevokedCode` | `ordering: a wrong client secret answers before the revoked check` | stage 2, the row the review's round 1 finding added |
 
 Counts in this document carry their command:
 
@@ -1407,19 +1410,61 @@ cannot run without the migration and the method. Section 7's plan entry records 
 changed, which is the return on doing it in that order.
 
 ### Stage 2: rejection at redemption and at refresh
-Status: **Not started**
-Detail: **sketch**
+Status: **Done**
+Seams: 5. Tiers: unit. Docs: none, internals only. Nothing a user can observe changes until stage 4
+writes a marker, and no page states today's behaviour on either path.
 
-Read the marker at the two sites decision 7 fixes, both from data already loaded, so neither adds a
-query: `codeEntity.Revoked` on the `authorization_code` path, placed after client-secret validation,
-after PKCE and after the `if wasReused` return, and `refreshToken.Code.Revoked` on the
-`refresh_token` path, placed after `validator/client-ownership`. Both carry the comment decision 7
-requires, explaining why the check sits apart from the checks in `validator/authcode-preauth` rather
-than joining them, or a reviewer tidies it back into the block that #137 exists to fix. Seam 5, whose
-four ordering rows are the only testable content of decision 7 and are what stop the drift: a wrong
-verifier, a wrong secret, a reused code and a wrong client each return their own error rather than
-the revoked-code error. Tier: unit. Docs: none, internals only, since nothing is user-visible until
-stage 3 writes a marker. Expand against stage 1's code.
+1. **The `authorization_code` rejection.** Status: **Done**
+   In `ValidateTokenRequest`, read `codeEntity.Revoked` after client-secret validation, after PKCE and
+   after the `if wasReused` return, immediately before the success return. Generic `invalid_grant`,
+   "Code is invalid.", matching its neighbours. Carries the comment decision 7 requires: it sits apart
+   from `validator/authcode-preauth` because that block runs before client authentication, so a check
+   placed there tells a presenter of a stolen code whether the session was terminated, which is the
+   class #137 exists to close; and it sits after the reuse return so #77's cascade is not pre-empted,
+   reuse being the stronger signal that already revokes everything this check would refuse.
+2. **The `refresh_token` rejection.** Status: **Done**
+   Read `refreshToken.Code.Revoked` immediately after `validator/client-ownership`, before the `typ`
+   switch. Guarded by `!isROPCToken`: a ROPC token has `code_id = NULL` and no session, so it has no
+   grant origin to terminate, and reading the zero-valued `Code` on that path would be meaningless
+   rather than merely harmless. Reuses the Refresh branch's existing message by lifting its `const`
+   to the case scope, so the two paths cannot drift into two spellings of one fact.
+3. **Unit cases at seam 5.** Status: **Done**
+   New `TestValidateTokenRequest_RevokedCode`, mirroring `TestValidateTokenRequest_AuthStateGeneration`
+   in shape: table-driven subtests over both grant types plus ROPC, on the same mock trio. The rows,
+   expectations written before running them:
+
+   | Case | Expected | Which gate rejects it |
+   |---|---|---|
+   | auth code, revoked, everything else correct | `invalid_grant` | the new revoked check |
+   | auth code, not revoked | accepted | none, the positive control |
+   | auth code, revoked, wrong PKCE verifier | `invalid_grant`, "Invalid code_verifier (PKCE)." | PKCE, which is ahead of it |
+   | auth code, revoked, confidential client with no secret | `invalid_client` | client authentication, ahead of it |
+   | auth code, revoked, already used so reuse is detected | `AuthCodeReusedError` | the `wasReused` return, ahead of it |
+   | refresh, revoked code, correct client | `invalid_grant` | the new refresh check |
+   | refresh, revoked code, wrong client | `invalid_request`, "does not belong to the client" | ownership, ahead of it |
+   | refresh, ROPC token with no code | accepted | not applicable, no grant origin to terminate |
+   | refresh, code not revoked | accepted | none, the positive control |
+
+   **The three ordering rows are decision 7's only testable content.** Each varies exactly one thing
+   from the first row and names the gate that must answer instead, so none of them can pass if the
+   revoked check drifts up into `validator/authcode-preauth`. Two positive controls, one per grant
+   type, because a check that rejected everything would pass every negative row.
+4. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules`. No data or integration tier: this stage
+   adds no query and changes no endpoint.
+
+**As built.** Both checks landed exactly where step 1 and step 2 put them, and the `const
+invalidTokenMessage` was lifted to the case scope as planned, so the two ways a grant's session can
+stop backing it share one spelling. Three anchor rows were added to section 0 for the new code:
+`validator/code-revoked`, `validator/refresh-code-revoked` and `test/revoked-code-ordering`.
+
+**One departure, and it is the review's.** Step 3's table listed nine rows; ten shipped. The extra one
+is `test/revoked-code-ordering`, a **present but wrong** client secret, added because the review's
+round 1 finding showed the planned missing-secret row was the benign member of its class. Recorded in
+full in section 7, because the reasoning is the useful part: a missing secret is refused by a length
+check that runs before decryption, so that row alone would have stayed green under a relocation of the
+revoked check into the confidential branch just ahead of `subtle.ConstantTimeCompare`, which is
+exactly the oracle decision 7 exists to prevent.
 
 ### Stage 3: the termination helper, uncalled
 Status: **Not started**
@@ -1687,6 +1732,76 @@ partial review. Everything static was reviewed, including a search for any other
 confirmed, against the diff rather than from the request, that the stage touches no index, no endpoint,
 `token_validator.go` not at all, and `DeleteUsedCodesWithoutRefreshTokens` not at all, which are the
 four out-of-scope boundaries this stage could plausibly have crossed.
+
+### Stage 2, 2026-08-04
+
+**Landed.** `validator/code-revoked` and `validator/refresh-code-revoked` in `ValidateTokenRequest`,
+the `invalidTokenMessage` const lifted to the `refresh_token` case scope so both rejections spell one
+fact one way, and `test/revoked-code-ordering`'s parent test `TestValidateTokenRequest_RevokedCode`
+with ten subtests. Three anchor rows added to section 0. Commit `266615b`.
+
+The marker now means something. Stage 1 wrote the column and its sweep with nothing reading it; after
+this commit a revoked code cannot be redeemed and no refresh token descended from one can be
+exchanged. Still nothing **writes** a marker in production, because that is stage 4, so no observable
+behaviour changes yet.
+
+**Tiers.** Unit green, all three modules (`where.sh test --type modules`), re-run from scratch at the
+gate rather than carried forward from the implementation session. `TestValidateTokenRequest_RevokedCode`
+verified individually: 10 leaf subtests, all pass. No data or integration tier, correctly: this stage
+adds no query and changes no endpoint. `check-anchors.sh` passes all 45 rows, the 42 sealed ones plus
+the three this stage added.
+
+**The stage spanned two driver sessions**, which is worth recording because the run log is the only
+place it shows. The first implemented all three steps and ran both review rounds; it ended before
+writing any of this down. The second re-verified from disk rather than trusting the document: the
+`git diff | sha256sum` hash still matched `.review/before.sha` exactly, so the reviewer had changed no
+tracked file, the round 2 verdict's `request_id` still matched the live request, and the tiers were
+re-run rather than quoted. Nothing was rebuilt, because the code on disk matched the plan's steps.
+
+**Deviation, and it is the review's.** Step 3's table specified nine rows and ten shipped. The added
+row is a **present but wrong** client secret, and it exists because round 1 showed the planned
+missing-secret row could not do the job alone. Nothing else departs from the plan.
+
+**Review, round 1.** `gpt-5.6-sol`, effort high, `type: code-review`. Conformance, quality and security
+all reviewed.
+
+1. **The client-secret ordering row did not cover a present but incorrect secret.** `Raised by:
+   reviewer`, security, blocking, confidence high. Status: **Resolved**
+   Verified and correct, for a subtler reason than "a case was missing". The planned row supplied
+   **no** secret, which `ValidateTokenRequest` refuses at a `len(input.ClientSecret) == 0` guard that
+   runs before decryption, so it pinned only that the revoked check sits after the missing-credential
+   return. It did not pin that the check sits after authentication *completes*. Relocating the revoked
+   check into the confidential branch, after that guard and before `subtle.ConstantTimeCompare`, would
+   have handed a termination-state oracle to anyone holding a stolen code and any nonempty string,
+   which is precisely what decision 7 exists to prevent.
+   **Demonstrated rather than argued.** The relocation was applied to the real code and the suite
+   re-run. Under it the missing-secret row **passed**, confirming it as the benign member of its class;
+   the new wrong-secret row **failed**, which is its whole purpose; `a revoked code is refused` also
+   failed, incidentally, because its fixture uses a public client so the relocated check never runs;
+   and every other row passed, which is what they are for, each being refused by a different gate. The
+   mutation was reverted and the suite is green. The round 1 no-op mutation also holds: with both
+   checks deleted, exactly the two direct rejection rows fail and nothing else.
+
+**Review, round 2, clean.** Same model and effort, resumed in the same Codex thread, scoped to two
+narrow questions rather than a re-review: does the added row close the gap, and is any other row the
+benign member of its class in the same way. Zero findings, verdict `static-review-exhausted`, all
+three axes `reviewed`. The reviewer answered the second question against the code rather than in
+general terms, and its answer is the part worth keeping: the wrong-PKCE row is present and nonempty so
+it reaches the challenge comparison; the wrong-client refresh row authenticates the presenter and
+loads a revoked code owned by another client; and the reuse row is found only by the used-code lookup
+and asserts both the error type and its carried `Code`. It also noted the one relocation the reuse row
+alone would survive, moving the check inside `if !wasReused`, and that the wrong-secret and wrong-PKCE
+rows reject that placement. Hash check clean, identical before and after.
+
+**Not reached, both rounds.** No test tier. `where.sh test` exits 3 in the reviewer's sandbox because
+it cannot reach docker, the standing limitation recorded in the plan entry. The reviewer read the
+run's recorded results and said so plainly rather than implying it had reproduced them, which is the
+honest form of a partial review. The gate is not weakened by it here: the tier in question is unit,
+the run executed it at the gate, and every finding this stage produced was a static reading of test
+coverage rather than a failure the reviewer needed to run anything to see.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
+`Decided`.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,7 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** in progress, started 2026-08-04. Stages 1 and 2 done, stage 3 next.
+**Run state:** in progress, started 2026-08-04. Stages 1, 2 and 3 done, stage 4 next.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -92,6 +92,10 @@ log can cite it the same way. Nothing above the line changed.
 | `validator/code-revoked` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if codeEntity.Revoked {` | stage 2, the redemption rejection, behind client auth, PKCE and the reuse return |
 | `validator/refresh-code-revoked` | `src/core/validators/token_validator.go` | `ValidateTokenRequest` | `if !isROPCToken && refreshToken.Code.Revoked {` | stage 2, the refresh rejection, behind ownership and ahead of the `typ` switch, so it reaches Offline |
 | `test/revoked-code-ordering` | `src/core/validators/token_validator_test.go` | `TestValidateTokenRequest_RevokedCode` | `ordering: a wrong client secret answers before the revoked check` | stage 2, the row the review's round 1 finding added |
+| `audit/terminated-session` | `src/core/constants/constants.go` | `n/a` | `AuditTerminatedUserSession = "terminated_user_session"` | stage 3, decision 9's second event, emitted by stage 4 |
+| `revoke/terminate-session` | `src/authserver/internal/handlers/revocation.go` | `TerminateUserSessionTx` | `revokedCodeCount, err := db.RevokeCodesBySessionIdentifier(tx, userSession.SessionIdentifier)` | stage 3, the first of decision 5's three writes and the only one that survives |
+| `test/terminate-offline-token` | `src/authserver/internal/handlers/revocation_test.go` | `TestTerminateUserSessionTx_RevokesTheGrantsOfTheSession` | `the offline token of the terminated session must be revoked` | stage 3, decision 2's guard at this seam |
+| `test/terminate-zero-result` | `src/authserver/internal/handlers/revocation_test.go` | `TestTerminateUserSessionTx_AnyFailureYieldsTheZeroResult` | `the count must not survive a rolled-back transaction` | stage 3, the keep-this row of the failure table |
 
 Counts in this document carry their command:
 
@@ -1467,19 +1471,112 @@ revoked check into the confidential branch just ahead of `subtle.ConstantTimeCom
 exactly the oracle decision 7 exists to prevent.
 
 ### Stage 3: the termination helper, uncalled
-Status: **Not started**
-Detail: **sketch**
+Status: **Done**
+Seams: `revocation_test.go`, which section 5 names as the helper's home and which owns the
+transaction threading, the zero result on the error path, and decision 5's write order. Section 5's
+rejected-seams list is what keeps that scope honest: this file is mock based, so seam 1's
+rolled-back-transaction case and seam 9 own the atomicity, and this seam owns only what a mock can
+answer for.
+Tiers: unit (three modules). Integration and data not applicable: no endpoint changes, no query added,
+and every data method called here was covered on four engines in stage 1 or already existed.
+Docs: none, internals only. Nothing calls the helper, so nothing observable changes until stage 4.
 
-Deliberately inert: the helper exists and nothing calls it, so this commit changes no behaviour and
-owes no user-facing text. A helper in `revocation.go` modelled on `RevokeUserAuthStateTx`, performing
-decision 5's three writes in one transaction (`RevokeCodesBySessionIdentifier`, the sid-scoped refresh
-sweep through `db/refresh-by-sid` and `revoke/refresh-tokens`, then `DeleteUserSession`), returning
-the zero result on any error so a caller cannot audit a half-truth, and reporting the revoked code
-count and the transitioned JTIs decision 9's payload needs. Plus the new `terminated_user_session`
-constant and its entry in the audit event list in `constants.go`. Seam: `revocation_test.go`, which
-owns the transaction threading, the zero result on the error path, and that the three writes are
-issued in decision 5's order. Tier: unit. Docs: none, internals only, because nothing observable
-changes until stage 4 calls it.
+Deliberately inert, which is the plan review's second finding: stage 4 carries the endpoint calls and
+every piece of user-facing material about them in one commit, so this stage cannot deploy the broader
+security action ahead of the copy describing it.
+
+**The docs line is verified rather than assumed, because the new audit event does reach a UI
+surface.** `AuditEventTypes` feeds the audit log viewer's event filter, and
+`admin_settings_audit_log_viewer.html` renders `{{range .auditEventTypes}}` into
+`<option value="{{.}}">{{.}}</option>` with no `T` call, so the new event appears there as the raw
+identifier exactly as the other 94 do. No catalog key, and per section 2 `concepts/audit-log.mdx`
+points at `constants.go` rather than enumerating events.
+
+1. **`AuditTerminatedUserSession`, and its three registrations.** Status: **Done**
+   Landed at `audit/terminated-session`, with `constants_test.go` at `expectedCount` 95.
+   In `constants.go`, the constant `terminated_user_session` placed after `AuditRevokedUserAuthState`,
+   whose doc comment is the convention for a security event of this shape: why it exists beside
+   `AuditDeletedUserSession` rather than replacing it, that it fires only after the termination
+   transaction commits, and that it is the event to count for terminations, which is decision 9's own
+   stated downside. Plus its entry in `AuditEventTypes`, which `TestAuditEventTypes_Alphabetical`
+   sorts by **value**, so it belongs between `AuditStartedNewUserSesson` and
+   `AuditTokenIssuedAuthorizationCodeResponse`. Plus `constants_test.go`: `expectedCount` 94 to 95 and
+   the entry in `allAuditConstants`, which `TestAuditEventTypes_MatchesConstants` compares in both
+   directions and by count. Three registrations rather than one, and those two tests are why
+   forgetting any of them fails loudly instead of quietly.
+2. **`TerminationResult`.** Status: **Done**
+   Landed in `revocation.go` beside `RevocationResult`, two fields, as written.
+   In `revocation.go` beside `RevocationResult`, carrying exactly what decision 9's payload needs
+   beyond the caller's own inputs: `RevokedCodeCount int64` and `RevokedRefreshTokenJtis []string`.
+   The count is what this call **transitioned**, not what the session has, so a second termination of
+   the same session reports 0, which is the only question the audit event has to answer. `userId`,
+   `userSessionId` and `sessionIdentifier` stay out: the caller already holds the session row, and
+   restating them here would let a result and its payload disagree.
+3. **`TerminateUserSessionTx(db, userSession) (TerminationResult, error)`.** Status: **Done**
+   Landed at `revoke/terminate-session`, no inner variant, both entry guards ahead of the
+   transaction.
+   In `revocation.go`, owning its own transaction and committing it, with decision 5's three writes in
+   decision 5's order: `RevokeCodesBySessionIdentifier`, then the sid-scoped sweep through
+   `db/refresh-by-sid` fed into `revoke/refresh-tokens`, then `DeleteUserSession`. The zero result on
+   every error path, since the code sweep can succeed and the transaction still roll back, and a
+   caller that audits a count from a rolled-back transaction records a revocation that never happened.
+   The comment carries three things a later reader needs: that step 1 is the write which survives and
+   steps 2 and 3 are cleanup, that the sid-scoped **query** is the only thing reaching an offline
+   grant's tokens because their own `session_identifier` is empty (decision 2), and that this
+   deliberately does not advance the user's generation, because that would sign out every other device
+   the user has (section 4.6).
+
+   Takes the loaded `*models.UserSession` rather than an id plus a sid, because two of the writes key
+   on the identifier and the third on the id: from one row they cannot disagree, and both call sites in
+   stage 4 already load it for their 404 and their ownership check. Nil and an empty identifier are
+   refused at entry, before the transaction opens, which is where `RevokeUserAuthState` puts its own
+   precondition for the same reason.
+
+   **No inner `TerminateUserSession(db, tx, ...)` variant**, which is the one place this departs from
+   the shape of `RevokeUserAuthStateTx`. #106 needed the split because a credential write had to join
+   the same transaction through a callback; nothing composes with this one, so a second entry point
+   would be surface with no caller and a second contract to keep straight.
+4. **Unit cases at the seam.** Status: **Done**
+   Landed as four test functions over 10 leaf cases, including `test/terminate-offline-token` and
+   `test/terminate-zero-result`. Every row below shipped.
+   In `revocation_test.go`, on the strict `mocks_data.Database` the file already uses, so an
+   unexpected or missing call fails a case on its own. Fixture: three refresh tokens on the terminated
+   session, `rt-session-bound` (own sid set), `rt-offline` (own sid **empty**, code id set) and
+   `rt-already-gone` (already revoked). Expectations written before running them:
+
+   | Case | Expected | Which mechanism rejects it, or what it proves |
+   |---|---|---|
+   | a session with two live grants and one already-revoked token | the sweep's count reported as-is, JTIs `[rt-session-bound, rt-offline]`, session deleted, committed | the happy path and decision 9's payload |
+   | the offline token, whose own `session_identifier` is empty | revoked | decision 2: the sid-scoped query is the only thing that reaches it, and this row fails against an implementation that filters the returned rows by `rt.SessionIdentifier` |
+   | the already-revoked token | absent from the JTIs, and not written again | #77's invariant, inherited from `revoke/refresh-tokens` |
+   | the user's generation, and the user-scoped token query | never called | section 4.6 and decision 5's table: a user-scoped sweep signs out every other device |
+   | write order | codes, then tokens, then the delete | decision 5 states it. Within one transaction it is **not** a safety boundary, and neither sweep reads `user_sessions`, so this pins the design's order rather than a correctness property |
+   | nothing to revoke: no codes, no tokens | count 0, JTIs empty and non-nil, session still deleted and committed | ending a session with no grants is not an error, and the payload carries `[]` rather than null |
+   | nil session | error, `BeginTransaction` never called | the entry guard |
+   | empty session identifier | error, `BeginTransaction` never called | the entry guard. Without it the sweep refuses it three statements later, inside an open transaction, and it reads as a database fault |
+   | `BeginTransaction` fails | zero result, error | |
+   | the code sweep fails | zero result, and no token query, no delete, no commit | |
+   | the token query fails **after the code sweep returned 2** | zero result, `RevokedCodeCount` **0** | **keep this row.** It is the only one that fails against a partially populated result, which is exactly what would let a caller audit a revocation that rolled back |
+   | a token write fails | zero result, and no delete, no commit | |
+   | the delete fails | zero result, and no commit | |
+   | the commit fails | zero result | the caller must not audit, and the durable outcome is indeterminate per the helper's comment |
+5. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules`. Four anchor rows added for the new code,
+   not three: the plan undercounted, because `TerminationResult`'s two fields need no anchor of their
+   own but both new test functions do.
+
+**As built.** All five steps landed as written. Four anchor rows in section 0 rather than the three
+step 5 predicted, and 10 leaf cases rather than the "13" an earlier draft of this note claimed, which
+is what re-running the suite at the gate rather than quoting it is for: 2 standalone tests plus 2 and 6
+subtests, over `TestTerminateUserSessionTx_RevokesTheGrantsOfTheSession`, `_NothingToRevoke`,
+`_RejectsAnUnusableSession` and `_AnyFailureYieldsTheZeroResult`.
+
+Two deviations, both in `constants_test.go` and both small. The event was also added to
+`criticalEvents` in `TestAuditEventTypes_ContainsCriticalEvents`, which step 1 named only
+`expectedCount` and `allAuditConstants`; the argument is #106's own, one entry above it in the same
+list, that `deleted_user_session` survives either way, so an event that stopped being emitted would
+leave the security action with only a lifecycle record and nothing attesting what it revoked. And the
+review moved one displaced comment in `revocation_test.go`, recorded in section 7.
 
 ### Stage 4: both endpoints terminate, and everything that says so
 Status: **Not started**
@@ -1802,6 +1899,123 @@ coverage rather than a failure the reviewer needed to run anything to see.
 
 **Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
 `Decided`.
+
+### Stage 3, 2026-08-04
+
+**Landed.** `revoke/terminate-session`, that is `TerminateUserSessionTx` in `revocation.go`, with
+`TerminationResult` beside `RevocationResult`; `audit/terminated-session`, the
+`AuditTerminatedUserSession` constant and its three registrations; and four new test functions in
+`revocation_test.go` over 10 leaf cases, covering the happy path, the empty case, both entry guards
+and every one of the six failure points. Four anchor rows added to section 0. Commit `d19d8b5`.
+
+Nothing calls the helper and nothing emits the event, which is the stage's defining property: this
+commit changes no observable behaviour. Stage 4 wires both endpoints and carries every piece of
+user-facing material about them in the same commit, per the plan review's finding 2.
+
+**Tiers.** Unit green, all three modules (`where.sh test --type modules`, exit 0, no `FAIL` lines,
+"All tests completed successfully"), run at the gate rather than carried forward from the
+implementation session. The stage's 10 leaf cases pass, and so do all six `TestAuditEventTypes_*`
+guards with the new event, the count guard now at 95 and `_Alphabetical` accepting
+`terminated_user_session` between `started_new_user_session` and
+`token_issued_authorization_code_response`. No data tier and no integration tier, correctly: this
+stage adds no query, changes no endpoint, and every data method it calls was covered on four engines
+in stage 1 or already existed. `check-anchors.sh` passes all 49 rows, `gofmt -l` is silent on all four
+changed files, `git diff --check` is clean.
+
+**Mutation evidence, because a green mock-based suite is worth what its rows would catch.** Two
+mutations applied to the real helper, run, and reverted, in this session rather than quoted from the
+implementation session's notes.
+
+1. Re-filtering the swept rows by `rt.SessionIdentifier == userSession.SessionIdentifier`, the
+   plausible tidy-up that silently drops offline tokens. Exactly one test failed,
+   `test/terminate-offline-token`'s parent, on three independent assertions: the JTI list came back
+   `[rt-session-bound]`, the offline assertion reported "the offline token of the terminated session
+   must be revoked", and the strict mock reported "7 out of 8 expectation(s) were met" for the
+   unreached `UpdateRefreshToken`. That is gap 1 reintroduced, caught three ways.
+2. Populating the result as the helper goes and returning it on the error path. **This refutes what
+   the implementation session wrote in the mailbox**, and the correction is the useful part. That note
+   claimed exactly one row failed, `test/terminate-zero-result`, and concluded it was therefore the
+   only row with teeth against a partially populated result. Measured here, **four** of the six failure
+   rows fail: the keep-this row plus `a token write fails`, `the deletion fails` and `the commit
+   fails`, because the shared `assert.Equal(t, TerminationResult{}, result)` in the table's loop
+   catches every path where a write had already succeeded. The row is still worth keeping, for the
+   narrower reason that it names the property and is the only one asserting the count itself, so its
+   failure reads as a contract violation rather than a struct mismatch. Step 4's table keeps its
+   original wording, because it is the prediction and editing it would erase the evidence that the
+   prediction was wrong; the comment in the test file was corrected, since a comment stating a
+   measured falsehood is the same defect class as stage 1's finding 1.
+
+**Deviations from the plan as written.** Three, all small.
+
+1. Step 1 named `expectedCount` and `allAuditConstants`; the event was also added to `criticalEvents`
+   in `TestAuditEventTypes_ContainsCriticalEvents`, with a comment in the shape of the
+   `AuditRevokedUserAuthState` entry immediately above it. The argument is #106's own, one issue over:
+   `deleted_user_session` survives either way, so if this event stopped being emitted the security
+   action would leave only a lifecycle record and nothing attesting what it revoked.
+2. Four anchor rows, not the three step 5 predicted. `TerminationResult`'s fields need no anchor of
+   their own, but both new test functions do.
+3. 10 leaf cases, not the 13 the mailbox note claimed. Counted from the suite's own output at the
+   gate: 2 standalone tests, 2 subtests under `_RejectsAnUnusableSession`, 6 under
+   `_AnyFailureYieldsTheZeroResult`.
+
+**Design choice worth recording, since it departs from #106's shape.** There is no inner
+`TerminateUserSession(db, tx, ...)` beside the `Tx` variant. #106 needed that split because a
+credential write had to join the same transaction through a callback; nothing composes with this one,
+so a second entry point would be surface with no caller and a second contract to keep straight. If a
+later stage does need to compose a write into the termination transaction, splitting it is mechanical.
+
+**Review, round 1.** `gpt-5.6-sol`, effort high, `type: code-review`, request
+`129-20260804T225911Z`. Conformance, quality and security all `reviewed`, verdict `findings`.
+
+**The reviewer reached a test tier for the first time in this run**, which matters because the stage 1
+and stage 2 entries above both record that it could not. Its `ran` list: `leo-review/SKILL.md` and the
+full agreement, the complete uncommitted diff and the neighbouring code, `git diff --check`, `gofmt -d`
+on all four changed Go files, `check-anchors.sh` with 49 anchors passing, and `where.sh test --type
+modules` reported as all three modules passing. Recorded as the reviewer's claim rather than as
+independent confirmation, since the run cannot see into its sandbox; the run executed the tier itself
+either way. Its `unchecked` list holds nothing the gate depended on: the data and integration tiers,
+correctly not applicable to an uncalled helper, the unchanged PKCE, redirect, token-validation,
+rate-limiting and secret-comparison internals, and the run's own source mutations, which it assessed
+statically because a reviewer may not edit source.
+
+**Hash check clean.** `git diff | sha256sum` was still `1ca531ab…`, matching `.review/before.sha`, when
+this session started, so the reviewer changed no tracked file and reviewed exactly the code committed
+here apart from this session's two comment edits.
+
+1. **A stage 3 fixture was inserted between `stubRevocationSweepTx`'s doc comment and the function.**
+   `Raised by: reviewer`, quality, minor, confidence high. Status: **Resolved**
+   Verified against the file and correct. The comment sat at the end of the #106 material and the new
+   termination fixtures went in directly beneath it, so it attached to the `terminateSessionId` and
+   `terminateSid` constants, describing a mock-stubbing helper that was by then 300 lines further down
+   and undocumented. Resolved by the reviewer's own forced answer, moving the eleven-line comment back
+   above `stubRevocationSweepTx`, which is the smaller of the two fixes and keeps that cross-file
+   helper last in the file where it already was; the alternative, moving the whole stage 3 block below
+   it, would have put a helper shared with `handler_reset_password_test.go` in the middle. Unit tier
+   re-run green afterwards.
+   Bookkeeping class under the reviewer reference's table, prose disagreeing with what it sits above,
+   so it does not justify a second round. Same class and same disposition as stage 1's finding 1.
+
+**No round 2, and the gate passes on one round.** Zero conformance findings and zero security
+findings, all three axes reviewed, and the only finding was a comment position. What this session
+changed since the reviewed hash is two comments in one test file, no behaviour, suite green, so a
+second round would be reviewing comment placement.
+
+**The stage stalled between sessions, and the reason belongs here because nothing else records it.**
+The implementation session wrote its trace to `.review/stage3-log.md` instead of this section, and the
+mailbox does not survive the next gate, so on the skill's own terms the stage had recorded nothing. No
+session then ran to ingest round 1, and the driver re-invoked the reviewer three further times against
+a byte-identical request. Each re-invocation correctly refused to treat it as a new round, verified the
+request hash `719cb6cb…` and the diff hash unchanged, re-raised the same finding and marked it
+`needs_human: true`, that flag meaning "somebody has to notice the request was never rewritten" rather
+than a question for the user, since the same finding carried a mechanical `forced_answer` on its first
+emission. No new findings came from any of them. Because the driver clears `verdict.json` and
+`response.md` before each reviewer run, round 1's own verdict was recovered from `.review/drive.log`,
+and its content was verified against the code before being written up here. Two lessons, both
+procedural: the trace goes in the agreement at the moment it is known, and a round-2 request that is
+never written stalls the loop silently rather than loudly.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
+`Decided`. No follow-up found: the only defect this stage surfaced was in its own comments.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,10 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** **all eight stages committed, 2026-08-05.** Stage 8, the last, closed on a clean review
+**Run state: complete, 2026-08-05.** All eight stages committed, the full suite green on every tier and
+all four engines, sections 8 and 9 posted to PR [#138](https://github.com/leodip/goiabada/pull/138) as
+two comments, and the pull request marked ready for review. The closing pass is the last entry in section
+7. The issue stays open: closing it is the user's call. Stage 8, the last, closed on a clean review
 round 1 whose diff hash matched the committed tree exactly: two integration tests carrying gap 2's
 evidence and no production line, since gap 2 closed structurally in stages 1 and 2. Its expansion found
 that the marker's refusal and the sweep's are different gates with different messages, the marker's
@@ -15,8 +18,7 @@ storage and the marker is the only thing refusing it. Two mutations measured, an
 under them is the argument for the stage: stage 4's headline case and stage 6's consent ceremony both
 pass with the marker's read or its write removed, and only these two tests fail. Section 3 has zero
 `Open` items, section 8 nothing deferred, section 9 four drafted follow-ups the run never files.
-Remaining: the closing pass, which is the full suite across every tier, sections 8 and 9 posted to the
-pull request, and `gh pr ready`. Below, the earlier state, kept because the run log reads against it.
+Below, the earlier state, kept because the run log reads against it.
 **Stage 7 closed on a clean round 1**: one predicate
 extension so codes revoked while still unredeemed do not accumulate (decision 8), green on the modules
 tier and on the data tier across all four engines, with five mutations measured. Its expansion found
@@ -4120,6 +4122,66 @@ tree. That is the clean case the reviewer reference describes.
 `Decided`, and section 9 its four follow-ups. Stage 8 is committed with this document following it, and
 it is the last: next is the run's closing pass, the full suite across every tier, sections 8 and 9 onto
 the pull request, and the PR marked ready for review.
+
+### Closing pass, 2026-08-05: the full suite, the two comments, and the PR ready
+
+The guard answered `DONE: every stage is Done` at stage 8's gate, exit 11, which is the terminal state
+rather than a refusal. What follows is the closing pass, and it is recorded here because the pull request
+summarises it and this document is the record.
+
+**The full suite, every tier, on the committed tree.** `where.sh test --type all`, foreground, exit 0,
+**zero `FAIL` and zero panics** across 46189 log lines, ending in the harness's
+`All tests completed successfully.` Per tier:
+
+- **Modules**, all three, every package `ok`. Reported `(cached)`, which is worth naming rather than
+  hiding: Go's test cache is keyed on the content of the inputs, so a cached `ok` is a genuine pass for
+  these exact bytes, and the packages this stage did not touch had already run green on identical
+  sources at stage 7's gate.
+- **Data**, run per engine: mysql 9.9s, postgres 4.1s, mssql 5.8s, sqlite 2.3s, each `ok`.
+- **Integration**, run per engine: mysql 64.8s, postgres 74.3s, mssql 99.2s, sqlite 43.2s, each `ok`.
+- 9022 `--- PASS` lines and 52 `ok` package lines in total.
+
+**The race's per-engine reading reproduced exactly, which is the third independent run to say so.**
+Every engine produced one replacement token alongside the termination. mysql and postgres logged
+`replacement 0 was revoked in storage: it landed before the termination's sweep`; mssql and sqlite logged
+`replacement 0 is still live in storage: the sweep never saw it, which is gap 2's own interleaving`. No
+engine needed the sequential termination retry. That matches the stage 8 entry's table engine for engine,
+across the implementation session, the reviewer's independent run and this one.
+
+**Section 8 posted**, as
+[a PR comment](https://github.com/leodip/goiabada/pull/138#issuecomment-5196348942). Nothing was
+deferred, so the comment says why an empty section is not a forgotten one: every question this run met
+was in authentication, token or session territory, where `decisions.md` forbids both self-resolving and
+deferring, so the two the run could not answer became decisions 15 and 16 and halted it instead. Both
+answers are quoted in section 3 and both are built.
+
+**Section 9 posted**, as
+[a second PR comment](https://github.com/leodip/goiabada/pull/138#issuecomment-5196349557), each of the
+four follow-ups with its title, labels, body and the `gh` command that files it. Follow-up 2 is a
+`gh issue comment 109` rather than a new issue, for the reason section 9 gives. **Duplicate searches
+re-run at the close**, against the 33 currently open issues rather than the list from when each was
+drafted: `serialization boundary sweep` returns #131, #132 and #129 only, so nothing new covers
+follow-up 1's window; `logout` returns #109, #135, #129 and #114, none of which covers the no-hint
+path's silence; `amr auth methods` and `ClearAuthContext` return nothing at all. All four still stand,
+and **none was filed**, which is deliberate: drafting is the run's job and filing is the user's.
+
+**The pull request body rewritten** to what actually landed: the three gaps in the terms the code closes
+them, a stage-by-stage table with each commit, the closing suite result, the deviations that were load
+bearing, the three known limits stated rather than implied, and a line pointing at each of the two
+comments above. Then `gh pr ready 138`.
+
+**What the run cost and what it met, for the next planning pass.** Eight stages over two days, 26
+commits, 60 files. **Thirteen review rounds**, counted from their own headings: one on the plan, then 1,
+2, 1, 1, 2, 3, 1 and 1 on stages 1 to 8. Three stages passed clean on a first round (4, 7 and 8), three
+needed a second (2, 5 and 6, the last needing a third), and the remainder produced a single finding each,
+resolved inside the stage. **Sixteen mutations** measured, numbered continuously across the run. **Two
+blocking escalations, both belonging to decision 6**, which is inside the normal range for a change this
+size; the observation that decision 6 was the expensive one is recorded in section 3 rather than here,
+because that judgement belongs to the next `/leo-spec` rather than to this run. Four follow-ups drafted,
+three of them defects this work sat next to rather than caused.
+
+**Where this leaves the issue.** #129 stays open. Closing it is the user's call, and the pull request is
+ready for review with everything the run knows either in this document or in the two comments.
 
 ---
 

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -3197,8 +3197,15 @@ within decisions.md's "one or two on a hard change is normal" and is worth the n
 decision 6 carried two questions its own text could not answer, and both were found by a reviewer
 reading the built code rather than by the interview.
 
-**State at the halt.** Stage 6's thirteen-file diff is complete, green on every tier it claims, and
-**uncommitted**, exactly as stage 5 waited on decision 15. Nothing that rests on decision 16 is
+**State at the halt.** Stage 6's **twelve**-file diff is complete, green on every tier it claims, and
+**uncommitted**, exactly as stage 5 waited on decision 15. Twelve rather than the thirteen this
+paragraph first claimed, which counted this document alongside the stage tree; `git status` is
+`code.go` on the four engines plus `commondb/code.go`, `database.go` and `mocks/database_mock.go`,
+then `handler_auth_issue.go`, `handler_auth_issue_test.go`, `code_test.go`,
+`session_deletion_test.go` and `concepts/user-sessions.mdx`. Corrected rather than absorbed because a
+count that disagrees with the tree reads as a lost file to whoever resumes, and it cost one
+verification detour before it was. Same class as the request miscount recorded at stage 5 round 2.
+Nothing that rests on decision 16 is
 committed. This agreement is committed, carrying decision 16 `Open` and this entry, because the next
 session reads the agreement rather than the transcript. One bookkeeping fix rode along: the
 `middleware/session-identifier` label was cited three times by the stage 6 text and declared in no

--- a/docs/issue-129-durable-session-termination.md
+++ b/docs/issue-129-durable-session-termination.md
@@ -5,7 +5,8 @@
 **Written:** 2026-08-04
 **Last synced:** 2026-08-04 (issue has zero comments; body is the whole specification)
 **Agreement sealed:** 2026-08-04, amended 2026-08-04 on a reconciliation pass, still sealed
-**Run state:** in progress, started 2026-08-04. Stages 1, 2 and 3 done, stage 4 next.
+**Run state:** in progress, started 2026-08-04. Stages 1 to 4 done, so the behaviour change has landed.
+Stage 5, the `/auth/completed` gate, is next and is still a sketch.
 **PR:** [#138](https://github.com/leodip/goiabada/pull/138) (draft)
 
 **Related:** #106 (closed) built the per-user generation boundary and the revocation helper this
@@ -41,8 +42,8 @@ exists and will need reconciling against this document's section 3.
 
 | Label | File | Function | Locate by | Note |
 |---|---|---|---|---|
-| `admin/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go` | `HandleAPIUserSessionDelete` | `err = database.DeleteUserSession(nil, sessionId)` | termination site 1, bare delete, no revocation |
-| `account/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go` | `HandleAPIAccountSessionDelete` | `if err := database.DeleteUserSession(nil, sessionId); err != nil {` | termination site 2, ownership checked, bare delete |
+| `admin/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go` | `HandleAPIUserSessionDelete` | `result, err := handlers.TerminateUserSessionTx(database, userSession)` | termination site 1. **Locator re-swept by stage 4**, which is what replaced the bare delete this row used to cite |
+| `account/session-delete` | `src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go` | `HandleAPIAccountSessionDelete` | `result, err := handlers.TerminateUserSessionTx(database, us)` | termination site 2, ownership checked. **Locator re-swept by stage 4**, same reason |
 | `logout/last-client-delete` | `src/authserver/internal/handlers/handler_account_logout.go` | `handleExistingSessionOnLogout` | `if len(userSession.Clients) == 1 {` | termination site 3, deletes the session only when the last client logs out |
 | `logout/basic-post-fork` | `src/authserver/internal/handlers/handler_account_logout.go` | `HandleAccountLogoutPost` | `if hint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint"); len(hint) > 0 {` | without a hint the handler clears the cookie and writes nothing to the database |
 | `catalog/end-session-modal` | `src/core/i18n/catalogs/active.en.toml` | `n/a` | `adminconsole.account.sessions.modal_confirm_body_prefix` | one of three end-session modals; decision 14 adds a key beside each |
@@ -96,6 +97,14 @@ log can cite it the same way. Nothing above the line changed.
 | `revoke/terminate-session` | `src/authserver/internal/handlers/revocation.go` | `TerminateUserSessionTx` | `revokedCodeCount, err := db.RevokeCodesBySessionIdentifier(tx, userSession.SessionIdentifier)` | stage 3, the first of decision 5's three writes and the only one that survives |
 | `test/terminate-offline-token` | `src/authserver/internal/handlers/revocation_test.go` | `TestTerminateUserSessionTx_RevokesTheGrantsOfTheSession` | `the offline token of the terminated session must be revoked` | stage 3, decision 2's guard at this seam |
 | `test/terminate-zero-result` | `src/authserver/internal/handlers/revocation_test.go` | `TestTerminateUserSessionTx_AnyFailureYieldsTheZeroResult` | `the count must not survive a rolled-back transaction` | stage 3, the keep-this row of the failure table |
+| `revoke/log-terminated` | `src/authserver/internal/handlers/revocation.go` | `LogTerminatedUserSession` | `func LogTerminatedUserSession(auditLogger AuditLogger, userSession *models.UserSession,` | stage 4, decision 9's payload, one emitter for both endpoints |
+| `catalog/modal-revocation-note` | `src/core/i18n/catalogs/active.en.toml` | `n/a` | `adminconsole.account.sessions.modal_revocation_note` | stage 4, one of decision 14's six keys |
+| `test/terminate-endpoint-audit` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions_test.go` | `TestHandleAPIUserSessionDelete_TerminatesAndAuditsBothEvents` | `assert.Len(t, terminatedPayload, 6)` | stage 4, decision 9's payload asserted field by field |
+| `test/failure-suppresses-events` | `src/authserver/internal/handlers/apihandlers/handler_api_users_sessions_test.go` | `TestHandleAPIUserSessionDelete_TerminationFailureIsA500` | `is the case that decided this file had to` | stage 4, the contract no other tier can reach |
+| `test/forbidden-does-not-terminate` | `src/authserver/internal/handlers/apihandlers/handler_api_account_sessions_test.go` | `TestHandleAPIAccountSessionDelete_ForbiddenDoesNotTerminate` | `func TestHandleAPIAccountSessionDelete_ForbiddenDoesNotTerminate(t *testing.T) {` | stage 4, ownership ahead of termination |
+| `test/terminate-offline-endpoint` | `src/authserver/tests/integration/api_users_sessions_test.go` | `TestAPIUserSessionDelete_TerminatesTheOfflineGrantsOfThatSession` | `THE SURVIVOR IS THE HALF THAT CARRIES THIS TEST` | stage 4, seam 8's headline claim and its same-user control |
+| `test/second-offline-grant` | `src/authserver/tests/integration/credential_change_revocation_test.go` | `secondOfflineGrantForSameUser` | `func secondOfflineGrantForSameUser(t *testing.T, base *offlineGrant, password string) *offlineGrant {` | stage 4, the one new harness helper |
+| `test/logout-revokes-nothing` | `src/authserver/tests/integration/api_account_logout_request_test.go` | `TestLogout_WithIdTokenHint_RevokesNoGrants` | `logout must revoke nothing, decision 3` | stage 4, decision 3 pinned |
 
 Counts in this document carry their command:
 
@@ -1579,41 +1588,161 @@ leave the security action with only a lifecycle record and nothing attesting wha
 review moved one displaced comment in `revocation_test.go`, recorded in section 7.
 
 ### Stage 4: both endpoints terminate, and everything that says so
-Status: **Not started**
-Detail: **sketch**
+Status: **Done**
+Seams: the two new handler test files section 1 asked for, 8 (`POST /auth/token`), 9 (the
+session-management endpoints) and 10 (the catalogs, which need no new test code).
+Tiers: unit (three modules), integration (dev container). Data not applicable, and deliberately so:
+this stage adds no query and no migration, and every data method it reaches was covered on four
+engines in stage 1 or already existed.
+Docs: all of section 2's "Documentation owed", minus the two ceremony sentences held back for stages
+5 and 6.
 
 The activation stage. It carries the endpoint calls **and** every piece of user-facing material about
 them, in one commit, so no deploy can perform the broader security action while a page or a modal
 still describes the narrower one. That pairing is the plan review's second finding and the reason
 stage 3 above is inert.
 
-`admin/session-delete` and `account/session-delete` call the helper, ownership still enforced on the
-account one, and each emits `AuditDeletedUserSession` unchanged plus `terminated_user_session` with
-decision 9's payload, both **after** the commit. Seams: the two new handler test files section 1 asked
-for, covering both events with their payload on success and **neither** event with a 500 on helper
-failure, which is the contract no other tier can reach; seam 8 for the headline claim (authorize with
-`offline_access`, terminate, refresh refused, paired with the assertion that an unrelated session
-still refreshes, without which the test passes against a change that revokes everything); seam 9 for
-both endpoints, the account one's 403, and pinning logout unchanged through request shapes #109 is not
-rewriting. Seam 10 for the catalog keys, which needs no new test code because
-`TestCatalog_ParityEnPtBR` and `TestCatalog_NoEmptyValues` already fail on a key in one catalog only
-or present and empty, and the step says so explicitly so the absence of new cases does not read as
-untested copy. Tiers: unit, integration.
-
-Docs, all of it here: the falsified sentences in `concepts/tokens.mdx`, a new ending-a-session section
-in `concepts/user-sessions.mdx`, both endpoints in `integration/rest-api.mdx`, a durable-termination
-bullet in `reference/security.mdx`, and decision 14's three keys in each catalog plus one `msg +=`
-line in each of `account_user_sessions.html`, `admin_users_sessions.html` and
-`admin_clients_usersessions.html`, placed before the `if (isCurrent)` append so the immediate-logout
-warning stays last and containing no double quote, since the string is interpolated into a JavaScript
-double-quoted literal. Two wordings, second person on the account page and third person on the two
-admin pages.
-
 **The new concepts section is limited to what is true when this lands**: what the two endpoints revoke
 (decision 2) and decision 11's limit, that an offline grant's access token keeps working until it
 expires. It must **not** yet claim that an in-flight ceremony cannot recreate the session, because
 that is stages 5 and 6, and documenting a fail-open path as closed is worse than documenting nothing.
 Those two sentences land with the stages that make them true.
+
+1. **`LogTerminatedUserSession`, one emitter for decision 9's payload.** Status: **Done**
+   In `revocation.go` beside `LogRevokedUserAuthState`, which is the precedent and states the reason:
+   one function rather than two literals, so the payload cannot differ between the two sites and there
+   is a single place to assert its shape field by field. Takes the loaded `*models.UserSession` for the
+   same reason `TerminateUserSessionTx` does, since `userId`, `userSessionId` and `sessionIdentifier`
+   all come off that one row and so cannot describe two different sessions. Six keys, exactly decision
+   9's: `userId`, `userSessionId`, `sessionIdentifier`, `revokedRefreshTokenJtis`, `revokedCodeCount`,
+   `loggedInUser`.
+2. **`admin/session-delete` terminates.** Status: **Done**
+   Replace `database.DeleteUserSession(nil, sessionId)` with `handlers.TerminateUserSessionTx(database,
+   userSession)`, the session row being already loaded for the pre-existing 404. On error, the existing
+   500 and **no** audit event of either kind. On success, `AuditDeletedUserSession` first with its
+   payload untouched, then `LogTerminatedUserSession`. The 404 and the two 400s answer before the
+   helper, unchanged, so a missing session never opens a transaction.
+3. **`account/session-delete` terminates.** Status: **Done**
+   The same replacement, with the ownership check still ahead of it: `us.UserId != user.Id` answers 403
+   before the helper is entered. Same event pair, same order, same failure contract.
+4. **Unit cases at the admin handler, in a new `handler_api_users_sessions_test.go`.**
+   Status: **Done**
+   Section 1 recorded that neither handler test file exists, and the preamble to this section records
+   why the first draft of the plan wrongly declined to create them. On the strict `mocks_data.Database`
+   and `mocks_audit.AuditLogger` the sibling files already use, with a thin `stubTermination` helper
+   following `stubSweep`'s precedent in `handler_api_account_password_test.go`: thin because
+   `revocation_test.go` owns the termination table exhaustively and restating it here would mean two
+   places to update. Expectations written before running them:
+
+   | Case | Expected | Which mechanism answers, or what it proves |
+   |---|---|---|
+   | a live session, helper succeeds | 200, both events, and `terminated_user_session` carrying exactly decision 9's six keys | decision 9's payload, field by field, asserted with a length check so a dropped key cannot pass |
+   | the same case, the older event's payload | exactly `userSessionId` and `loggedInUser` | decision 9 promises it is untouched, so an external consumer parsing it strictly keeps working |
+   | the helper fails, the code sweep erroring | 500, **neither** event, no commit | **keep this row.** It is the contract that decided the file's existence: the integration tier can read audit rows but cannot force the termination transaction to fail, so nothing above the unit tier can prove the events are suppressed |
+   | the session id is not found | 404, and `BeginTransaction` never called | the pre-existing 404 still answers first. Without this row a handler that terminated before checking would pass every other row |
+
+5. **Unit cases at the account handler, in a new `handler_api_account_sessions_test.go`.**
+   Status: **Done**
+   Same harness, and the token context through `setTokenContextWithClaims`, which the profile-picture
+   test file already provides:
+
+   | Case | Expected | Which mechanism answers, or what it proves |
+   |---|---|---|
+   | the caller's own session, helper succeeds | 200, both events, decision 9's six keys | the self-service half of decision 5 |
+   | another user's session | 403, and `BeginTransaction` never called | ownership answers before termination. **Keep this row:** a handler that terminated first and then returned 403 satisfies every existing test in the suite, because the pre-existing integration case asserts only the status code |
+   | the helper fails | 500, neither event | the same suppression contract, at the second site, because the two emitters are adjacent in the code and it is easy to leave one outside the error check |
+
+6. **Decision 14's three keys in each catalog, and one line in each of three templates.**
+   Status: **Done**
+   `modal_revocation_note` under the three prefixes decision 14's table names, placed between
+   `modal_confirm_body_suffix` and the current-session warning in each catalog, which is the order the
+   template appends them in. Two wordings, second person on the account page and third person on the
+   two admin pages, exactly as decision 14 sealed them, plus the pt-BR drafts refined against the
+   register of the neighbouring strings. **No double quote in any of the six values**, since each is
+   interpolated into a JavaScript double-quoted literal inside `endSessionClick`, and the `msg +=` line
+   goes **before** the `if (isCurrent)` append so the immediate-logout warning stays last.
+   **Seam 10 needs no new test code, and that is the finding rather than an omission.**
+   `TestCatalog_ParityEnPtBR` already fails in both directions when a key exists in one catalog and not
+   the other, and `TestCatalog_NoEmptyValues` already fails on a key present with an empty value, which
+   go-i18n otherwise renders as the raw key in the UI. Adding the keys to both files is what puts them
+   under the existing guard. Stated explicitly so the absence of new cases does not read as untested
+   copy.
+7. **The docs site, four pages.** Status: **Done**
+   Per section 2's "Documentation owed", and per section 2's verified list of what owes nothing:
+   `concepts/audit-log.mdx` points at `constants.go` rather than enumerating events,
+   `integration/endpoints.mdx`'s `/auth/logout` description stays accurate because decision 3 leaves
+   logout unchanged, and `CLAUDE.md` and `AGENTS.md` enumerate neither migrations nor the `codes` table.
+   - `concepts/tokens.mdx`, offline refresh tokens: the two falsified sentences. The distinction
+     decision 4 rests on is the one to draw, a session **expiring** still leaves an offline grant
+     working and a session **explicitly ended** does not.
+   - `concepts/user-sessions.mdx`: a new `## Ending a session` section after "Credential changes and
+     live sessions" and before "Forcing re-authentication", covering what the two endpoints revoke
+     (decision 2), decision 11's limit that an offline grant's access token keeps working until it
+     expires because it carries no session identifier to check, and decision 9's counting note. Without
+     that limit a reader generalizes the credential-change bullet, "reject a token from a superseded
+     session on the very next request", to termination and is wrong.
+   - `integration/rest-api.mdx`: one sentence on each of the two endpoints, linking to the new section.
+   - `reference/security.mdx`, "Authentication security": a durable-termination bullet in the shape of
+     the "Replay containment" one, which is the established shape for a security property here.
+8. **Integration cases at seams 8 and 9.** Status: **Done**
+   All in existing suites, per section 5. The harness is #106's: `createOfflineGrant` runs a full
+   `offline_access` ceremony through the real login and consent screens and returns the grant plus the
+   session identifier read off the `codes` row, and `offlineGrant.refresh` presents its refresh token.
+   One new helper, `secondOfflineGrantForSameUser`, which is `secondSessionFor` with the offline scope:
+   a fresh cookie jar and a distinct `User-Agent`, the latter load bearing rather than cosmetic because
+   `StartNewUserSession` deletes other sessions of the same user sharing device name, type, OS and IP.
+
+   | Case | File | Expected | What it proves |
+   |---|---|---|---|
+   | two offline grants of the **same user** on sessions A and B, admin `DELETE` on A | `api_users_sessions_test.go` | both refresh before, then A's refresh `invalid_grant` and B's still works | the headline claim at the highest seam that can observe it, plus the control seam 8 requires. **The control belongs to the same user deliberately:** it varies only the session, so it rejects a table-wide sweep and a user-scoped one at once, where an unrelated user's grant would leave the second untested |
+   | one offline grant, account `DELETE` on the caller's own session | `api_account_sessions_test.go` | refresh refused | the self-service half, end to end |
+   | another user's session holding an offline grant, account `DELETE` | `api_account_sessions_test.go` | 403 **and** that grant still refreshes | ownership answers before termination, observed rather than mocked. The pre-existing 403 case asserts only the status, which a handler terminating first would still satisfy |
+   | `/auth/logout` with `id_token_hint` and `post_logout_redirect_uri`, the session's only client | `api_account_logout_request_test.go` | 302 to the post-logout redirect, and the offline refresh token still works | decision 3: logout revokes nothing, in every case. The 302 assertion is what stops the case passing because logout did nothing at all |
+   | the same, with a second client on the session | `api_account_logout_request_test.go` | the logged-out client's **session-bound** refresh token still works | decision 3's second contract, pinned so #135 has to change it deliberately. The second client is created directly with `CreateUserSessionClient`, which this suite already does, because what matters is the count `handleExistingSessionOnLogout` reads |
+   | `test/fresh-ceremony-after-delete` | `session_deletion_test.go` | unchanged and green | #46's guard. No new code, named because it is the case decision 6 must not break and stage 5 depends on it |
+
+   **Driven through request shapes #109 is not rewriting**, per decision 13. Both logout cases supply
+   `id_token_hint` **and** `post_logout_redirect_uri`, because #109 item 1 is that the second is wrongly
+   required and its check returns before the teardown. They assert only what #129 cares about, that no
+   grant was revoked, and nothing about whether the parameter was required, how the redirect was built,
+   or whether the session row survived, which is #109 divergence B's business. The hint is taken from
+   the token exchange's own `id_token` rather than from the logout-request API, so the case does not
+   depend on that API's client resolution, which is also #109's surface.
+
+   **What this tier deliberately does not prove.** The marker's distinctive property, that a child
+   inserted after termination is born already rejected, is invisible here: the sweep revokes every
+   token that exists at termination, so these cases would pass against a sweep with no marker at all.
+   That is correct division of labour, seams 1 to 4 own the column and section 5 rejects asserting
+   `codes.revoked` from an integration test, and stage 8 owns the racing-child evidence.
+9. **Verify.** Status: **Done**
+   `check-anchors.sh`, then `where.sh test --type modules` and `where.sh test --type integration`. The
+   integration tier runs for the first time this run, so a failure there is as likely to be harness as
+   regression and gets diagnosed rather than worked around.
+
+**As built.** All nine steps landed as written. Five deviations, all small, plus one omission with a
+stated reason.
+
+1. **Two sealed anchor rows were re-swept**, which no earlier stage had to do: `admin/session-delete`
+   and `account/session-delete` cited the bare `DeleteUserSession` calls this stage replaced, so their
+   locators resolved to nothing. Both now cite the helper call and say in their note that stage 4
+   re-swept them. Stage 1's line "Nothing above the line changed" no longer holds, and saying so here
+   is cheaper than leaving a reader to notice.
+2. **Nine anchor rows added**, more than any earlier stage, because the stage created two test files,
+   an emitter, a catalog key and four integration cases.
+3. Both handlers hoist `authHelper.GetLoggedInSubject(r)` into a local rather than calling it twice,
+   one call per event. No behaviour change; it just stops the two payloads reading as though they
+   could disagree.
+4. `secondOfflineGrantForSameUser` landed in `credential_change_revocation_test.go`, which is #106's
+   file, rather than in the suite that uses it. That is where `offlineGrant`, `createOfflineGrant` and
+   `secondSessionFor` already live, and it sits directly beneath the helper it mirrors.
+5. The consent branch the helper was going to need turned out to be unnecessary: both
+   `HandleAuthCompletedGet` and `HandleConsentGet` route an `offline_access` request to consent
+   unconditionally, to re-confirm the refresh token grant, so the second ceremony is deterministic and
+   the helper asserts the consent screen rather than branching on it. Verified in both handlers.
+6. **Omitted deliberately: a case for the no-hint POST at `logout/basic-post-fork`.** Seam 9 made it
+   conditional, "if a case covers the no-hint POST", and it was not written. That path calls no
+   revocation code at all, so a case there would pin nothing the `id_token_hint` cases do not already
+   pin, and decision 13 leaves the path itself to #109, where it is drafted as follow-up 2.
 
 ### Stage 5: the `/auth/completed` gate
 Status: **Not started**
@@ -2016,6 +2145,122 @@ never written stalls the loop silently rather than loudly.
 
 **Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
 `Decided`. No follow-up found: the only defect this stage surfaced was in its own comments.
+
+### Stage 4, 2026-08-04
+
+**Landed.** The activation stage, in one commit as the plan review's finding 2 requires.
+`revoke/log-terminated`, that is `LogTerminatedUserSession`; both endpoints calling
+`TerminateUserSessionTx` at `admin/session-delete` and `account/session-delete`, each emitting
+`AuditDeletedUserSession` with its payload untouched plus `terminated_user_session` with decision 9's
+six keys, both after the commit and neither on the error path; the two handler test files section 1
+asked for, six cases over `test/terminate-endpoint-audit`, `test/failure-suppresses-events` and
+`test/forbidden-does-not-terminate` among them; five integration cases, `test/terminate-offline-endpoint`,
+its account sibling, the account 403 pairing, and the two logout pinnings starting at
+`test/logout-revokes-nothing`; one new harness helper at `test/second-offline-grant`; decision 14's
+`catalog/modal-revocation-note` and its five siblings plus one line in each of the three templates; and
+the four documentation pages. Nine anchor rows added and two sealed ones re-swept.
+
+**This is the commit where the behaviour changes.** Stages 1 to 3 were inert by construction: the
+column existed with nothing writing it, the rejections existed with nothing marked, and the helper
+existed with no caller. After this commit ending a session at either endpoint revokes the codes of that
+session and the refresh tokens those grants issued, offline ones included, and every page and modal
+that describes the action says so in the same commit.
+
+**Tiers.** Unit green, all three modules, run at the gate after the mutations below were reverted
+("All tests completed successfully", no `FAIL` lines). The stage's six new unit cases pass.
+Integration green on **all four engines**, `where.sh test --type integration` exit 0, 3544 passing
+tests, zero `FAIL` lines; each of the five new cases passes four times, once per engine. No data tier,
+correctly: this stage adds no query and no migration, and every data method it reaches was covered on
+four engines in stage 1 or already existed. `check-anchors.sh` passes all 57 rows, `gofmt -l` is silent,
+`git diff --check` is clean, and `cd site && npm run build` completes with 42 pages and no link errors.
+
+**The integration tier ran for the first time in this run**, and it needed no repair: the two earlier
+stages recorded it as not applicable rather than untried.
+
+**Mutation evidence, because three of this stage's rows exist to catch specific mistakes.** Each
+mutation was applied to the real code, run, and reverted, in this session.
+
+1. **The sid-scoped sweep replaced by the user-scoped one**, `GetRefreshTokensByUserId`, which is the
+   plausible tidy-up that reuses #106's query. At the integration tier exactly one assertion failed,
+   the survivor half of `test/terminate-offline-endpoint`: "the same user's OTHER session must be
+   untouched: map[error:invalid_grant error_description:This refresh token has been revoked.]". The
+   terminated half still passed, which is the point: without the survivor row this mutation ships. At
+   the unit tier it also failed four `TestTerminateUserSessionTx_*` cases on the strict mock, so both
+   tiers catch it, and the integration one catches it as the observable outcome rather than as an
+   unexpected call.
+2. **Termination moved ahead of the account handler's ownership check.** Exactly
+   `test/forbidden-does-not-terminate` and `TestHandleAPIAccountSessionDelete_TerminationFailureIsA500`
+   failed. The happy-path case still passed, and so, by reading, would the pre-existing integration
+   case `TestAPIAccountSessionDelete_ForbiddenOnOtherUsersSession`, which asserts only the status code
+   and the error description. That is the whole argument for adding both the unit row and its
+   integration pairing: before #129 the mistake leaked nothing, and after it revokes a stranger's
+   grants.
+3. **`AuditDeletedUserSession` moved above the error check**, in both handlers, which is the one-line
+   mistake the two adjacent emitters invite. Exactly the two `_TerminationFailureIsA500` cases failed,
+   one per handler, and nothing else. That is the contract the plan review said had no other home, and
+   it now has a measurement rather than an argument.
+
+**Deviations from the plan as written.** Six, recorded in full in the stage's as-built note above: two
+sealed anchor rows re-swept, nine anchor rows rather than an unstated number, `GetLoggedInSubject`
+hoisted to one call per handler, the new harness helper placed in #106's test file beside the helper it
+mirrors, the helper's consent branch dropped once both handlers were verified to route
+`offline_access` to consent unconditionally, and the no-hint POST logout case deliberately not written.
+
+**Nothing deferred, nothing contested, no decision raised.** Section 3 keeps its fourteen items, all
+`Decided`. No follow-up found: the only surprise this stage produced was that the consent path is
+unconditional, which is existing behaviour working as its comments describe.
+
+**Review request.** `129-20260805T000627Z`. The two new test files were marked intent-to-add so
+`git diff` covers them, which no earlier stage needed; the request carries the resulting hash and this
+entry deliberately does not, since recording it here changes it. Everything above this line was written
+before the review ran, which is stage 3's lesson: the trace goes into the agreement at the moment it is
+known, because the mailbox does not survive the next gate.
+
+**Review, round 1, clean.** `gpt-5.6-sol`, effort high, `type: code-review`. Conformance, quality and
+security all `reviewed`, verdict `clean`, zero findings and zero follow-ups. The scope is recorded
+below rather than summarised, because zero findings in a narrow scope reads exactly like zero findings
+in a thorough one.
+
+**What it ran**, its own list: `where.sh test --type modules` passing all three modules,
+`where.sh test --type integration` passing on mysql, postgres, mssql and sqlite, `npm run build`
+completing with 42 pages, `check-anchors.sh` passing all 57 rows, `git diff --check HEAD` clean, and
+`gofmt -l` silent on every changed Go file. This is the second gate at which the reviewer reached a
+test tier and the first at which it reached the integration one, which the stage 1 and 2 entries above
+record it could not.
+
+**What it checked by reading**, named because these are the stage's contracts rather than general
+approval: that `admin/session-delete` and `account/session-delete` are the only production callers this
+stage adds for `TerminateUserSessionTx`, with decision 5's four excluded `DeleteUserSession` callers
+untouched; that the account handler resolves the token subject and compares `us.UserId` to it before
+opening the transaction, and the admin handler's 404 and two 400s still answer first; that both
+handlers emit `deleted_user_session` with exactly its two prior keys and then `terminated_user_session`
+with exactly decision 9's six, both after a successful helper return and so after the commit, and
+neither reachable from an error path; that the six catalog values contain no double quote that would
+break their JavaScript literal and each template appends before its current-session warning; that the
+four pages describe what stage 4 actually provides and do **not** claim the stage 5 and 6 ceremony gap
+is closed; and that the logout production path is unchanged, with both new cases supplying
+`id_token_hint` and `post_logout_redirect_uri` and asserting only what decision 3 owns. On security it
+recorded that storage failures fail closed through both handlers and the helper, that the marker
+update, the sid-scoped sweep and the session delete share one transaction with parameterised
+predicates, that the join reaches offline tokens through their code without widening to another session
+or user, and that no raw code, refresh token, client secret or OTP reaches a log, response, template or
+URL.
+
+**Its `unchecked` list holds nothing the gate depended on.** The data tier, correctly not applicable to
+a stage adding no query, interface method, migration or schema change, with stage 1's four-engine
+evidence standing behind every data method it reaches; the run's own three source mutations, which it
+assessed statically by inspecting each target branch and the tests claimed to catch it, because a
+reviewer may not modify source under review; and unchanged cryptography, token signature internals,
+global PKCE policy, redirect matching and unrelated rate limiting, none of which the diff reaches.
+
+**Hash check clean.** `git diff HEAD | sha256sum` was still `570a8395…` when this session started,
+matching both `.review/before.sha` and the hash the reviewer reported after its run, so it changed no
+tracked file and reviewed exactly the code committed here. `check-anchors.sh` re-run at ingestion, 57
+rows passing, and the two handler diffs re-read against the reviewer's conformance claims before this
+was written.
+
+**No round 2.** All three axes reviewed with the tiers actually executed and zero findings is the clean
+case the reviewer reference describes, and nothing changed after the reviewed hash.
 
 ---
 

--- a/site/src/content/docs/concepts/tokens.mdx
+++ b/site/src/content/docs/concepts/tokens.mdx
@@ -85,12 +85,14 @@ Normal tokens are linked to the user session. They can be used to get a new acce
 
 ### Offline refresh tokens
 
-Offline refresh tokens are not linked to a user session. They can be used to obtain a new access token even when the user is not actively using the application.
+Offline refresh tokens don't depend on an active user session. They can be used to obtain a new access token even when the user is not actively using the application, and they keep working after the browser session that created them has expired.
 
 - They are governed by two limits, both configurable on **Settings → Tokens**: an idle timeout (defaults to 30 days) and a maximum lifetime (defaults to 1 year)
 - Useful for background tasks or applications that need to access resources on behalf of users without their immediate interaction
 
-Because an offline refresh token can remain usable for a long time, and keeps working after the browser session that created it has gone, it is the grant most worth thinking about when a user's credentials change. See [credential changes and live sessions](/concepts/user-sessions/#credential-changes-and-live-sessions).
+A session expiring and a session being ended are not the same thing, and only the first leaves an offline token working. When somebody explicitly ends the session an offline token was authorized through, that token is revoked. See [ending a session](/concepts/user-sessions/#ending-a-session).
+
+Because an offline refresh token can remain usable for a long time, it is also the grant most worth thinking about when a user's credentials change. See [credential changes and live sessions](/concepts/user-sessions/#credential-changes-and-live-sessions).
 
 ### Requesting offline tokens
 

--- a/site/src/content/docs/concepts/user-sessions.mdx
+++ b/site/src/content/docs/concepts/user-sessions.mdx
@@ -69,6 +69,10 @@ This is what separates ending a session from a session merely expiring. An offli
 
 A sign-in that was still in progress cannot slip past this. If someone was partway through signing in to an application and was relying on the session you ended rather than typing a password, that sign-in does not quietly become a replacement session. Goiabada sends them back to the login page instead.
 
+Nor can a sign-in that had already reached the consent screen. Goiabada checks the session once more at the very last step, just before it hands the application its authorization code, so a sign-in left waiting on that screen is sent back to the login page as well rather than collecting a code on a session that is no longer there.
+
+An application renewing quietly in the background with [`prompt=none`](/concepts/prompt-parameter/) hits the same check and is told rather than shown: it gets a `login_required` error back, never a login page, so it can decide when to ask the person to sign in again.
+
 Logging out is not the same thing. It is navigation rather than a security decision, so it leaves refresh tokens alone.
 
 Each termination writes two entries to the [audit log](/concepts/audit-log/): `terminated_user_session`, recording what was revoked, and `deleted_user_session`, the lifecycle record beside it. Count `terminated_user_session` if you want to know how many sessions were ended.

--- a/site/src/content/docs/concepts/user-sessions.mdx
+++ b/site/src/content/docs/concepts/user-sessions.mdx
@@ -55,6 +55,28 @@ This is inherent to stateless tokens rather than a limitation of the revocation 
 If your resource servers must reject access immediately after a credential change, they need to verify the token against Goiabada on each request rather than relying on signature validation alone.
 </Aside>
 
+## Ending a session
+
+A session can be ended explicitly: a user ends one from their own sessions page, or an administrator ends one from the user or client pages. That is a security action rather than housekeeping, so it also cuts off what the session authorized.
+
+| What | Effect |
+| ---- | ------ |
+| The session | Deleted. That device has to sign in again |
+| Refresh tokens from that session | Revoked, including offline ones that were still working in the background |
+| Authorization codes from that session | Revoked, so a code that was issued but not yet redeemed can no longer be exchanged |
+
+This is what separates ending a session from a session merely expiring. An offline refresh token is meant to outlive the browser session it came from, so it keeps working when that session times out. Ending the session revokes it deliberately.
+
+Logging out is not the same thing. It is navigation rather than a security decision, so it leaves refresh tokens alone.
+
+Each termination writes two entries to the [audit log](/concepts/audit-log/): `terminated_user_session`, recording what was revoked, and `deleted_user_session`, the lifecycle record beside it. Count `terminated_user_session` if you want to know how many sessions were ended.
+
+### What ending a session does not cover
+
+An access token that was already issued for an offline grant keeps working until it expires, even at Goiabada's own endpoints. Offline access tokens carry no reference to a session, so there is nothing for Goiabada to match against the session you ended. This differs from a credential change, where Goiabada's own endpoints reject the old token on the very next request.
+
+The bound is the access token's own expiration, 5 minutes by default. If you have raised **Token expiration** substantially, you have widened it.
+
 ## Forcing re-authentication
 
 There are two ways to force re-authentication in an authorization request:

--- a/site/src/content/docs/concepts/user-sessions.mdx
+++ b/site/src/content/docs/concepts/user-sessions.mdx
@@ -67,6 +67,8 @@ A session can be ended explicitly: a user ends one from their own sessions page,
 
 This is what separates ending a session from a session merely expiring. An offline refresh token is meant to outlive the browser session it came from, so it keeps working when that session times out. Ending the session revokes it deliberately.
 
+A sign-in that was still in progress cannot slip past this. If someone was partway through signing in to an application and was relying on the session you ended rather than typing a password, that sign-in does not quietly become a replacement session. Goiabada sends them back to the login page instead.
+
 Logging out is not the same thing. It is navigation rather than a security decision, so it leaves refresh tokens alone.
 
 Each termination writes two entries to the [audit log](/concepts/audit-log/): `terminated_user_session`, recording what was revoked, and `deleted_user_session`, the lifecycle record beside it. Count `terminated_user_session` if you want to know how many sessions were ended.

--- a/site/src/content/docs/integration/rest-api.mdx
+++ b/site/src/content/docs/integration/rest-api.mdx
@@ -542,7 +542,7 @@ Updates session metadata (implementation specific).
 DELETE /api/v1/admin/user-sessions/{id}
 ```
 
-Terminates a user session by ID.
+Terminates a user session by ID. This also revokes the refresh tokens and authorization codes that session authorized, including offline refresh tokens. See [ending a session](/concepts/user-sessions/#ending-a-session).
 
 ---
 
@@ -1542,6 +1542,8 @@ Returns all active sessions with device info and validity status. Each session i
 ```
 DELETE /api/v1/account/sessions/{id}
 ```
+
+Terminates one of the caller's own sessions, including the current one. This also revokes the refresh tokens and authorization codes that session authorized, including offline refresh tokens. See [ending a session](/concepts/user-sessions/#ending-a-session).
 
 ---
 

--- a/site/src/content/docs/reference/security.mdx
+++ b/site/src/content/docs/reference/security.mdx
@@ -31,6 +31,7 @@ Goiabada includes several built-in security features:
 - **Two-factor authentication** - Optional or mandatory 2FA using TOTP
 - **Rate limiting** - Configurable rate limiting on sensitive endpoints (login, OTP verification, password reset)
 - **Session management** - Configurable session timeouts with idle and absolute expiration
+- **Durable session termination** - Ending a session revokes the refresh tokens and authorization codes that session authorized, including offline refresh tokens that outlive the browser session. A `terminated_user_session` [audit event](/concepts/audit-log/) records what each termination revoked. See [ending a session](/concepts/user-sessions/#ending-a-session)
 
 ### Token security
 

--- a/src/adminconsole/web/template/account_user_sessions.html
+++ b/src/adminconsole/web/template/account_user_sessions.html
@@ -17,6 +17,7 @@
     function endSessionClick(elem, evt, userSessionId, device, isCurrent) {
 
         let msg = "{{ T $.ctx "adminconsole.account.sessions.modal_confirm_body_prefix" }}" + device + "{{ T $.ctx "adminconsole.account.sessions.modal_confirm_body_suffix" }}";
+        msg += "{{ T $.ctx "adminconsole.account.sessions.modal_revocation_note" }}";
         if(isCurrent) {
             msg += "{{ T $.ctx "adminconsole.account.sessions.modal_current_warning" }}";
         }

--- a/src/adminconsole/web/template/admin_clients_usersessions.html
+++ b/src/adminconsole/web/template/admin_clients_usersessions.html
@@ -12,6 +12,7 @@
     function endSessionClick(elem, evt, userSessionId, email, device, isCurrent) {
 
         let msg = "{{ T $.ctx "adminconsole.admin_clients.usersessions.modal_confirm_body_prefix" }}" + email + "{{ T $.ctx "adminconsole.admin_clients.usersessions.modal_confirm_body_suffix" }}";
+        msg += "{{ T $.ctx "adminconsole.admin_clients.usersessions.modal_revocation_note" }}";
         if(isCurrent) {
             msg += "{{ T $.ctx "adminconsole.admin_clients.usersessions.modal_current_warning" }}";
         }

--- a/src/adminconsole/web/template/admin_users_sessions.html
+++ b/src/adminconsole/web/template/admin_users_sessions.html
@@ -12,6 +12,7 @@
     function endSessionClick(elem, evt, userSessionId, device, isCurrent) {
 
         let msg = "{{ T $.ctx "adminconsole.admin_users.sessions.modal_confirm_body_prefix" }}" + device + "{{ T $.ctx "adminconsole.admin_users.sessions.modal_confirm_body_suffix" }}";
+        msg += "{{ T $.ctx "adminconsole.admin_users.sessions.modal_revocation_note" }}";
         if (isCurrent) {
             msg += "{{ T $.ctx "adminconsole.admin_users.sessions.modal_confirm_current_warning" }}";
         }

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_sessions.go
@@ -181,17 +181,26 @@ func HandleAPIAccountSessionDelete(
 			return
 		}
 
-		// Delete session (including current, allowed)
-		if err := database.DeleteUserSession(nil, sessionId); err != nil {
+		// Terminate the session, including the current one, rather than merely deleting it: this is
+		// the explicit self-service "end this session" action, so it also marks the codes issued
+		// through the session revoked and sweeps the refresh tokens those grants produced, in one
+		// transaction (#129 decision 5). The ownership check above answers 403 first, so this is
+		// never reached for somebody else's session.
+		result, err := handlers.TerminateUserSessionTx(database, us)
+		if err != nil {
 			writeJSONError(w, "Internal server error", "INTERNAL_SERVER_ERROR", http.StatusInternalServerError)
 			return
 		}
 
-		// Audit
+		// Both events, after the commit, neither on the error path above: an audited termination
+		// that rolled back would be a false record. deleted_user_session keeps its existing
+		// payload untouched and terminated_user_session carries the security detail (decision 9).
+		loggedInUser := authHelper.GetLoggedInSubject(r)
 		auditLogger.Log(constants.AuditDeletedUserSession, map[string]interface{}{
 			"userSessionId": sessionId,
-			"loggedInUser":  authHelper.GetLoggedInSubject(r),
+			"loggedInUser":  loggedInUser,
 		})
+		handlers.LogTerminatedUserSession(auditLogger, us, loggedInUser, result)
 
 		// Success response
 		resp := api.SuccessResponse{Success: true}

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_sessions_test.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_sessions_test.go
@@ -1,0 +1,145 @@
+package apihandlers
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
+	"github.com/leodip/goiabada/core/constants"
+	mocks_data "github.com/leodip/goiabada/core/data/mocks"
+	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// The self-service half of #129 stage 4. This file did not exist either, for the reason recorded at
+// the top of handler_api_users_sessions_test.go, and it shares that file's stubTermination and
+// apiTerminateTx.
+//
+// What is unique to this site is the ownership check: it must answer 403 BEFORE anything is
+// terminated, and the pre-existing integration case asserts only the status code, which a handler
+// terminating first would still satisfy.
+
+// accountSessionDeleteRequest builds the DELETE with the chi URL parameter and the validated token
+// the handler reads.
+func accountSessionDeleteRequest(sessionId string, subject string) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/account/sessions/"+sessionId, nil)
+	req = setChiURLParam(req, "id", sessionId)
+	return setTokenContextWithClaims(req, map[string]interface{}{"sub": subject})
+}
+
+// TestHandleAPIAccountSessionDelete_TerminatesAndAuditsBothEvents is the wiring test for the
+// self-service half of decision 5. The payload is asserted here too rather than left to the admin
+// site: LogTerminatedUserSession is shared, but which session row each handler hands it is not, and
+// this is the site that resolves the row through an ownership check first.
+func TestHandleAPIAccountSessionDelete_TerminatesAndAuditsBothEvents(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	const subject = "the-user"
+	user := &models.User{Id: 42, Enabled: true}
+	userSession := &models.UserSession{Id: 100, SessionIdentifier: "sid-own", UserId: 42}
+
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(100)).Return(userSession, nil).Once()
+	database.On("GetUserBySubject", (*sql.Tx)(nil), subject).Return(user, nil).Once()
+	stubTermination(database, userSession, 1, []*models.RefreshToken{
+		{Id: 1, RefreshTokenJti: "rt-live"},
+	})
+
+	authHelper.On("GetLoggedInSubject", mock.Anything).Return(subject)
+	var deletedPayload map[string]interface{}
+	auditLogger.On("Log", constants.AuditDeletedUserSession, mock.Anything).
+		Run(func(args mock.Arguments) {
+			deletedPayload = args.Get(1).(map[string]interface{})
+		}).Return().Once()
+	var terminatedPayload map[string]interface{}
+	auditLogger.On("Log", constants.AuditTerminatedUserSession, mock.Anything).
+		Run(func(args mock.Arguments) {
+			terminatedPayload = args.Get(1).(map[string]interface{})
+		}).Return().Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIAccountSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, accountSessionDeleteRequest("100", subject))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+
+	require.NotNil(t, deletedPayload)
+	assert.Equal(t, int64(100), deletedPayload["userSessionId"])
+	assert.Equal(t, subject, deletedPayload["loggedInUser"])
+	assert.Len(t, deletedPayload, 2)
+
+	require.NotNil(t, terminatedPayload)
+	assert.Equal(t, int64(42), terminatedPayload["userId"])
+	assert.Equal(t, int64(100), terminatedPayload["userSessionId"])
+	assert.Equal(t, "sid-own", terminatedPayload["sessionIdentifier"])
+	assert.Equal(t, subject, terminatedPayload["loggedInUser"])
+	assert.Equal(t, int64(1), terminatedPayload["revokedCodeCount"])
+	assert.Equal(t, []string{"rt-live"}, terminatedPayload["revokedRefreshTokenJtis"])
+	assert.Len(t, terminatedPayload, 6)
+}
+
+// TestHandleAPIAccountSessionDelete_ForbiddenDoesNotTerminate is the row that carries this file.
+// KEEP IT. Ownership has to answer before termination, and the pre-existing integration case
+// (TestAPIAccountSessionDelete_ForbiddenOnOtherUsersSession) asserts only the 403, so a handler that
+// terminated somebody else's session and THEN refused would leave it green. The strict mock is the
+// mechanism: no termination expectation is registered, so any call fails the test.
+func TestHandleAPIAccountSessionDelete_ForbiddenDoesNotTerminate(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	const subject = "the-user"
+	// The session belongs to user 7; the caller is user 42.
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(100)).
+		Return(&models.UserSession{Id: 100, SessionIdentifier: "sid-someone-else", UserId: 7}, nil).Once()
+	database.On("GetUserBySubject", (*sql.Tx)(nil), subject).
+		Return(&models.User{Id: 42, Enabled: true}, nil).Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIAccountSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, accountSessionDeleteRequest("100", subject))
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	database.AssertExpectations(t)
+	database.AssertNotCalled(t, "BeginTransaction")
+	database.AssertNotCalled(t, "RevokeCodesBySessionIdentifier", mock.Anything, mock.Anything)
+	database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+	auditLogger.AssertNotCalled(t, "Log", mock.Anything, mock.Anything)
+}
+
+// TestHandleAPIAccountSessionDelete_TerminationFailureIsA500 repeats the suppression contract at the
+// second site deliberately. The two audit emitters are adjacent in both handlers, so leaving the
+// first one outside the error check is a one-line mistake that the other site's test cannot see.
+func TestHandleAPIAccountSessionDelete_TerminationFailureIsA500(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	const subject = "the-user"
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(100)).
+		Return(&models.UserSession{Id: 100, SessionIdentifier: "sid-own", UserId: 42}, nil).Once()
+	database.On("GetUserBySubject", (*sql.Tx)(nil), subject).
+		Return(&models.User{Id: 42, Enabled: true}, nil).Once()
+	database.On("BeginTransaction").Return(apiTerminateTx, nil).Once()
+	database.On("RevokeCodesBySessionIdentifier", apiTerminateTx, "sid-own").
+		Return(int64(0), errors.New("the code sweep failed")).Once()
+	database.On("RollbackTransaction", apiTerminateTx).Return(nil).Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIAccountSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, accountSessionDeleteRequest("100", subject))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	database.AssertExpectations(t)
+	database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+	auditLogger.AssertNotCalled(t, "Log", mock.Anything, mock.Anything)
+}

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_sessions.go
@@ -172,18 +172,26 @@ func HandleAPIUserSessionDelete(
 			return
 		}
 
-		// Delete the user session
-		err = database.DeleteUserSession(nil, sessionId)
+		// Terminate the session rather than merely deleting it: this is the explicit
+		// administrative "end this session" action, so it also marks the codes issued through the
+		// session revoked and sweeps the refresh tokens those grants produced, all in one
+		// transaction (#129 decision 5). The 404 above answers first, so a missing session never
+		// opens one.
+		result, err := handlers.TerminateUserSessionTx(database, userSession)
 		if err != nil {
 			writeJSONError(w, "Internal server error", "INTERNAL_SERVER_ERROR", http.StatusInternalServerError)
 			return
 		}
 
-		// Log audit event
+		// Both events, after the commit, neither on the error path above: an audited termination
+		// that rolled back would be a false record. deleted_user_session keeps its existing
+		// payload untouched and terminated_user_session carries the security detail (decision 9).
+		loggedInUser := authHelper.GetLoggedInSubject(r)
 		auditLogger.Log(constants.AuditDeletedUserSession, map[string]interface{}{
 			"userSessionId": sessionId,
-			"loggedInUser":  authHelper.GetLoggedInSubject(r),
+			"loggedInUser":  loggedInUser,
 		})
+		handlers.LogTerminatedUserSession(auditLogger, userSession, loggedInUser, result)
 
 		// Return success response
 		response := api.SuccessResponse{

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_sessions_test.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_sessions_test.go
@@ -1,0 +1,175 @@
+package apihandlers
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
+	"github.com/leodip/goiabada/core/constants"
+	mocks_data "github.com/leodip/goiabada/core/data/mocks"
+	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// This file did not exist before #129 stage 4, and section 1 of the agreement recorded its absence
+// as a finding rather than an oversight: neither session-delete endpoint had any unit coverage.
+//
+// What it owns is decision 9's audit contract, and that contract has no other home. The integration
+// tier can read audit rows back through GetAuditLogsPaginated, so it can observe the success half,
+// but it cannot force the termination transaction to fail, so nothing there can prove BOTH events
+// are suppressed when it does. The termination table itself lives in revocation_test.go and is not
+// restated here.
+
+// apiTerminateTx is an opaque non-nil transaction, the counterpart of apiRevokeTx. Letting
+// BeginTransaction return nil would exercise a shape production never runs.
+var apiTerminateTx = &sql.Tx{}
+
+// stubTermination registers the calls TerminateUserSessionTx makes for one session. Thin on
+// purpose, following stubSweep: revocation_test.go owns the exhaustive termination table over the
+// happy path, both entry guards and all six failure points, and restating it here would mean two
+// places to update.
+func stubTermination(database *mocks_data.Database, userSession *models.UserSession,
+	revokedCodeCount int64, tokens []*models.RefreshToken) {
+
+	database.On("BeginTransaction").Return(apiTerminateTx, nil).Once()
+	database.On("RevokeCodesBySessionIdentifier", apiTerminateTx, userSession.SessionIdentifier).
+		Return(revokedCodeCount, nil).Once()
+	database.On("GetRefreshTokensBySessionIdentifier", apiTerminateTx, userSession.SessionIdentifier).
+		Return(tokens, nil).Once()
+	for i := range tokens {
+		if tokens[i].Revoked {
+			continue
+		}
+		jti := tokens[i].RefreshTokenJti
+		database.On("UpdateRefreshToken", apiTerminateTx, mock.MatchedBy(func(rt *models.RefreshToken) bool {
+			return rt.RefreshTokenJti == jti
+		})).Return(nil).Once()
+	}
+	database.On("DeleteUserSession", apiTerminateTx, userSession.Id).Return(nil).Once()
+	database.On("CommitTransaction", apiTerminateTx).Return(nil).Once()
+	database.On("RollbackTransaction", apiTerminateTx).Return(nil).Once()
+}
+
+// adminSessionDeleteRequest builds the DELETE with the chi URL parameter the handler reads.
+func adminSessionDeleteRequest(sessionId string) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/user-sessions/"+sessionId, nil)
+	return setChiURLParam(req, "id", sessionId)
+}
+
+// TestHandleAPIUserSessionDelete_TerminatesAndAuditsBothEvents is the wiring test for the
+// administrative half of decision 5, and it doubles as the field-by-field assertion on decision 9's
+// payload, because this is where the new event is emitted from.
+func TestHandleAPIUserSessionDelete_TerminatesAndAuditsBothEvents(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	const subject = "the-admin"
+	userSession := &models.UserSession{Id: 100, SessionIdentifier: "sid-terminated", UserId: 42}
+
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(100)).Return(userSession, nil).Once()
+	// One live token and one already revoked, so the JTI list below proves the payload reports what
+	// this call TRANSITIONED rather than what the session held.
+	stubTermination(database, userSession, 3, []*models.RefreshToken{
+		{Id: 1, RefreshTokenJti: "rt-live"},
+		{Id: 2, RefreshTokenJti: "rt-already-gone", Revoked: true},
+	})
+
+	authHelper.On("GetLoggedInSubject", mock.Anything).Return(subject)
+	var deletedPayload map[string]interface{}
+	auditLogger.On("Log", constants.AuditDeletedUserSession, mock.Anything).
+		Run(func(args mock.Arguments) {
+			deletedPayload = args.Get(1).(map[string]interface{})
+		}).Return().Once()
+	var terminatedPayload map[string]interface{}
+	auditLogger.On("Log", constants.AuditTerminatedUserSession, mock.Anything).
+		Run(func(args mock.Arguments) {
+			terminatedPayload = args.Get(1).(map[string]interface{})
+		}).Return().Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIUserSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, adminSessionDeleteRequest("100"))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+
+	// The older event's payload, unchanged. Decision 9 chose two events over one extended event on
+	// compatibility grounds, so an external consumer parsing this one strictly must keep working:
+	// exactly two keys, and neither renamed.
+	require.NotNil(t, deletedPayload)
+	assert.Equal(t, int64(100), deletedPayload["userSessionId"])
+	assert.Equal(t, subject, deletedPayload["loggedInUser"])
+	assert.Len(t, deletedPayload, 2)
+
+	// The new event's payload, field by field. Asserted here rather than trusted because it is the
+	// only durable record of what a termination revoked, and a missing or renamed field is invisible
+	// to every other test.
+	require.NotNil(t, terminatedPayload)
+	assert.Equal(t, int64(42), terminatedPayload["userId"])
+	assert.Equal(t, int64(100), terminatedPayload["userSessionId"])
+	assert.Equal(t, "sid-terminated", terminatedPayload["sessionIdentifier"])
+	assert.Equal(t, subject, terminatedPayload["loggedInUser"])
+	assert.Equal(t, int64(3), terminatedPayload["revokedCodeCount"])
+	assert.Equal(t, []string{"rt-live"}, terminatedPayload["revokedRefreshTokenJtis"])
+	// Exactly these six keys. A seventh would go unnoticed, and more importantly this pins that none
+	// of the six was dropped, which an assertion on a nil map value cannot do.
+	assert.Len(t, terminatedPayload, 6)
+}
+
+// TestHandleAPIUserSessionDelete_TerminationFailureIsA500 is the case that decided this file had to
+// exist. KEEP IT. The integration tier can read audit rows but cannot make the termination
+// transaction fail, so this is the only seam that can show neither event is emitted when it does.
+func TestHandleAPIUserSessionDelete_TerminationFailureIsA500(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	userSession := &models.UserSession{Id: 100, SessionIdentifier: "sid-terminated", UserId: 42}
+
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(100)).Return(userSession, nil).Once()
+	database.On("BeginTransaction").Return(apiTerminateTx, nil).Once()
+	database.On("RevokeCodesBySessionIdentifier", apiTerminateTx, "sid-terminated").
+		Return(int64(0), errors.New("the code sweep failed")).Once()
+	database.On("RollbackTransaction", apiTerminateTx).Return(nil).Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIUserSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, adminSessionDeleteRequest("100"))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	database.AssertExpectations(t)
+	database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+	// NEITHER event. deleted_user_session would otherwise claim a deletion that rolled back, and
+	// the two emitters are adjacent in the handler, so it is easy to leave the first one outside the
+	// error check.
+	auditLogger.AssertNotCalled(t, "Log", mock.Anything, mock.Anything)
+}
+
+// TestHandleAPIUserSessionDelete_NotFoundDoesNotTerminate pins that the pre-existing 404 still
+// answers first. Without it, a handler that terminated before looking the session up would pass
+// every other case here.
+func TestHandleAPIUserSessionDelete_NotFoundDoesNotTerminate(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	database.On("GetUserSessionById", (*sql.Tx)(nil), int64(999)).Return(nil, nil).Once()
+
+	rr := httptest.NewRecorder()
+	handler := HandleAPIUserSessionDelete(database, authHelper, auditLogger)
+	handler.ServeHTTP(rr, adminSessionDeleteRequest("999"))
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	database.AssertExpectations(t)
+	// No transaction is opened for a session that does not exist.
+	database.AssertNotCalled(t, "BeginTransaction")
+	auditLogger.AssertNotCalled(t, "Log", mock.Anything, mock.Anything)
+}

--- a/src/authserver/internal/handlers/handler_auth_completed.go
+++ b/src/authserver/internal/handlers/handler_auth_completed.go
@@ -74,9 +74,11 @@ func HandleAuthCompletedGet(
 
 		targetAcrLevel := authContext.GetTargetAcrLevel(client.DefaultAcrLevel)
 		hasValidUserSession := userSessionManager.HasValidUserSession(r.Context(), userSession, authContext.ParseRequestedMaxAge())
-		// authContext.AuthenticatedAt is set by the password handler when the user
-		// actually enters credentials. It is nil for SSO session reuse (existing
-		// session flows through level1completed without hitting the password handler).
+		// authContext.AuthenticatedAt is set when the user actually enters credentials in
+		// this ceremony, by the password handler and by the OTP handler. It is nil for SSO
+		// session reuse (existing session flows through level1completed without hitting
+		// either). Used only to decide whether to refresh the session's AuthTime below:
+		// it is NOT proof of level 1, since OTP alone sets it (#129 decision 15).
 		userReallyAuthenticated := authContext.AuthenticatedAt != nil && !authContext.AuthenticatedAt.IsZero()
 
 		if hasValidUserSession {
@@ -120,6 +122,36 @@ func HandleAuthCompletedGet(
 				"clientId": client.Id,
 			})
 		} else {
+			// No valid session. Only level 1 authentication performed in THIS ceremony
+			// justifies creating one: without this gate StartNewUserSession below mints a
+			// session from authContext.UserId with no proof anyone authenticated, so a
+			// ceremony whose session was ended mid-flight silently recreates it (#129
+			// decision 6).
+			//
+			// The predicate is deliberately "this ceremony did level 1" rather than "no
+			// valid session". The second shape is legitimate: a session is deleted and the
+			// user then starts a fresh ceremony and really does enter a password, which is
+			// what TestSessionDeletedDuringAuthFlow_LoginSucceeds guards (#46). There is no
+			// loop either, because the second pass through here has Level1AuthCompleted set
+			// by handler_auth_pwd.
+			//
+			// It reads Level1AuthCompleted rather than userReallyAuthenticated above, and
+			// that is the whole point of the field (#129 decision 15): AuthenticatedAt has
+			// two writers, and a ceremony that stepped up to OTP by reusing a session
+			// satisfies it without a password. handlePromptNone sets AuthenticatedAt too,
+			// from the session it reused, and while it goes straight to /auth/issue and
+			// never arrives here, it would be stopped rather than let through if it ever did.
+			if !authContext.Level1AuthCompleted {
+				authContext.AuthState = oauth.AuthStateRequiresLevel1
+				err = authHelper.SaveAuthContext(w, r, authContext)
+				if err != nil {
+					httpHelper.InternalServerError(w, r, err)
+					return
+				}
+				http.Redirect(w, r, config.GetAuthServer().BaseURL+"/auth/level1", http.StatusFound)
+				return
+			}
+
 			// start new session
 			newSession, err := userSessionManager.StartNewUserSession(
 				w, r, authContext.UserId, client.Id, authContext.AuthMethods, targetAcrLevel.String(),

--- a/src/authserver/internal/handlers/handler_auth_completed_test.go
+++ b/src/authserver/internal/handlers/handler_auth_completed_test.go
@@ -197,6 +197,101 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		permissionChecker.AssertExpectations(t)
 	})
 
+	// The only row that distinguishes the two spellings of userReallyAuthenticated. The SSO
+	// subtest above carries nil, which short-circuits before !IsZero() is reached, and the
+	// re-auth subtest carries a nonzero timestamp, which passes either way; so with the
+	// !IsZero() term deleted a zero AuthenticatedAt would count as authentication and the
+	// session's AuthTime would be overwritten with now. That term is pre-existing and the
+	// #129 gate does not read it, but nothing else in the file covers it (found by round 2
+	// of the stage 5 review).
+	t.Run("Successful flow, existing session, zero AuthenticatedAt does not refresh AuthTime", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		templateFS := &mocks_test.TestFS{}
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		// Non-nil but zero, which is what an AuthContext round-tripped through the cookie
+		// yields for an absent RFC 3339 timestamp.
+		var zeroAuthenticatedAt time.Time
+		authContext := &oauth.AuthContext{
+			AuthState:       oauth.AuthStateAuthenticationCompleted,
+			ClientId:        "test-client",
+			UserId:          1,
+			Scope:           "openid profile",
+			AuthenticatedAt: &zeroAuthenticatedAt,
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.MatchedBy(func(r *http.Request) bool {
+			return r.Context().Value(constants.ContextKeySessionIdentifier) == sessionIdentifier
+		})).Return(authContext, nil)
+
+		sessionAuthTime := time.Now().UTC().Add(-5 * time.Minute)
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: sessionAuthTime,
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			ConsentRequired:          false,
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		// No UpdateUserSession expectation: a zero timestamp is not authentication, so
+		// AuthTime must not be refreshed. Reaching it fails the case on the strict mock.
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: true,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("openid profile", nil)
+
+		// The session's existing AuthTime is carried forward rather than replaced.
+		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
+			return ac.AuthState == oauth.AuthStateReadyToIssueCode &&
+				ac.AuthenticatedAt != nil && ac.AuthenticatedAt.Equal(sessionAuthTime)
+		})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, config.GetAuthServer().BaseURL+"/auth/issue", rr.Header().Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
 	t.Run("Successful flow, new session, consent not required", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
@@ -211,6 +306,10 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/completed", nil)
 		rr := httptest.NewRecorder()
 
+		// This ceremony did level 1: handler_auth_pwd sets both of these. Without
+		// Level1AuthCompleted the #129 gate restarts level 1 rather than starting a
+		// session, so this subtest is also the positive control for that gate.
+		pwdAuthTime := time.Now().UTC()
 		authContext := &oauth.AuthContext{
 			AuthState:   oauth.AuthStateAuthenticationCompleted,
 			ClientId:    "test-client",
@@ -221,6 +320,8 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			// forwards THIS value. With 0 the assertion would also pass against a
 			// hard-coded zero (#106 decision 11).
 			AuthStateGeneration: 7,
+			AuthenticatedAt:     &pwdAuthTime,
+			Level1AuthCompleted: true,
 		}
 
 		sessionIdentifier := "new-test-session"
@@ -578,6 +679,8 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/completed", nil)
 		rr := httptest.NewRecorder()
 
+		// Positive control for the #129 gate, as in the subtest above.
+		pwdAuthTime := time.Now().UTC()
 		authContext := &oauth.AuthContext{
 			AuthState:   oauth.AuthStateAuthenticationCompleted,
 			ClientId:    "test-client",
@@ -588,6 +691,8 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			// forwards THIS value. With 0 the assertion would also pass against a
 			// hard-coded zero (#106 decision 11).
 			AuthStateGeneration: 7,
+			AuthenticatedAt:     &pwdAuthTime,
+			Level1AuthCompleted: true,
 		}
 
 		sessionIdentifier := "new-test-session"
@@ -663,6 +768,8 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/completed", nil)
 		rr := httptest.NewRecorder()
 
+		// Positive control for the #129 gate, as in the two subtests above.
+		pwdAuthTime := time.Now().UTC()
 		authContext := &oauth.AuthContext{
 			AuthState:   oauth.AuthStateAuthenticationCompleted,
 			ClientId:    "test-client",
@@ -672,6 +779,8 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			// Nonzero for the same reason as the other cases: it pins that the handler
 			// forwards this value rather than a hard-coded zero (#106).
 			AuthStateGeneration: 7,
+			AuthenticatedAt:     &pwdAuthTime,
+			Level1AuthCompleted: true,
 		}
 
 		sessionIdentifier := "new-test-session"
@@ -724,6 +833,156 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 
 		assert.Equal(t, http.StatusFound, rr.Code)
 		assert.Equal(t, config.GetAuthServer().BaseURL+"/auth/consent", rr.Header().Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	// #129 decisions 6 and 15. The two subtests below are the gate on the else branch; the
+	// three "new session" subtests above are its positive control, since they now differ
+	// from these only in carrying Level1AuthCompleted. That pairing is what pins the
+	// predicate as "this ceremony did level 1" rather than "no valid session", which is the
+	// shape TestSessionDeletedDuringAuthFlow_LoginSucceeds (#46) legitimately has.
+	//
+	// The second subtest is decision 15's: it carries a non-nil AuthenticatedAt written by
+	// the OTP handler, so it is the row that fails against a gate reading
+	// userReallyAuthenticated. That discriminator is still read on the valid-session branch,
+	// and the zero-AuthenticatedAt subtest above is what covers its !IsZero() term.
+	//
+	// StartNewUserSession is deliberately not stubbed on the strict mock, so reaching it
+	// fails the case on its own rather than through an assertion that could be deleted.
+	t.Run("No valid session and this ceremony did not authenticate, restarts level 1", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		templateFS := &mocks_test.TestFS{}
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		// An SSO ceremony: handler_authorize copied the session's user, methods and
+		// generation onto the context and never reached the password handler, so both
+		// AuthenticatedAt and Level1AuthCompleted are unset. The session was then ended
+		// mid-flight.
+		authContext := &oauth.AuthContext{
+			AuthState:           oauth.AuthStateAuthenticationCompleted,
+			ClientId:            "test-client",
+			UserId:              1,
+			Scope:               "openid profile",
+			AuthMethods:         "pwd",
+			AuthStateGeneration: 7,
+			Level1AuthCompleted: false,
+		}
+
+		sessionIdentifier := "terminated-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.MatchedBy(func(r *http.Request) bool {
+			return r.Context().Value(constants.ContextKeySessionIdentifier) == sessionIdentifier
+		})).Return(authContext, nil)
+
+		// The session is gone, which is what "ended mid-flight" looks like from here.
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(nil, nil)
+		database.On("UserSessionLoadUser", mock.Anything, (*models.UserSession)(nil)).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			ConsentRequired:          false,
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, (*models.UserSession)(nil), mock.AnythingOfType("*int")).Return(false)
+
+		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
+			return ac.AuthState == oauth.AuthStateRequiresLevel1
+		})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, config.GetAuthServer().BaseURL+"/auth/level1", rr.Header().Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("No valid session and only OTP authenticated this ceremony, restarts level 1", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		templateFS := &mocks_test.TestFS{}
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		// Decision 15's ceremony. An SSO reuse stepped up to level 2, so AuthMethods came
+		// off the reused session and handler_auth_otp set AuthenticatedAt on a successful
+		// code, but no password was ever entered, so Level1AuthCompleted stays false. A gate
+		// reading userReallyAuthenticated recreates the session here; this gate must not.
+		otpAuthTime := time.Now().UTC()
+		authContext := &oauth.AuthContext{
+			AuthState:           oauth.AuthStateAuthenticationCompleted,
+			ClientId:            "test-client",
+			UserId:              1,
+			Scope:               "openid profile",
+			AuthMethods:         "pwd otp",
+			AuthStateGeneration: 7,
+			AuthenticatedAt:     &otpAuthTime,
+			Level1AuthCompleted: false,
+		}
+
+		sessionIdentifier := "terminated-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.MatchedBy(func(r *http.Request) bool {
+			return r.Context().Value(constants.ContextKeySessionIdentifier) == sessionIdentifier
+		})).Return(authContext, nil)
+
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(nil, nil)
+		database.On("UserSessionLoadUser", mock.Anything, (*models.UserSession)(nil)).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			ConsentRequired:          false,
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, (*models.UserSession)(nil), mock.AnythingOfType("*int")).Return(false)
+
+		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
+			return ac.AuthState == oauth.AuthStateRequiresLevel1
+		})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, config.GetAuthServer().BaseURL+"/auth/level1", rr.Header().Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)

--- a/src/authserver/internal/handlers/handler_auth_issue.go
+++ b/src/authserver/internal/handlers/handler_auth_issue.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/customerrors"
 	"github.com/leodip/goiabada/core/data"
@@ -89,6 +90,89 @@ func HandleIssueGet(
 		}
 
 		// Authorization Code Flow
+
+		// A ceremony must not bind a grant to a session that no longer exists (#129
+		// decision 6, second half). The session was alive at /auth/completed, which bumped
+		// or created it, and the user may then have spent minutes on the consent screen;
+		// if it was ended in between, the code minted below is brand new and no marker
+		// written by the termination can reach it, because the row did not exist yet.
+		//
+		// An EMPTY identifier is the shape that case actually arrives in, not a stale one.
+		// MiddlewareSessionIdentifier looks the session up on every request and puts the
+		// identifier in the request context ONLY when the row exists, so the read above
+		// yields "" for a ceremony whose session was ended. The non-empty branch below
+		// covers the narrower race where the middleware saw the session alive on this very
+		// request and the termination committed afterwards.
+		//
+		// Neither case is inert. grantIsOffline treats an empty session identifier as an
+		// offline grant on its own, so a code issued here would yield an Offline refresh
+		// token: it stores a max lifetime instead of a session identifier and the validator
+		// never consults a session, which means it outlives the terminated session by up to
+		// RefreshTokenOfflineMaxLifetimeInSeconds whether or not offline_access was asked
+		// for.
+		//
+		// This is deliberately a LIVENESS check and not a validity one: it asks whether the
+		// row resolves, and leaves idle timeout and max age to /auth/completed, which has
+		// already applied them. Restarting level 1 rather than failing to the client is
+		// decision 6's answer for the same reason the gate at /auth/completed uses it, and
+		// the second pass mints a session of its own before arriving back here.
+		sessionIsLive := false
+		if sessionIdentifier != "" {
+			userSession, err := database.GetUserSessionBySessionIdentifier(nil, sessionIdentifier)
+			if err != nil {
+				httpHelper.InternalServerError(w, r, err)
+				return
+			}
+			sessionIsLive = userSession != nil
+		}
+		if !sessionIsLive {
+			// prompt=none is the one ceremony that cannot be restarted: /auth/level1 sends the
+			// browser to /auth/pwd, which renders a form, and this request forbids any UI at
+			// all (OIDC Core 3.1.2.1, and concepts/prompt-parameter.mdx says the same). Nothing
+			// between here and the form reads the prompt, so the client would be handed a login
+			// page and no error, and a silent-renewal iframe would wait for its own timeout
+			// instead. It gets login_required instead (#129 decision 16), which is what
+			// handlePromptNone itself returns when its session lookup finds no row: the
+			// condition really is the same one, arriving one redirect hop later, so the client
+			// cannot tell the two apart and does not need to. No code is minted on either
+			// branch, so the fail-open decision 6 closes stays closed.
+			if authContext.HasPromptValue("none") {
+				slog.Warn("the session backing this silent ceremony is gone, returning login_required instead of issuing a code",
+					"sessionIdentifier", sessionIdentifier)
+				// The clear goes FIRST, which is the order the code path below uses too.
+				// ClearAuthContext persists the deletion through a Set-Cookie on w, and
+				// redirToClientWithError commits the response in every response mode, so
+				// clearing afterwards leaves the header on a response already written and
+				// the browser keeps a ready_to_issue_code context it can replay. Failing
+				// the clear is a 500 rather than a refusal the browser cannot record.
+				err := authHelper.ClearAuthContext(w, r)
+				if err != nil {
+					httpHelper.InternalServerError(w, r, err)
+					return
+				}
+				err = redirToClientWithError(w, r, templateFS, constants.ErrorLoginRequired,
+					"User authentication is required",
+					authContext.ResponseMode, authContext.RedirectURI, authContext.State,
+					authContext.ResponseType)
+				if err != nil {
+					httpHelper.InternalServerError(w, r, err)
+					return
+				}
+				return
+			}
+
+			slog.Warn("the session backing this ceremony is gone, restarting level 1 instead of issuing a code",
+				"sessionIdentifier", sessionIdentifier)
+			authContext.AuthState = oauth.AuthStateRequiresLevel1
+			err = authHelper.SaveAuthContext(w, r, authContext)
+			if err != nil {
+				httpHelper.InternalServerError(w, r, err)
+				return
+			}
+			http.Redirect(w, r, config.GetAuthServer().BaseURL+"/auth/level1", http.StatusFound)
+			return
+		}
+
 		createCodeInput := &oauth.CreateCodeInput{
 			AuthContext:       *authContext,
 			SessionIdentifier: sessionIdentifier,
@@ -97,6 +181,26 @@ func HandleIssueGet(
 		if err != nil {
 			httpHelper.InternalServerError(w, r, err)
 			return
+		}
+
+		// The check above is a read followed by an insert, so a termination can commit
+		// between the two. This compensates for that (#129 decision 12): the two sweepers
+		// cover each other, since a code committing before the termination's UPDATE reads
+		// the codes table is marked by the termination, and a code committing after it is
+		// marked here. Only a code landing between that UPDATE and its COMMIT escapes both,
+		// which is recorded as a residual in the #129 agreement rather than closed here.
+		//
+		// A failure is a 500 rather than a code handed over: the row exists and carries no
+		// marker at this point, so returning it is exactly the fail-open this statement is
+		// for. Unredeemed it expires in 60 seconds.
+		codeRevoked, err := database.RevokeCodeIfSessionGone(nil, code.Id, sessionIdentifier)
+		if err != nil {
+			httpHelper.InternalServerError(w, r, err)
+			return
+		}
+		if codeRevoked {
+			slog.Warn("the session backing this ceremony was ended while its code was being issued, so the code was revoked",
+				"codeId", code.Id, "sessionIdentifier", sessionIdentifier)
 		}
 
 		auditLogger.Log(constants.AuditCreatedAuthCode, map[string]interface{}{

--- a/src/authserver/internal/handlers/handler_auth_issue_test.go
+++ b/src/authserver/internal/handlers/handler_auth_issue_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -95,8 +97,11 @@ func TestHandleIssueGet(t *testing.T) {
 
 		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
 
-		req, err := http.NewRequest("GET", "/auth/issue", nil)
-		assert.NoError(t, err)
+		// The positive control for the liveness check (#129 stage 6): the ordinary ceremony,
+		// with a session identifier in the context and a session row behind it. It fails
+		// against a check that refuses a live session, and the compensating call it now
+		// expects is what pins that the statement is issued at all.
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
 
 		rr := httptest.NewRecorder()
 
@@ -111,6 +116,8 @@ func TestHandleIssueGet(t *testing.T) {
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 
+		stubLiveSession(database)
+
 		// Mock code creation
 		mockCode := &models.Code{
 			Id:          1,
@@ -120,8 +127,13 @@ func TestHandleIssueGet(t *testing.T) {
 			State:       "test-state",
 		}
 		codeIssuer.On("CreateAuthCode", mock.MatchedBy(func(input *oauth.CreateCodeInput) bool {
-			return reflect.DeepEqual(input.AuthContext, *authContext)
+			return reflect.DeepEqual(input.AuthContext, *authContext) &&
+				input.SessionIdentifier == liveSessionIdentifier
 		})).Return(mockCode, nil)
+
+		// The compensating revoke, keyed on the code just inserted and the session it was
+		// bound to. It matches nothing here, since the session is live.
+		database.On("RevokeCodeIfSessionGone", (*sql.Tx)(nil), int64(1), liveSessionIdentifier).Return(false, nil)
 
 		// Mock audit logging
 		auditLogger.On("Log", constants.AuditCreatedAuthCode, mock.MatchedBy(func(details map[string]interface{}) bool {
@@ -142,8 +154,308 @@ func TestHandleIssueGet(t *testing.T) {
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)
 		codeIssuer.AssertExpectations(t)
+		database.AssertExpectations(t)
 		auditLogger.AssertExpectations(t)
 	})
+
+	// The liveness check from #129 decision 6's second half. The window it closes opens
+	// after /auth/completed: the session was alive and was bumped there, the user then sits
+	// on the consent screen, and the session is ended before the code is minted. Stage 1's
+	// marker cannot reach that code, because the row does not exist when the termination
+	// sweeps.
+	//
+	// "No code created" is enforced rather than asserted in the refusal rows below: the strict
+	// mocks_oauth.CodeIssuer carries no CreateAuthCode expectation, so reaching it fails the
+	// case on its own, and the audit logger is not stubbed either.
+	//
+	// Two outcomes, one predicate. An interactive ceremony restarts level 1 (decision 6), and
+	// a prompt=none one is returned login_required (decision 16), because a request that
+	// forbids UI cannot be sent to a password form.
+	t.Run("No session identifier in the context, restarts level 1", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		// An empty identifier is the shape the terminated ceremony actually arrives in:
+		// MiddlewareSessionIdentifier finds the row gone, deletes the identifier from the
+		// cookie session, and leaves it out of the request context. It is also the shape
+		// grantIsOffline reads as an offline grant, so a code issued here would produce a
+		// refresh token with a max lifetime and no session to check.
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		var savedAuthContext *oauth.AuthContext
+		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
+			savedAuthContext = ac
+			return ac.AuthState == oauth.AuthStateRequiresLevel1
+		})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Contains(t, rr.Header().Get("Location"), "/auth/level1")
+		assert.NotNil(t, savedAuthContext)
+		assert.Equal(t, oauth.AuthStateRequiresLevel1, savedAuthContext.AuthState)
+
+		// No lookup either: with nothing to resolve there is no question to ask the database.
+		database.AssertNotCalled(t, "GetUserSessionBySessionIdentifier")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
+	t.Run("Session identifier resolves to no session, restarts level 1", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		// The narrower half of the same predicate: the middleware saw the session alive on
+		// this very request and the termination committed immediately afterwards, so the
+		// identifier is still in the context but the row is gone.
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		database.On("GetUserSessionBySessionIdentifier", (*sql.Tx)(nil), liveSessionIdentifier).Return(nil, nil)
+
+		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
+			return ac.AuthState == oauth.AuthStateRequiresLevel1
+		})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Contains(t, rr.Header().Get("Location"), "/auth/level1")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
+	t.Run("No session and prompt=none, returns login_required to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		// The same empty identifier as the row above, arriving from handlePromptNone rather
+		// than from the consent screen: it validated and bumped the session, redirected here,
+		// and the session was ended in that hop. Restarting level 1 would render a password
+		// form, which this request forbids (#129 decision 16).
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+			Prompt:       "none",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		// Asserting that ClearAuthContext was called says nothing about whether the clear
+		// reaches the browser, because the real helper persists the deletion through a
+		// Set-Cookie on w and a header set after the redirect has written the status line
+		// is dropped. The stub writes a sentinel where the CookieStore would write that
+		// cookie, so the committed response is what carries the assertion below.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Header().Get("Location")
+		assert.Contains(t, location, "https://example.com/callback")
+		assert.Contains(t, location, "error=login_required")
+		assert.Contains(t, location, "state=test-state")
+		assert.NotContains(t, location, "code=")
+		assert.NotContains(t, location, "/auth/level1")
+
+		// Result() reads the header as it was when the response was committed, which is the
+		// only view that can tell the two orderings apart: rr.Header() shows the sentinel
+		// either way, since the handler and the stub share one live map.
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed, or the browser keeps a ready_to_issue_code context to replay")
+
+		// The ceremony ends here rather than being restarted, so the state the interactive
+		// rows assert is never saved.
+		authHelper.AssertNotCalled(t, "SaveAuthContext")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
+	t.Run("Session lookup fails", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		// A database fault must not read as a terminated session, and must not read as a
+		// live one either: no code is minted and no restart is offered.
+		dbError := errors.New("session lookup failed")
+		database.On("GetUserSessionBySessionIdentifier", (*sql.Tx)(nil), liveSessionIdentifier).Return(nil, dbError)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return err == dbError
+		})).Return()
+
+		handler.ServeHTTP(rr, req)
+
+		httpHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+		authHelper.AssertNotCalled(t, "SaveAuthContext")
+	})
+
+	t.Run("The compensating revoke fails, so no code reaches the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		stubLiveSession(database)
+
+		mockCode := &models.Code{
+			Id:          1,
+			Code:        "test-code",
+			ClientId:    1,
+			RedirectURI: "https://example.com/callback",
+			State:       "test-state",
+		}
+		codeIssuer.On("CreateAuthCode", mock.Anything).Return(mockCode, nil)
+
+		// The code row exists and carries no marker at this point, so handing it over is
+		// exactly the fail-open decision 12 closes. Unredeemed it expires in 60 seconds.
+		revokeError := errors.New("compensating revoke failed")
+		database.On("RevokeCodeIfSessionGone", (*sql.Tx)(nil), int64(1), liveSessionIdentifier).Return(false, revokeError)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return err == revokeError
+		})).Return()
+
+		handler.ServeHTTP(rr, req)
+
+		// Not a redirect to the client: the code was created but never delivered.
+		assert.NotContains(t, rr.Header().Get("Location"), "code=test-code")
+
+		httpHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertNotCalled(t, "Log")
+		authHelper.AssertNotCalled(t, "ClearAuthContext")
+	})
+}
+
+// liveSessionIdentifier is the session identifier the code-flow subtests put in the request
+// context. Any non-empty value does, since the liveness check asks the database rather than
+// parsing it.
+const liveSessionIdentifier = "session-identifier-abc"
+
+// requestWithSessionIdentifier builds the /auth/issue request the way
+// MiddlewareSessionIdentifier leaves it when the session row exists: the identifier is in the
+// request context. Its absence is the terminated case, which is why the subtests that expect
+// a code have to opt in (#129 stage 6).
+func requestWithSessionIdentifier(t *testing.T, sessionIdentifier string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("GET", "/auth/issue", nil)
+	assert.NoError(t, err)
+	return req.WithContext(context.WithValue(req.Context(),
+		constants.ContextKeySessionIdentifier, sessionIdentifier))
+}
+
+// stubLiveSession makes the liveness check pass, which is the precondition for reaching
+// CreateAuthCode at all after #129 stage 6.
+func stubLiveSession(database *mocks_data.Database) {
+	database.On("GetUserSessionBySessionIdentifier", (*sql.Tx)(nil), liveSessionIdentifier).
+		Return(&models.UserSession{Id: 55, SessionIdentifier: liveSessionIdentifier}, nil)
 }
 
 func TestIsImplicitFlow(t *testing.T) {
@@ -1091,8 +1403,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
 
-		req, err := http.NewRequest("GET", "/auth/issue", nil)
-		assert.NoError(t, err)
+		// A live session, since this subtest reaches code creation (#129 stage 6).
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
 
 		rr := httptest.NewRecorder()
 
@@ -1119,6 +1431,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		}
 		database.On("GetUserById", mock.Anything, int64(1)).Return(mockUser, nil)
 
+		stubLiveSession(database)
+
 		// Mock code creation
 		mockCode := &models.Code{
 			Id:          1,
@@ -1130,6 +1444,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		codeIssuer.On("CreateAuthCode", mock.MatchedBy(func(input *oauth.CreateCodeInput) bool {
 			return reflect.DeepEqual(input.AuthContext, *authContext)
 		})).Return(mockCode, nil)
+
+		database.On("RevokeCodeIfSessionGone", (*sql.Tx)(nil), int64(1), liveSessionIdentifier).Return(false, nil)
 
 		// Mock audit logging
 		auditLogger.On("Log", constants.AuditCreatedAuthCode, mock.MatchedBy(func(details map[string]interface{}) bool {
@@ -1229,8 +1545,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
 
-		req, err := http.NewRequest("GET", "/auth/issue", nil)
-		assert.NoError(t, err)
+		// A live session, since this subtest reaches code creation (#129 stage 6).
+		req := requestWithSessionIdentifier(t, liveSessionIdentifier)
 
 		rr := httptest.NewRecorder()
 
@@ -1249,6 +1565,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		// Do NOT mock database.GetUserById - it should not be called when IdTokenHintSub is empty
 
+		stubLiveSession(database)
+
 		// Mock code creation
 		mockCode := &models.Code{
 			Id:          1,
@@ -1260,6 +1578,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		codeIssuer.On("CreateAuthCode", mock.MatchedBy(func(input *oauth.CreateCodeInput) bool {
 			return reflect.DeepEqual(input.AuthContext, *authContext)
 		})).Return(mockCode, nil)
+
+		database.On("RevokeCodeIfSessionGone", (*sql.Tx)(nil), int64(1), liveSessionIdentifier).Return(false, nil)
 
 		// Mock audit logging
 		auditLogger.On("Log", constants.AuditCreatedAuthCode, mock.MatchedBy(func(details map[string]interface{}) bool {

--- a/src/authserver/internal/handlers/handler_auth_otp.go
+++ b/src/authserver/internal/handlers/handler_auth_otp.go
@@ -306,6 +306,11 @@ func HandleAuthOtpPost(
 		authContext.AddAuthMethod(enums.AuthMethodOTP.String())
 		// Mark that real authentication occurred — used by handler_auth_completed
 		// to decide whether to refresh the session's AuthTime.
+		//
+		// Deliberately does NOT set authContext.Level1AuthCompleted. OTP is level 2, and a
+		// ceremony can arrive here having reused a session rather than entered a password,
+		// so verifying OTP is no proof of level 1 and must not let a ceremony recreate a
+		// session that was ended mid-flight (#129 decision 15).
 		utcNow := time.Now().UTC()
 		authContext.AuthenticatedAt = &utcNow
 		authContext.AuthState = oauth.AuthStateAuthenticationCompleted

--- a/src/authserver/internal/handlers/handler_auth_otp_test.go
+++ b/src/authserver/internal/handlers/handler_auth_otp_test.go
@@ -603,7 +603,11 @@ func TestHandleAuthOtpPost(t *testing.T) {
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
 			return ac.AuthState == oauth.AuthStateAuthenticationCompleted &&
 				ac.AuthMethods == enums.AuthMethodOTP.String() &&
-				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero()
+				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero() &&
+				// OTP is level 2 and must not claim level 1: a ceremony can reach here by
+				// reusing a session rather than by entering a password, so setting this
+				// would let it recreate a session that was just ended (#129 decision 15).
+				!ac.Level1AuthCompleted
 		})).Return(nil)
 
 		handler.ServeHTTP(rr, req)
@@ -680,7 +684,11 @@ func TestHandleAuthOtpPost(t *testing.T) {
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
 			return ac.AuthState == oauth.AuthStateAuthenticationCompleted &&
 				ac.AuthMethods == enums.AuthMethodOTP.String() &&
-				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero()
+				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero() &&
+				// OTP is level 2 and must not claim level 1: a ceremony can reach here by
+				// reusing a session rather than by entering a password, so setting this
+				// would let it recreate a session that was just ended (#129 decision 15).
+				!ac.Level1AuthCompleted
 		})).Return(nil)
 
 		handler.ServeHTTP(rr, req)

--- a/src/authserver/internal/handlers/handler_auth_pwd.go
+++ b/src/authserver/internal/handlers/handler_auth_pwd.go
@@ -244,6 +244,11 @@ func HandleAuthPwdPost(
 		// to decide whether to refresh the session's AuthTime.
 		utcNow := time.Now().UTC()
 		authContext.AuthenticatedAt = &utcNow
+		// This ceremony performed level 1, so it may create a session even when the one it
+		// started on has gone. This is the only writer of the field, deliberately: the OTP
+		// handler also sets AuthenticatedAt, and level 2 alone must not stand in for level 1
+		// at the gate in handler_auth_completed (#129 decisions 6 and 15).
+		authContext.Level1AuthCompleted = true
 		authContext.AuthState = oauth.AuthStateLevel1PasswordCompleted
 		err = authHelper.SaveAuthContext(w, r, authContext)
 		if err != nil {

--- a/src/authserver/internal/handlers/handler_auth_pwd_test.go
+++ b/src/authserver/internal/handlers/handler_auth_pwd_test.go
@@ -439,6 +439,11 @@ func TestHandleAuthPwdPost(t *testing.T) {
 				ac.AuthState == oauth.AuthStateLevel1PasswordCompleted &&
 				ac.AuthMethods == enums.AuthMethodPassword.String() &&
 				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero() &&
+				// This handler is the only writer of Level1AuthCompleted, so this is the
+				// only unit case that fails if the write is dropped. Without it the gate in
+				// handler_auth_completed sends every fresh login back to /auth/pwd and only
+				// the integration tier notices (#129 decision 15).
+				ac.Level1AuthCompleted &&
 				// Captured from the user whose credentials were just verified. Thin on
 				// purpose: token_issuer_auth_state_generation_test.go owns the tables.
 				ac.AuthStateGeneration == 7

--- a/src/authserver/internal/handlers/handler_token.go
+++ b/src/authserver/internal/handlers/handler_token.go
@@ -180,17 +180,23 @@ func HandleTokenPost(
 				return
 			}
 			if !claimed {
-				// Lost the race: another request concurrently redeemed this same code
-				// and won the atomic claim above. Reject this duplicate WITHOUT running
-				// the session-wide reuse cascade. The winner is a legitimate in-flight
-				// redemption (a concurrent duplicate still had to carry the correct
-				// PKCE verifier), and tearing the session down here would fight the
-				// winner's in-progress token minting on the same rows.
+				// No row transitioned. Usually that means another request concurrently
+				// redeemed this same code and won the atomic claim above, and since #129
+				// it can also mean the code was revoked between validation and this claim
+				// because its session was terminated. The two are not distinguishable from
+				// here and do not need to be: both refuse generically.
+				//
+				// Reject WITHOUT running the session-wide reuse cascade. In the race case
+				// the winner is a legitimate in-flight redemption (a concurrent duplicate
+				// still had to carry the correct PKCE verifier), and tearing the session
+				// down here would fight the winner's in-progress token minting on the same
+				// rows. In the revoked case the session is already gone and its grants are
+				// already swept, so there is nothing left to cascade over.
 				//
 				// This does not weaken reuse protection: a genuine *later* replay of an
 				// already-used code is still detected and fully revoked by the
 				// sequential-reuse path in the validator above (#77).
-				slog.Debug("authorization_code: lost the concurrent claim race, rejecting duplicate redemption",
+				slog.Debug("authorization_code: code could not be claimed, rejecting redemption",
 					"codeId", validateResult.CodeEntity.Id)
 				httpHelper.JsonError(w, r, customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant",
 					"Code is invalid.", http.StatusBadRequest))

--- a/src/authserver/internal/handlers/revocation.go
+++ b/src/authserver/internal/handlers/revocation.go
@@ -404,3 +404,32 @@ func LogRevokedUserAuthState(auditLogger AuditLogger, userId int64, reason strin
 		"newGeneration":              result.NewGeneration,
 	})
 }
+
+// LogTerminatedUserSession emits AuditTerminatedUserSession, the security record of an explicit
+// "end this session" action (#129 decision 9). One function rather than a literal at each of the
+// two endpoints, following LogRevokedUserAuthState: the payload cannot then differ between sites,
+// and there is a single place to assert its shape field by field.
+//
+// It takes the loaded session row for the same reason TerminateUserSessionTx does. userId,
+// userSessionId and sessionIdentifier all come off that one row, so they cannot end up describing
+// two different sessions, and both call sites already hold it for their own not-found and
+// ownership checks.
+//
+// Call this only after TerminateUserSessionTx returned without error, and beside rather than
+// instead of AuditDeletedUserSession, whose payload decision 9 leaves untouched.
+func LogTerminatedUserSession(auditLogger AuditLogger, userSession *models.UserSession,
+	loggedInUser string, result TerminationResult) {
+
+	auditLogger.Log(constants.AuditTerminatedUserSession, map[string]interface{}{
+		"userId":            userSession.UserId,
+		"userSessionId":     userSession.Id,
+		"sessionIdentifier": userSession.SessionIdentifier,
+		"loggedInUser":      loggedInUser,
+		// What this call TRANSITIONED, not what the session had. A second termination of the same
+		// session reports 0 and an empty list, which is the honest answer to the only question an
+		// auditor asks of this event.
+		"revokedCodeCount": result.RevokedCodeCount,
+		// Always a list rather than null: TerminationResult initialises it on the success path.
+		"revokedRefreshTokenJtis": result.RevokedRefreshTokenJtis,
+	})
+}

--- a/src/authserver/internal/handlers/revocation.go
+++ b/src/authserver/internal/handlers/revocation.go
@@ -271,6 +271,117 @@ func RevokeUserAuthStateTx(db data.Database, userId int64, exceptSid string,
 	return result, nil
 }
 
+// TerminationResult reports what terminating one session actually did. It carries exactly what
+// the terminated_user_session audit payload needs beyond the caller's own inputs (#129
+// decision 9); the user id, the session id and the session identifier stay out because the
+// caller already holds the session row, and restating them here would let a result and its
+// payload disagree.
+type TerminationResult struct {
+	// RevokedCodeCount is how many codes this call TRANSITIONED from live to revoked, not how
+	// many the session has. A second termination of the same session reports 0, which is what
+	// makes the audit event answer the only question an auditor asks of it, whether this action
+	// revoked anything.
+	RevokedCodeCount int64
+	// RevokedRefreshTokenJtis lists only the tokens this call transitioned, per
+	// revokeRefreshTokens. A token already revoked before the call is absent. Non-nil on the
+	// success path, so a JSON audit payload carries [] rather than null.
+	RevokedRefreshTokenJtis []string
+}
+
+// TerminateUserSessionTx ends one session as a security action: it writes the durable fact that
+// the grants of that session are revoked, sweeps the tokens those grants issued, and deletes the
+// session row, in ONE transaction it owns and commits (#129 decision 5).
+//
+// The three writes, in the order decision 5 states:
+//
+//  1. RevokeCodesBySessionIdentifier marks every code issued through this session revoked. This
+//     is the write that SURVIVES, and the only one that is a boundary. A refresh token can only
+//     descend from a code and a rotated child inherits its parent's code_id, so marking the code
+//     rejects every present and future descendant of the grant: a child inserted after this
+//     commit is born already rejected, because the fact predates its existence.
+//  2. The sid-scoped refresh-token sweep. GetRefreshTokensBySessionIdentifier matches
+//     codes.session_identifier through a join, and that join is the ONLY thing that reaches an
+//     offline grant's tokens, because an offline refresh token's own session_identifier is empty
+//     and the sid its grant came from lives on the codes row. Filtering these rows by
+//     rt.SessionIdentifier would therefore drop exactly the offline tokens decision 2 exists to
+//     revoke.
+//  3. DeleteUserSession, which is what makes the effect immediate for session-bound tokens: they
+//     already stop validating once the row is gone.
+//
+// Steps 2 and 3 are cleanup. Absence of a session row is never read as termination anywhere,
+// because the background worker reaps idle and expired sessions routinely while an offline grant
+// is designed to outlive that, which is why the durable fact has to be written down positively
+// (decision 4).
+//
+// It deliberately does NOT advance the user's authentication generation, and must not: that would
+// invalidate every other device the user has, which is the opposite of what ending one session
+// means and the whole reason #129 exists separately from #106.
+//
+// The three writes share one transaction so the durable fact and the deletion cannot land
+// separately. On any error the returned result is the zero value rather than a partially
+// populated one: the code sweep can succeed and the transaction still roll back, and a caller
+// auditing that count would record a revocation that never happened.
+//
+// The audit events are the CALLER's job, after this returns successfully, because AuditLogger.Log
+// takes no transaction and a logged termination that then rolled back would be a false record
+// (decision 9, following RevokeUserAuthStateTx).
+//
+// WHAT A COMMIT FAILURE DOES AND DOES NOT GUARANTEE is the contract RevokeUserAuthStateTx
+// documents at length and this shares: the deferred rollback covers failures before the commit
+// only, and `database/sql` promises nothing about a Commit that returns an error. So a 500 from a
+// caller here must not be read as "nothing happened"; the durable outcome of a reported commit
+// failure is indeterminate, and the bounded consequence is a termination with no audit record of
+// it, which is fail-closed on the security side and a gap on the forensic side.
+func TerminateUserSessionTx(db data.Database, userSession *models.UserSession) (TerminationResult, error) {
+	// Both sweeps key on the session identifier and the delete keys on the id, so this takes the
+	// loaded row rather than two loose values: from one row they cannot describe two different
+	// sessions, and both call sites already load it for their own not-found and ownership checks.
+	if userSession == nil {
+		return TerminationResult{}, errors.WithStack(errors.New("terminating a user session requires the session to terminate"))
+	}
+
+	// Refused at entry rather than three statements later. RevokeCodesBySessionIdentifier rejects
+	// an empty identifier itself, so the outcome is the same either way, but reaching it means
+	// opening a transaction first and surfacing a bad argument as a database failure.
+	if userSession.SessionIdentifier == "" {
+		return TerminationResult{}, errors.WithStack(errors.New("terminating a user session requires a session identifier"))
+	}
+
+	tx, err := db.BeginTransaction()
+	if err != nil {
+		return TerminationResult{}, err
+	}
+	defer db.RollbackTransaction(tx) //nolint:errcheck
+
+	revokedCodeCount, err := db.RevokeCodesBySessionIdentifier(tx, userSession.SessionIdentifier)
+	if err != nil {
+		return TerminationResult{}, err
+	}
+
+	tokens, err := db.GetRefreshTokensBySessionIdentifier(tx, userSession.SessionIdentifier)
+	if err != nil {
+		return TerminationResult{}, err
+	}
+
+	revokedJtis, err := revokeRefreshTokens(db, tx, tokens)
+	if err != nil {
+		return TerminationResult{}, err
+	}
+
+	if err := db.DeleteUserSession(tx, userSession.Id); err != nil {
+		return TerminationResult{}, err
+	}
+
+	if err := db.CommitTransaction(tx); err != nil {
+		return TerminationResult{}, err
+	}
+
+	return TerminationResult{
+		RevokedCodeCount:        revokedCodeCount,
+		RevokedRefreshTokenJtis: revokedJtis,
+	}, nil
+}
+
 // LogRevokedUserAuthState emits AuditRevokedUserAuthState. One function rather than four
 // literals, so the payload cannot differ between sites and there is a single place to assert
 // its shape field by field.

--- a/src/authserver/internal/handlers/revocation_test.go
+++ b/src/authserver/internal/handlers/revocation_test.go
@@ -472,6 +472,307 @@ func TestRevokeRefreshTokens(t *testing.T) {
 	})
 }
 
+// The session under termination (#129 stage 3). Deliberately a different id and identifier from
+// the #106 fixtures above, so an expectation copied from one of those tests cannot match here by
+// accident.
+const (
+	terminateSessionId = int64(300)
+	terminateSid       = "sid-terminate"
+)
+
+func terminatedSession() *models.UserSession {
+	return &models.UserSession{
+		Id:                terminateSessionId,
+		SessionIdentifier: terminateSid,
+		UserId:            revokeUserId,
+	}
+}
+
+// terminationFixture builds the three refresh tokens the sid-scoped sweep reasons about:
+//
+//	1 rt-session-bound  session-bound, its own session_identifier set
+//	2 rt-offline        OFFLINE, its own session_identifier EMPTY, code id set
+//	3 rt-already-gone   session-bound, ALREADY revoked
+//
+// Token 2 is the load-bearing one. An offline grant is not session-bound, so the row itself
+// carries no sid and only the joined codes row ties it to this session. It is returned here
+// because GetRefreshTokensBySessionIdentifier matches codes.session_identifier, and any
+// implementation that re-filters these rows by rt.SessionIdentifier drops exactly the offline
+// tokens decision 2 exists to revoke.
+func terminationFixture() []*models.RefreshToken {
+	return []*models.RefreshToken{
+		{
+			Id: 1, RefreshTokenJti: "rt-session-bound",
+			SessionIdentifier: terminateSid,
+			RefreshTokenType:  "Refresh",
+			CodeId:            sql.NullInt64{Int64: 21, Valid: true},
+		},
+		{
+			Id: 2, RefreshTokenJti: "rt-offline",
+			SessionIdentifier: "",
+			RefreshTokenType:  "Offline",
+			CodeId:            sql.NullInt64{Int64: 22, Valid: true},
+		},
+		{
+			Id: 3, RefreshTokenJti: "rt-already-gone",
+			SessionIdentifier: terminateSid,
+			RefreshTokenType:  "Refresh",
+			CodeId:            sql.NullInt64{Int64: 23, Valid: true},
+			Revoked:           true,
+		},
+	}
+}
+
+// TestTerminateUserSessionTx_RevokesTheGrantsOfTheSession is the happy path, and the owner of
+// decision 5's write order. Every expectation is registered on a strict mock against the exact
+// transaction BeginTransaction returned, so a write that reached the pool instead, or a call
+// nobody expected, fails the test on its own.
+func TestTerminateUserSessionTx_RevokesTheGrantsOfTheSession(t *testing.T) {
+	db := mocks_data.NewDatabase(t)
+	tokens := terminationFixture()
+
+	db.On("BeginTransaction").Return(revokeTx, nil).Once()
+	db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).Return(int64(2), nil).Once()
+	db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).Return(tokens, nil).Once()
+	// The two live tokens only. rt-already-gone is not written again.
+	db.On("UpdateRefreshToken", revokeTx, tokens[0]).Return(nil).Once()
+	db.On("UpdateRefreshToken", revokeTx, tokens[1]).Return(nil).Once()
+	db.On("DeleteUserSession", revokeTx, terminateSessionId).Return(nil).Once()
+	db.On("CommitTransaction", revokeTx).Return(nil).Once()
+	// The deferred rollback runs on the success path too, where it is a no-op against a committed
+	// transaction. A test omitting this fails on the strict mock.
+	db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+
+	result, err := TerminateUserSessionTx(db, terminatedSession())
+	require.NoError(t, err)
+
+	// The count is the sweep's own, reported as-is: it is what the audit event carries, and
+	// stage 1's data cases pin that it counts rows TRANSITIONED rather than rows matched.
+	assert.Equal(t, int64(2), result.RevokedCodeCount)
+
+	// Two JTIs, not three. rt-already-gone was revoked before the call, so it is neither written
+	// again nor reported, which is the invariant #77's teardown guard depends on.
+	assert.Equal(t, []string{"rt-session-bound", "rt-offline"}, result.RevokedRefreshTokenJtis)
+	assert.NotContains(t, result.RevokedRefreshTokenJtis, "rt-already-gone")
+
+	// The offline token is revoked although its own session_identifier is empty. This is the
+	// assertion that fails against an implementation re-filtering the swept rows by
+	// rt.SessionIdentifier, which would leave an offline grant refreshing after termination:
+	// gap 1, the defect this issue opens with.
+	assert.True(t, tokens[1].Revoked, "the offline token of the terminated session must be revoked")
+	assert.True(t, tokens[0].Revoked)
+
+	// Decision 5's order: the durable marker first, then the tokens, then the row. Within one
+	// transaction this is not a safety boundary and neither sweep reads user_sessions, so the
+	// assertion pins the design's order rather than a correctness property, and is here so
+	// reordering has to be deliberate.
+	codeSweep := callIndex(t, db, "RevokeCodesBySessionIdentifier")
+	tokenSweep := callIndex(t, db, "GetRefreshTokensBySessionIdentifier")
+	deletion := callIndex(t, db, "DeleteUserSession")
+	assert.Less(t, codeSweep, tokenSweep, "codes are marked before the tokens are swept")
+	assert.Less(t, tokenSweep, deletion, "the session row is deleted last")
+
+	// The negative control, and the reason this seam is worth having. Terminating one session
+	// must not advance the user's generation nor sweep user-scoped tokens: either would sign out
+	// every other device that user has, which is the opposite of what the action means and the
+	// reason #129 exists separately from #106.
+	db.AssertNotCalled(t, "IncrementUserAuthStateGeneration", mock.Anything, mock.Anything)
+	db.AssertNotCalled(t, "GetRefreshTokensByUserId", mock.Anything, mock.Anything)
+	db.AssertNotCalled(t, "PromoteRefreshTokenGenerations", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestTerminateUserSessionTx_NothingToRevoke covers a session with no grants at all. Ending it is
+// not an error, and the event still attests that the action happened, so the result reports zeros
+// rather than the helper refusing.
+func TestTerminateUserSessionTx_NothingToRevoke(t *testing.T) {
+	db := mocks_data.NewDatabase(t)
+
+	db.On("BeginTransaction").Return(revokeTx, nil).Once()
+	db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).Return(int64(0), nil).Once()
+	db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).
+		Return([]*models.RefreshToken{}, nil).Once()
+	db.On("DeleteUserSession", revokeTx, terminateSessionId).Return(nil).Once()
+	db.On("CommitTransaction", revokeTx).Return(nil).Once()
+	db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+
+	result, err := TerminateUserSessionTx(db, terminatedSession())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), result.RevokedCodeCount)
+	assert.Empty(t, result.RevokedRefreshTokenJtis)
+	// Non-nil, so the audit payload carries [] rather than null.
+	assert.NotNil(t, result.RevokedRefreshTokenJtis)
+	// The session still ends. The strict mock proves it: the DeleteUserSession expectation above
+	// is registered Once and an unmet expectation fails the test.
+	db.AssertNotCalled(t, "UpdateRefreshToken", mock.Anything, mock.Anything)
+}
+
+// TestTerminateUserSessionTx_RejectsAnUnusableSession pins the entry preconditions. Both are
+// refused before the transaction opens, which the strict mock enforces: no expectations are
+// registered at all, so any call whatsoever fails the case.
+func TestTerminateUserSessionTx_RejectsAnUnusableSession(t *testing.T) {
+	t.Run("nil session", func(t *testing.T) {
+		db := mocks_data.NewDatabase(t)
+
+		result, err := TerminateUserSessionTx(db, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires the session to terminate")
+		assert.Equal(t, TerminationResult{}, result)
+		assertNotAttempted(t, db, "BeginTransaction")
+	})
+
+	t.Run("empty session identifier", func(t *testing.T) {
+		db := mocks_data.NewDatabase(t)
+		session := terminatedSession()
+		session.SessionIdentifier = ""
+
+		result, err := TerminateUserSessionTx(db, session)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires a session identifier")
+		assert.Equal(t, TerminationResult{}, result)
+		// RevokeCodesBySessionIdentifier refuses an empty identifier itself, so the outcome would
+		// be the same three statements later. What this pins is that no transaction was opened
+		// and no write attempted, so a bad argument does not read as a database fault.
+		assertNotAttempted(t, db, "BeginTransaction")
+	})
+}
+
+// TestTerminateUserSessionTx_AnyFailureYieldsTheZeroResult walks every failure point and asserts
+// the same two things at each: the error reaches the caller, and the result is the ZERO value
+// rather than a partially populated one. The second is what stops a caller emitting an audit
+// event that claims a revocation the transaction rolled back.
+//
+// Each row registers only the calls its path reaches. The strict mock does the rest in both
+// directions: an unexpected call fails the case, and so does an expectation that was never met.
+func TestTerminateUserSessionTx_AnyFailureYieldsTheZeroResult(t *testing.T) {
+	boom := errors.New("connection refused")
+
+	cases := []struct {
+		name         string
+		setup        func(db *mocks_data.Database)
+		notAttempted []string
+		extraAssert  func(t *testing.T, result TerminationResult)
+	}{
+		{
+			name: "BeginTransaction fails",
+			setup: func(db *mocks_data.Database) {
+				db.On("BeginTransaction").Return(nil, boom).Once()
+			},
+			// Not even the rollback: there is no transaction to roll back.
+			notAttempted: []string{"RevokeCodesBySessionIdentifier", "RollbackTransaction"},
+		},
+		{
+			name: "the code sweep fails",
+			setup: func(db *mocks_data.Database) {
+				db.On("BeginTransaction").Return(revokeTx, nil).Once()
+				db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).
+					Return(int64(0), boom).Once()
+				db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+			},
+			notAttempted: []string{"GetRefreshTokensBySessionIdentifier", "DeleteUserSession",
+				"CommitTransaction"},
+		},
+		{
+			// KEEP THIS ROW. It is the one that names the property: the sweep returned 2, the
+			// transaction rolls back, and a caller auditing that 2 would record a revocation that
+			// never happened. Measured rather than assumed, against a helper mutated to populate
+			// the result as it goes: four of the six rows here fail under it, because the shared
+			// zero-value assertion in the loop below catches every path where a write had already
+			// succeeded. This row is the one that says WHY, and the only one asserting the count
+			// itself, so the failure reads as a contract violation rather than a struct mismatch.
+			name: "the token query fails after the code sweep revoked two codes",
+			setup: func(db *mocks_data.Database) {
+				db.On("BeginTransaction").Return(revokeTx, nil).Once()
+				db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).
+					Return(int64(2), nil).Once()
+				db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).
+					Return(nil, boom).Once()
+				db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+			},
+			notAttempted: []string{"UpdateRefreshToken", "DeleteUserSession", "CommitTransaction"},
+			extraAssert: func(t *testing.T, result TerminationResult) {
+				assert.Equal(t, int64(0), result.RevokedCodeCount,
+					"the count must not survive a rolled-back transaction")
+			},
+		},
+		{
+			name: "a token write fails",
+			setup: func(db *mocks_data.Database) {
+				tokens := terminationFixture()
+				db.On("BeginTransaction").Return(revokeTx, nil).Once()
+				db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).
+					Return(int64(2), nil).Once()
+				db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).
+					Return(tokens, nil).Once()
+				db.On("UpdateRefreshToken", revokeTx, tokens[0]).Return(boom).Once()
+				db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+			},
+			notAttempted: []string{"DeleteUserSession", "CommitTransaction"},
+		},
+		{
+			name: "the deletion fails",
+			setup: func(db *mocks_data.Database) {
+				db.On("BeginTransaction").Return(revokeTx, nil).Once()
+				db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).
+					Return(int64(1), nil).Once()
+				db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).
+					Return([]*models.RefreshToken{}, nil).Once()
+				db.On("DeleteUserSession", revokeTx, terminateSessionId).Return(boom).Once()
+				db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+			},
+			notAttempted: []string{"CommitTransaction"},
+		},
+		{
+			// The one failure whose durable outcome is unknowable, per the helper's comment. The
+			// caller still gets the zero result and must still not audit: a commit that reports an
+			// error may in fact have applied.
+			name: "the commit fails",
+			setup: func(db *mocks_data.Database) {
+				db.On("BeginTransaction").Return(revokeTx, nil).Once()
+				db.On("RevokeCodesBySessionIdentifier", revokeTx, terminateSid).
+					Return(int64(1), nil).Once()
+				db.On("GetRefreshTokensBySessionIdentifier", revokeTx, terminateSid).
+					Return([]*models.RefreshToken{}, nil).Once()
+				db.On("DeleteUserSession", revokeTx, terminateSessionId).Return(nil).Once()
+				db.On("CommitTransaction", revokeTx).Return(boom).Once()
+				db.On("RollbackTransaction", revokeTx).Return(nil).Once()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := mocks_data.NewDatabase(t)
+			tc.setup(db)
+
+			result, err := TerminateUserSessionTx(db, terminatedSession())
+
+			require.ErrorIs(t, err, boom)
+			assert.Equal(t, TerminationResult{}, result)
+			assert.Nil(t, result.RevokedRefreshTokenJtis,
+				"the error path returns the zero value, and a caller must not audit it")
+			assertNotAttempted(t, db, tc.notAttempted...)
+			if tc.extraAssert != nil {
+				tc.extraAssert(t, result)
+			}
+		})
+	}
+}
+
+// assertNotAttempted fails if any of the named methods appears in the mock's recorded calls. The
+// strict mock would already reject an unexpected call; this states which writes each failure path
+// must not have reached, so the intent survives a later edit to the expectations.
+func assertNotAttempted(t *testing.T, db *mocks_data.Database, methods ...string) {
+	t.Helper()
+	for _, call := range db.Calls {
+		for _, method := range methods {
+			assert.NotEqual(t, method, call.Method, "%v must not be attempted on this path", method)
+		}
+	}
+}
+
 // stubRevocationSweepTx registers every database call RevokeUserAuthStateTx makes for a user
 // with no live sessions and no refresh tokens, which is the shape a HANDLER test wants: it
 // exercises the wiring without restating the sweep table this file already owns exhaustively.

--- a/src/authserver/internal/workers/background_worker.go
+++ b/src/authserver/internal/workers/background_worker.go
@@ -32,6 +32,11 @@ const (
 	// Codes expire after 60 seconds (token_validator.go), so anything older than that
 	// can never be redeemed and can never gain a refresh token. Five minutes is that
 	// bound with generous room for clock skew and slow signing.
+	//
+	// The same cutoff also bounds the second class that sweep reaps, codes revoked
+	// while still unredeemed when a session was ended (#129). There the reason is only
+	// the 60 second lifetime rather than the foreign key race, so this value is already
+	// past what that class needs.
 	usedCodeCleanupGrace = 5 * time.Minute
 
 	// startupDelay holds the first poll back so the server can finish coming up

--- a/src/authserver/tests/data/code_test.go
+++ b/src/authserver/tests/data/code_test.go
@@ -891,6 +891,122 @@ func TestRevokeCodesBySessionIdentifier_TransactionAndFailurePath(t *testing.T) 
 	}
 }
 
+// TestRevokeCodeIfSessionGone covers the compensating revoke that runs immediately after a
+// code is inserted (#129 decision 12). The liveness read at /auth/issue and that insert are
+// two statements, so a termination can commit between them and leave a code bound to a
+// session that no longer exists and that the termination's own sweep could not have marked.
+func TestRevokeCodeIfSessionGone(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+
+	// A session that really exists, plus a code bound to it. This is the ordinary case: the
+	// statement runs after every authorization code issued, and normally matches nothing.
+	liveSession := createTestUserSession(t, user.Id)
+	liveCode := createTestCodeInSession(t, client.Id, user.Id, liveSession.SessionIdentifier)
+
+	// A session identifier with no row, plus two codes bound to it.
+	goneSession := "gone_" + gofakeit.LetterN(8)
+	goneCode := createTestCodeInSession(t, client.Id, user.Id, goneSession)
+	siblingOfGoneCode := createTestCodeInSession(t, client.Id, user.Id, goneSession)
+
+	// Keep this row. It is the only case that fails against a method that always revokes,
+	// and such a method would pass every other assertion in this test while breaking every
+	// authorization code the server issues.
+	revoked, err := database.RevokeCodeIfSessionGone(nil, liveCode.Id, liveSession.SessionIdentifier)
+	if err != nil {
+		t.Fatalf("RevokeCodeIfSessionGone for a live session returned error: %v", err)
+	}
+	if revoked {
+		t.Error("a code whose session still exists must not be revoked")
+	}
+	assertCodeRevoked(t, liveCode.Id, false, "a code whose session is still alive")
+
+	// The statement's own job. liveSession above is still in the table while this runs, which
+	// is what makes this also the control for the subquery's WHERE clause: a NOT EXISTS over
+	// user_sessions with no predicate would find that row and revoke nothing, forever.
+	revoked, err = database.RevokeCodeIfSessionGone(nil, goneCode.Id, goneSession)
+	if err != nil {
+		t.Fatalf("RevokeCodeIfSessionGone for a gone session returned error: %v", err)
+	}
+	if !revoked {
+		t.Error("a code whose session is gone must be revoked")
+	}
+	assertCodeRevoked(t, goneCode.Id, true, "a code whose session is gone")
+
+	// The id term. Without it this is a session-wide sweep wearing a single-code signature,
+	// and the compensating statement would revoke codes of earlier ceremonies on the same
+	// session that were legitimately issued while it was alive.
+	assertCodeRevoked(t, siblingOfGoneCode.Id, false,
+		"another code of the same gone session, not the one named by id")
+
+	// Idempotent, and the bool means "this call transitioned it" rather than "matched a row".
+	// The revoked = false term is what makes that true, and measurement says it is needed on
+	// all four engines here rather than on MySQL alone: the updated_at assignment changes on
+	// every call, so without the term an already-revoked row reports as affected everywhere.
+	// This interleaving is reachable rather than theoretical: it is the one where the
+	// termination's sweep marked the code first and this statement then ran on the same row.
+	revoked, err = database.RevokeCodeIfSessionGone(nil, goneCode.Id, goneSession)
+	if err != nil {
+		t.Fatalf("second RevokeCodeIfSessionGone returned error: %v", err)
+	}
+	if revoked {
+		t.Error("re-revoking an already revoked code must report false")
+	}
+	assertCodeRevoked(t, goneCode.Id, true, "a code after being revoked twice")
+
+	// An empty session identifier is rejected outright, and that guard is load bearing here
+	// rather than defensive: no user_sessions row carries an empty identifier, so NOT EXISTS
+	// over one is trivially true and the statement would revoke whatever code it was handed.
+	if _, err := database.RevokeCodeIfSessionGone(nil, liveCode.Id, ""); err == nil {
+		t.Error("an empty session identifier must return an error")
+	}
+	assertCodeRevoked(t, liveCode.Id, false, "a live session's code after the empty-identifier call")
+
+	// A zero code id is a caller bug, refused the way MarkCodeAsUsed refuses it.
+	if _, err := database.RevokeCodeIfSessionGone(nil, 0, goneSession); err == nil {
+		t.Error("a zero code id must return an error")
+	}
+	assertCodeRevoked(t, siblingOfGoneCode.Id, false, "an unnamed code after the zero-id call")
+}
+
+// TestRevokeCodeIfSessionGone_TransactionAndFailurePath answers the two questions a mock
+// cannot answer about a new data method, following the sweep's sibling above. The failure
+// path matters more here than usual: this statement is the second of the two sweepers that
+// cover each other, so collapsing a database fault into a benign false would leave a code
+// bound to a terminated session unmarked with the suite green.
+func TestRevokeCodeIfSessionGone_TransactionAndFailurePath(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+	goneSession := "gone_tx_" + gofakeit.LetterN(8)
+	code := createTestCodeInSession(t, client.Id, user.Id, goneSession)
+
+	tx := beginTx(t)
+	revoked, err := database.RevokeCodeIfSessionGone(tx, code.Id, goneSession)
+	if err != nil {
+		t.Fatalf("RevokeCodeIfSessionGone in a transaction returned error: %v", err)
+	}
+	if !revoked {
+		t.Fatal("expected the code to be revoked inside the transaction")
+	}
+
+	if err := database.RollbackTransaction(tx); err != nil {
+		t.Fatalf("RollbackTransaction: %v", err)
+	}
+
+	// Had the statement gone through the pool it would have survived the rollback. The
+	// production caller passes nil, but a method that ignores its transaction parameter is
+	// a trap for whichever caller composes it into one later.
+	assertCodeRevoked(t, code.Id, false, "a code revoked inside a rolled-back transaction")
+
+	revoked, err = database.RevokeCodeIfSessionGone(tx, code.Id, goneSession)
+	if err == nil {
+		t.Error("a statement that cannot run must return an error, not a benign false")
+	}
+	if revoked {
+		t.Error("a failed call must report false")
+	}
+}
+
 // TestUpdateCode_DoesNotClobberRevoked pins the dont-update tag on Code.Revoked
 // (#129 decision 4). Nothing else in the suite fails if the tag is removed: the
 // termination sweep writes the column with its own statement, while UpdateCode writes

--- a/src/authserver/tests/data/code_test.go
+++ b/src/authserver/tests/data/code_test.go
@@ -716,6 +716,179 @@ func TestDeleteUsedCodesWithoutRefreshTokens_AgeCutoff(t *testing.T) {
 	}
 }
 
+// revokeCodesOf marks one code revoked through the only method that writes the column,
+// since Code.Revoked is dont-update tagged and UpdateCode cannot set it. createTestCode
+// randomises the session identifier, so sweeping one code's session reaches that code
+// alone.
+func revokeCodesOf(t *testing.T, code *models.Code) {
+	t.Helper()
+	if _, err := database.RevokeCodesBySessionIdentifier(nil, code.SessionIdentifier); err != nil {
+		t.Fatalf("Failed to revoke the session of code %d: %v", code.Id, err)
+	}
+	assertCodeRevoked(t, code.Id, true, "the code the fixture just revoked")
+}
+
+// markCodeUsed puts a code in the redeemed state. The in-memory copy still reads
+// Revoked = false when the caller revoked it first, which is exactly the shape a handler
+// that loaded the code earlier holds, and the dont-update tag is what keeps it from
+// regressing the marker.
+func markCodeUsed(t *testing.T, code *models.Code) {
+	t.Helper()
+	code.Used = true
+	if err := database.UpdateCode(nil, code); err != nil {
+		t.Fatalf("Failed to mark code %d as used: %v", code.Id, err)
+	}
+}
+
+// assertCodeExists reports whether a code row is still there, which is what a reaper's
+// contract is about.
+func assertCodeExists(t *testing.T, codeId int64, want bool, what string) {
+	t.Helper()
+	code, err := database.GetCodeById(nil, codeId)
+	if err != nil {
+		t.Fatalf("Failed to re-read code %d: %v", codeId, err)
+	}
+	if want && code == nil {
+		t.Errorf("%s: was deleted, expected to survive", what)
+	}
+	if !want && code != nil {
+		t.Errorf("%s: survived, expected to be deleted", what)
+	}
+}
+
+// TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnused covers the second class this sweep
+// reaps since #129: a code revoked while it was still unredeemed, which is what ending a
+// session leaves behind when the grant it marked had not been exchanged yet (decision 8).
+// Without it those rows accumulate forever, and unbounded growth is the defect that moved
+// the marker off a session-keyed registry in the first place.
+//
+// The cutoff is varied rather than the rows, following TestDeleteUsedCodesWithoutRefreshTokens_AgeCutoff
+// above, because Code.CreatedAt is dont-update tagged and a row cannot be aged through the
+// ORM.
+func TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnused(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+
+	// Revoked while still unredeemed: the row the extension exists for.
+	revokedUnused := createTestCode(t, client.Id, user.Id)
+	revokeCodesOf(t, revokedUnused)
+
+	// Revoked after redemption, with an unrevoked refresh token descended from it. Keep
+	// this row. It is the regression guard for the retention argument decision 8 rests on,
+	// that the marker outlives every descendant that could present it, and its value is
+	// invisible once the design is right. The descendant is deliberately unrevoked, which
+	// is gap 2's racing child: a rotation that validated before the termination inserts it
+	// afterwards, so the termination's own token sweep never saw it and the code's marker
+	// is the only thing that rejects it. The stake is therefore higher than losing a
+	// marker: fk_refresh_tokens_code is ON DELETE CASCADE, so a sweep reaching this code
+	// would delete the very descendant the marker exists to reject, and the token would
+	// stop being rejected because it stopped existing rather than because it was contained.
+	revokedUsedWithToken := createTestCode(t, client.Id, user.Id)
+	revokeCodesOf(t, revokedUsedWithToken)
+	markCodeUsed(t, revokedUsedWithToken)
+	racingChild := &models.RefreshToken{
+		CodeId:            sql.NullInt64{Int64: revokedUsedWithToken.Id, Valid: true},
+		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
+		SessionIdentifier: revokedUsedWithToken.SessionIdentifier,
+		RefreshTokenType:  "Bearer",
+		Scope:             "openid profile offline_access",
+		IssuedAt:          sql.NullTime{Time: time.Now().UTC(), Valid: true},
+		ExpiresAt:         sql.NullTime{Time: time.Now().UTC().Add(time.Hour), Valid: true},
+		MaxLifetime:       sql.NullTime{Time: time.Now().UTC().Add(24 * time.Hour), Valid: true},
+		Revoked:           false,
+	}
+	if err := database.CreateRefreshToken(nil, racingChild); err != nil {
+		t.Fatalf("Failed to create the descendant refresh token: %v", err)
+	}
+
+	// Revoked after redemption with nothing referencing it. The pre-existing branch, and
+	// the proof that adding `used = false` to the new branch did not narrow the old one.
+	revokedUsedNoToken := createTestCode(t, client.Id, user.Id)
+	revokeCodesOf(t, revokedUsedNoToken)
+	markCodeUsed(t, revokedUsedNoToken)
+
+	// Unredeemed and never revoked: an abandoned ceremony's code. The negative control for
+	// the `revoked = true` term, and the only row that fails if the sweep is written to
+	// reap every unredeemed code.
+	unrevokedUnused := createTestCode(t, client.Id, user.Id)
+
+	// The cutoff the worker actually passes, first and while every row is still there.
+	// All four were created seconds ago, so all four must survive. This is the only
+	// assertion here that fails if the extension drops the shared created_at term, or
+	// states it per branch and gets one of them wrong.
+	if err := database.DeleteUsedCodesWithoutRefreshTokens(nil, time.Now().UTC().Add(-5*time.Minute)); err != nil {
+		t.Fatalf("Failed to run the sweep with the worker's cutoff: %v", err)
+	}
+	assertCodeExists(t, revokedUnused.Id, true, "a revoked, unredeemed code newer than the cutoff")
+	assertCodeExists(t, revokedUsedNoToken.Id, true, "a revoked, redeemed code newer than the cutoff")
+	assertCodeExists(t, revokedUsedWithToken.Id, true, "a revoked, redeemed code with a descendant refresh token, newer than the cutoff")
+	assertCodeExists(t, unrevokedUnused.Id, true, "an unrevoked, unredeemed code newer than the cutoff")
+
+	// Then a cutoff every row is past, so the remaining assertions are about the
+	// used/revoked predicate rather than about age.
+	if err := database.DeleteUsedCodesWithoutRefreshTokens(nil, time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatalf("Failed to run the sweep with a future cutoff: %v", err)
+	}
+	assertCodeExists(t, revokedUnused.Id, false, "a revoked, unredeemed code past the cutoff")
+	assertCodeExists(t, revokedUsedNoToken.Id, false, "a revoked, redeemed code with no refresh token, past the cutoff")
+	assertCodeExists(t, revokedUsedWithToken.Id, true,
+		"a revoked, redeemed code whose descendant refresh token is still there; the marker "+
+			"must outlive it, and deleting the code would cascade the descendant away")
+	assertCodeExists(t, unrevokedUnused.Id, true, "an unrevoked, unredeemed code past the cutoff")
+}
+
+// TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnusedWithRopcTokenPresent pins where the
+// NOT IN subquery sits, which is the one thing in the widened predicate that can ship inert.
+// ROPC refresh tokens carry code_id = NULL, and `x NOT IN (…, NULL)` is UNKNOWN rather than
+// TRUE, so the redeemed branch already matches nothing on any deployment that has issued one.
+// That is #130 and it is out of scope here. Keeping the subquery inside that branch is what
+// contains it: UNKNOWN OR TRUE is TRUE, so the revoked branch reaps anyway. Hoisting the
+// subquery beside the cutoff, which reads as the tidier factoring, makes the whole predicate
+// UNKNOWN and this method silently stops deleting anything at all.
+//
+// Separate from the test above rather than a row in it, because the NULL row changes what the
+// redeemed branch can prove: while it is present, a revoked and redeemed code with no refresh
+// token is no longer reaped either, which is #130 behaving as documented rather than a defect
+// in this change.
+func TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnusedWithRopcTokenPresent(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+
+	// A ROPC-shaped refresh token: no originating code, so code_id is NULL. Removed at the
+	// end so it cannot change what a later test in this package proves about the sweep.
+	ropcToken := &models.RefreshToken{
+		CodeId:            sql.NullInt64{Valid: false},
+		UserId:            sql.NullInt64{Int64: user.Id, Valid: true},
+		ClientId:          sql.NullInt64{Int64: client.Id, Valid: true},
+		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
+		SessionIdentifier: "",
+		RefreshTokenType:  "Bearer",
+		Scope:             "openid profile",
+		IssuedAt:          sql.NullTime{Time: time.Now().UTC(), Valid: true},
+		ExpiresAt:         sql.NullTime{Time: time.Now().UTC().Add(time.Hour), Valid: true},
+		MaxLifetime:       sql.NullTime{Time: time.Now().UTC().Add(24 * time.Hour), Valid: true},
+	}
+	if err := database.CreateRefreshToken(nil, ropcToken); err != nil {
+		t.Fatalf("Failed to create the ROPC refresh token: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.DeleteRefreshToken(nil, ropcToken.Id); err != nil {
+			t.Errorf("Failed to remove the ROPC refresh token: %v", err)
+		}
+	})
+
+	revokedUnused := createTestCode(t, client.Id, user.Id)
+	revokeCodesOf(t, revokedUnused)
+
+	if err := database.DeleteUsedCodesWithoutRefreshTokens(nil, time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatalf("Failed to run the sweep: %v", err)
+	}
+	assertCodeExists(t, revokedUnused.Id, false,
+		"a revoked, unredeemed code swept while a refresh token with a NULL code_id exists; "+
+			"if this survived, the NOT IN subquery was hoisted out of the redeemed branch and "+
+			"the whole predicate is UNKNOWN")
+}
+
 // TestUpdateCode_DoesNotClobberAuthStateGeneration pins decision 11(b) of #106 for
 // codes. See TestUpdateUser_DoesNotClobberAuthStateGeneration for why the tag
 // matters and why the value is deliberately nonzero.

--- a/src/authserver/tests/data/code_test.go
+++ b/src/authserver/tests/data/code_test.go
@@ -242,6 +242,32 @@ func TestMarkCodeAsUsed(t *testing.T) {
 	if _, err := database.MarkCodeAsUsed(nil, 0); err == nil {
 		t.Errorf("MarkCodeAsUsed with id 0 must return an error")
 	}
+
+	// A revoked code is not claimable even though it was never used. That is the
+	// second term of the predicate, and it is what makes ending a session durable
+	// against a redemption that validated a moment before the termination (#129).
+	// Keep BOTH this case and the already-used one above: either alone still passes
+	// with the other term deleted from the predicate.
+	revoked := createTestCode(t, client.Id, user.Id)
+	if _, err := database.RevokeCodesBySessionIdentifier(nil, revoked.SessionIdentifier); err != nil {
+		t.Fatalf("failed to revoke the code's session: %v", err)
+	}
+	claimed, err = database.MarkCodeAsUsed(nil, revoked.Id)
+	if err != nil {
+		t.Fatalf("MarkCodeAsUsed for a revoked code returned error: %v", err)
+	}
+	if claimed {
+		t.Errorf("MarkCodeAsUsed must not claim a revoked code, got claimed=true")
+	}
+
+	// And it stays unused, so nothing downstream can read it as redeemed.
+	unclaimed, err := database.GetCodeById(nil, revoked.Id)
+	if err != nil {
+		t.Fatalf("failed to reload the revoked code: %v", err)
+	}
+	if unclaimed.Used {
+		t.Errorf("a revoked code must remain unused after a failed claim")
+	}
 }
 
 func TestGetCodeById(t *testing.T) {
@@ -727,6 +753,172 @@ func TestUpdateCode_DoesNotClobberAuthStateGeneration(t *testing.T) {
 	if after.AuthStateGeneration != 7 {
 		t.Errorf("UpdateCode regressed auth_state_generation to %d, want 7 (is the dont-update tag missing?)",
 			after.AuthStateGeneration)
+	}
+	if !after.Used {
+		t.Error("the rest of the update must still apply, Used = false")
+	}
+}
+
+// createTestCodeInSession creates a code bound to a specific session identifier,
+// which the session-scoped revocation sweep is keyed on. createTestCode randomises
+// the identifier, so a caller needing two codes on ONE session cannot use it.
+func createTestCodeInSession(t *testing.T, clientId, userId int64, sessionIdentifier string) *models.Code {
+	t.Helper()
+	code := createTestCode(t, clientId, userId)
+	code.SessionIdentifier = sessionIdentifier
+	if err := database.UpdateCode(nil, code); err != nil {
+		t.Fatalf("Failed to bind test code to session %q: %v", sessionIdentifier, err)
+	}
+	return code
+}
+
+// assertCodeRevoked reloads a code and checks the marker, since the whole point of
+// the column is what a later read of it says.
+func assertCodeRevoked(t *testing.T, codeId int64, want bool, what string) {
+	t.Helper()
+	code, err := database.GetCodeById(nil, codeId)
+	if err != nil {
+		t.Fatalf("Failed to reload code %d: %v", codeId, err)
+	}
+	if code == nil {
+		t.Fatalf("Code %d disappeared", codeId)
+	}
+	if code.Revoked != want {
+		t.Errorf("%s: Revoked = %v, want %v", what, code.Revoked, want)
+	}
+}
+
+// TestRevokeCodesBySessionIdentifier covers the marker that makes ending a session
+// durable (#129): every code of the terminated session is marked, and nothing else is.
+func TestRevokeCodesBySessionIdentifier(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+
+	sessionA := "revoke_a_" + gofakeit.LetterN(8)
+	sessionB := "revoke_b_" + gofakeit.LetterN(8)
+
+	first := createTestCodeInSession(t, client.Id, user.Id, sessionA)
+	second := createTestCodeInSession(t, client.Id, user.Id, sessionA)
+	unrelated := createTestCodeInSession(t, client.Id, user.Id, sessionB)
+
+	// Every code of the target session transitions, and the count says how many. The
+	// count is what the audit event reports, so it is part of the contract.
+	count, err := database.RevokeCodesBySessionIdentifier(nil, sessionA)
+	if err != nil {
+		t.Fatalf("RevokeCodesBySessionIdentifier returned error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 codes revoked, got %d", count)
+	}
+	assertCodeRevoked(t, first.Id, true, "a code of the terminated session")
+	assertCodeRevoked(t, second.Id, true, "the second code of the terminated session")
+
+	// The negative control. Without it this test passes against a method that revokes
+	// every code in the table, which is the failure that matters most here: it would
+	// sign out every other device belonging to every user.
+	assertCodeRevoked(t, unrelated.Id, false, "a code of an unrelated session")
+
+	// Idempotent, and the count reports rows actually transitioned rather than rows
+	// matched. MySQL reports changed rows, so without `revoked = false` in the
+	// predicate the updated_at assignment alone would make this return 2 there and 0
+	// on the other three engines.
+	count, err = database.RevokeCodesBySessionIdentifier(nil, sessionA)
+	if err != nil {
+		t.Fatalf("second RevokeCodesBySessionIdentifier returned error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("re-revoking an already revoked session must report 0 rows, got %d", count)
+	}
+	assertCodeRevoked(t, first.Id, true, "a code after its session was revoked twice")
+
+	// An unknown session identifier is not an error, it simply matches nothing.
+	count, err = database.RevokeCodesBySessionIdentifier(nil, "revoke_missing_"+gofakeit.LetterN(8))
+	if err != nil {
+		t.Fatalf("RevokeCodesBySessionIdentifier for an unknown session returned error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("an unknown session identifier must report 0 rows, got %d", count)
+	}
+
+	// An empty identifier is rejected outright rather than used as a filter. Every
+	// user_sessions row carries a UUID, so an empty value means a caller bug, and
+	// matching on it would sweep codes that belong to no session under termination.
+	if _, err := database.RevokeCodesBySessionIdentifier(nil, ""); err == nil {
+		t.Error("an empty session identifier must return an error")
+	}
+	assertCodeRevoked(t, unrelated.Id, false,
+		"a code of an unrelated session after the empty-identifier call")
+}
+
+// TestRevokeCodesBySessionIdentifier_TransactionAndFailurePath answers the two
+// questions a mock can never answer about a new data method: does it enlist in the
+// caller's transaction rather than writing through the pool, and does its failure
+// path return an error rather than a benign zero. Both matter here because the
+// termination helper performs three writes in one transaction, and a method that
+// collapsed a database fault into (0, nil) would let the caller audit a revocation
+// that never happened.
+func TestRevokeCodesBySessionIdentifier_TransactionAndFailurePath(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+	session := "revoke_tx_" + gofakeit.LetterN(8)
+	code := createTestCodeInSession(t, client.Id, user.Id, session)
+
+	tx := beginTx(t)
+	count, err := database.RevokeCodesBySessionIdentifier(tx, session)
+	if err != nil {
+		t.Fatalf("RevokeCodesBySessionIdentifier in a transaction returned error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 code revoked inside the transaction, got %d", count)
+	}
+
+	if err := database.RollbackTransaction(tx); err != nil {
+		t.Fatalf("RollbackTransaction: %v", err)
+	}
+
+	// Had the statement gone through the pool instead of the transaction it would have
+	// survived the rollback, and a termination whose later steps failed would leave the
+	// grant marked while the session stayed alive.
+	assertCodeRevoked(t, code.Id, false, "a code revoked inside a rolled-back transaction")
+
+	// The failure path, forced by the same finished transaction.
+	count, err = database.RevokeCodesBySessionIdentifier(tx, session)
+	if err == nil {
+		t.Error("a statement that cannot run must return an error, not a benign zero count")
+	}
+	if count != 0 {
+		t.Errorf("a failed call must report 0 rows, got %d", count)
+	}
+}
+
+// TestUpdateCode_DoesNotClobberRevoked pins the dont-update tag on Code.Revoked
+// (#129 decision 4). Nothing else in the suite fails if the tag is removed: the
+// termination sweep writes the column with its own statement, while UpdateCode writes
+// every untagged column from whatever the caller happens to hold, so a Code loaded
+// before the termination would write revoked = false back and hand the grant to its
+// holder again.
+func TestUpdateCode_DoesNotClobberRevoked(t *testing.T) {
+	client := createTestClient(t)
+	user := createTestUser(t)
+	code := createTestCode(t, client.Id, user.Id)
+
+	if _, err := database.RevokeCodesBySessionIdentifier(nil, code.SessionIdentifier); err != nil {
+		t.Fatalf("Failed to revoke the code's session: %v", err)
+	}
+
+	// The in-memory copy still reads Revoked = false, exactly as a handler that loaded
+	// the code before the termination would.
+	code.Used = true
+	if err := database.UpdateCode(nil, code); err != nil {
+		t.Fatalf("Failed to update code: %v", err)
+	}
+
+	after, err := database.GetCodeById(nil, code.Id)
+	if err != nil {
+		t.Fatalf("Failed to reload updated code: %v", err)
+	}
+	if !after.Revoked {
+		t.Error("UpdateCode regressed revoked to false (is the dont-update tag missing?)")
 	}
 	if !after.Used {
 		t.Error("the rest of the update must still apply, Used = false")

--- a/src/authserver/tests/data/migration_000026_code_revoked_test.go
+++ b/src/authserver/tests/data/migration_000026_code_revoked_test.go
@@ -1,0 +1,191 @@
+package datatests
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000026_CodeRevoked exercises the migration that introduces the
+// termination marker (#129). It runs against an ISOLATED database of the configured
+// dialect (see migration_testdb_helper.go).
+//
+// The properties, in the order they appear below:
+//
+//  1. Absent at 000025, so the column found afterwards is the one 000026 added.
+//  2. Declared NOT NULL with a default of false. A DEFAULT of true here would mark
+//     every authorization code in the table as revoked at deployment, refusing every
+//     redemption and every refresh in flight, and it would pass every behavioural
+//     test in the suite because the ORM always writes the column explicitly and so
+//     never exercises the default.
+//  3. A codes row that predates the column reads revoked = false afterwards. This is
+//     property 2 proved on the engine rather than in the DDL, and it is what keeps
+//     authorizations already in flight working across the deployment.
+//  4. The down migration works and re-applying is clean. Only the 000024 and 000025
+//     tests execute a down migration at all, and this one has the same engine-specific
+//     hazard 000024 has: SQL Server refuses to drop a column while a default
+//     constraint depends on it, so 000026 names its constraint and drops it by name.
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestMigration000026_CodeRevoked
+func TestMigration000026_CodeRevoked(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(25), "migrate to 000025")
+
+	// 1. Absent before the migration.
+	exists, _, _ := codeRevokedShape000026(t, h)
+	assert.False(t, exists, "codes.revoked must not exist at 000025")
+
+	require.NoError(t, h.Migrator.Migrate(26), "apply 000026")
+
+	// 2. NOT NULL, defaulting to false.
+	assertCodeRevokedShape000026(t, h, "after apply")
+
+	// 3. A row that predates the column lands at false.
+	//
+	// Seeded through the ORM at 000026 and then carried DOWN to 000025 and back up,
+	// rather than seeded with raw SQL at 000025. Both prove the same thing, and the
+	// round trip costs a dozen lines instead of a hand-written insert covering the
+	// twenty NOT NULL columns of codes plus the clients and users rows its foreign
+	// keys require, with per-dialect datetime and boolean literals for each.
+	codeId := seedCode000026(t, h)
+
+	require.NoError(t, h.Migrator.Migrate(25), "roll back 000026")
+	require.NoError(t, h.Migrator.Migrate(26), "re-apply 000026")
+
+	assert.False(t, readCodeRevoked000026(t, h, codeId),
+		"a codes row that predates the column must land revoked = false")
+
+	// 4. The column survives the round trip with its shape intact.
+	assertCodeRevokedShape000026(t, h, "after down/up round trip")
+}
+
+// seedCode000026 inserts a client, a user and a code through the ORM against the
+// isolated database, returning the code's id. The shared helpers in code_test.go
+// cannot be reused: they write to the package-level `database`, which is the fully
+// migrated shared test database rather than this one.
+func seedCode000026(t *testing.T, h *isolatedDB) int64 {
+	t.Helper()
+	random := gofakeit.LetterN(6)
+
+	client := &models.Client{
+		ClientIdentifier: "mig26_client_" + random,
+		Description:      "Migration 000026 test client",
+	}
+	require.NoError(t, h.DB.CreateClient(nil, client), "seed client")
+
+	user := &models.User{
+		Enabled:  true,
+		Subject:  uuid.New(),
+		Username: "mig26_" + random,
+	}
+	require.NoError(t, h.DB.CreateUser(nil, user), "seed user")
+
+	// Two fields are here for engine-specific reasons, both found by running this on
+	// all four rather than by reading the schema. The challenge fields, because SQLite
+	// declares codes.code_challenge and codes.code_challenge_method NOT NULL where the
+	// other three allow NULL. AuthenticatedAt, because a zero time.Time reaches MySQL
+	// as '0000-00-00', which it rejects outright.
+	code := &models.Code{
+		ClientId:            client.Id,
+		UserId:              user.Id,
+		CodeHash:            "mig26_hash_" + random,
+		CodeChallenge:       sql.NullString{String: "mig26_challenge_" + random, Valid: true},
+		CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
+		RedirectURI:         "https://example.com/callback",
+		Scope:               "openid profile",
+		State:               "mig26_state_" + random,
+		Nonce:               "mig26_nonce_" + random,
+		IpAddress:           "192.168.1.1",
+		UserAgent:           "migration test",
+		ResponseMode:        "query",
+		AuthenticatedAt:     time.Now().UTC().Truncate(time.Microsecond),
+		SessionIdentifier:   "mig26_session_" + random,
+		AcrLevel:            "1",
+		AuthMethods:         "pwd",
+	}
+	require.NoError(t, h.DB.CreateCode(nil, code), "seed code")
+
+	return code.Id
+}
+
+func readCodeRevoked000026(t *testing.T, h *isolatedDB, codeId int64) bool {
+	t.Helper()
+	var revoked bool
+	q := fmt.Sprintf("SELECT revoked FROM codes WHERE id = %d", codeId)
+	require.NoError(t, h.SQL.QueryRow(q).Scan(&revoked), "read codes.revoked")
+	return revoked
+}
+
+func assertCodeRevokedShape000026(t *testing.T, h *isolatedDB, phase string) {
+	t.Helper()
+	exists, notNull, def := codeRevokedShape000026(t, h)
+	require.Truef(t, exists, "[%s] codes.revoked must exist", phase)
+	assert.Truef(t, notNull, "[%s] codes.revoked must be NOT NULL", phase)
+	assert.Equalf(t, "0", def,
+		"[%s] codes.revoked must default to false, got %q", phase, def)
+}
+
+// codeRevokedShape000026 reports whether codes.revoked exists, whether it is NOT NULL,
+// and its default expression normalised to "0" for false. It follows
+// generationColumnShape000024, with two differences: absence is a result rather than a
+// scan error, since this test asserts absence at 000025, and the default is a boolean,
+// which PostgreSQL reports as `false` where the other three report `0`. Both spellings
+// normalise to "0" so one expectation covers every engine.
+func codeRevokedShape000026(t *testing.T, h *isolatedDB) (bool, bool, string) {
+	t.Helper()
+
+	const table, col = "codes", "revoked"
+	var q string
+	switch dbType() {
+	case "mysql":
+		q = fmt.Sprintf(`SELECT IS_NULLABLE, COLUMN_DEFAULT FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = '%s' AND column_name = '%s'`, table, col)
+	case "postgres":
+		q = fmt.Sprintf(`SELECT is_nullable, column_default FROM information_schema.columns
+			WHERE table_name = '%s' AND column_name = '%s'`, table, col)
+	case "mssql":
+		q = fmt.Sprintf(`SELECT CAST(c.is_nullable AS VARCHAR(1)), dc.definition
+			FROM sys.columns c
+			LEFT JOIN sys.default_constraints dc
+			  ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+			WHERE c.object_id = OBJECT_ID('dbo.%s') AND c.name = '%s'`, table, col)
+	default: // sqlite
+		q = fmt.Sprintf(`SELECT CAST("notnull" AS TEXT), dflt_value
+			FROM pragma_table_info('%s') WHERE name = '%s'`, table, col)
+	}
+
+	var nullFlag, def sql.NullString
+	err := h.SQL.QueryRow(q).Scan(&nullFlag, &def)
+	if err == sql.ErrNoRows {
+		return false, false, ""
+	}
+	require.NoErrorf(t, err, "column metadata: %s.%s", table, col)
+
+	notNull := false
+	switch dbType() {
+	case "mysql", "postgres":
+		notNull = strings.EqualFold(nullFlag.String, "NO")
+	case "mssql":
+		notNull = nullFlag.String == "0"
+	default: // sqlite
+		notNull = nullFlag.String == "1"
+	}
+
+	// Defaults come back variously as `0`, `'0'`, `((0))` and `false`.
+	normalised := strings.Trim(strings.TrimSpace(def.String), "()' ")
+	if strings.EqualFold(normalised, "false") {
+		normalised = "0"
+	}
+	return true, notNull, normalised
+}

--- a/src/authserver/tests/integration/api_account_logout_request_test.go
+++ b/src/authserver/tests/integration/api_account_logout_request_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
@@ -12,6 +13,7 @@ import (
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper to get a user access token with account scope and also the auth code details (client, redirect, sid)
@@ -91,6 +93,130 @@ func TestAPIAccountLogoutRequest_Success_And_LogoutFlow_WithAndWithoutCookie(t *
 	assert.Equal(t, code.RedirectURI, loc2.Scheme+"://"+loc2.Host+loc2.Path)
 	assert.Equal(t, reqBody.State, loc2.Query().Get("state"))
 	assert.Equal(t, code.SessionIdentifier, loc2.Query().Get("sid"))
+}
+
+// The two cases below pin that #129 changed NOTHING about RP-initiated logout (decision 3). The
+// dividing line is intent: "end this session" is a security action aimed at a device, logout is
+// navigation, and the fact that logout happens to delete the session row when the departing client
+// was the only one on it is bookkeeping rather than a revocation decision.
+//
+// THEY ARE DRIVEN THROUGH REQUEST SHAPES #109 IS NOT REWRITING, per decision 13. Both supply
+// id_token_hint AND post_logout_redirect_uri, because #109's first item is that the second is wrongly
+// treated as required and its check returns before the teardown. They assert only what #129 cares
+// about, that no grant was revoked, and nothing about whether that parameter should be required, how
+// the redirect was built, or whether the session row survives, which is #109 divergence B's business.
+//
+// The hint comes from the token exchange's own id_token rather than from /api/v1/account/logout-request,
+// so these cases do not depend on that endpoint's client resolution, which is also #109's surface.
+
+// logoutWithHint performs the RP-initiated logout for a grant's client and returns nothing but a
+// completed teardown: it fails the test unless the server redirected to the post-logout URI, which is
+// what stops a "nothing was revoked" assertion passing because logout did nothing at all.
+func logoutWithHint(t *testing.T, grant *offlineGrant, idToken string) {
+	t.Helper()
+
+	state := gofakeit.LetterN(10)
+	logoutURL := config.GetAuthServer().BaseURL + "/auth/logout?id_token_hint=" + url.QueryEscape(idToken) +
+		"&post_logout_redirect_uri=" + url.QueryEscape(grant.redirectURI) +
+		"&state=" + state
+
+	resp, err := grant.httpClient.Get(logoutURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "logout should redirect")
+
+	location, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, grant.redirectURI, location.Scheme+"://"+location.Host+location.Path,
+		"the teardown must have run to completion, not stopped at an error page")
+	require.Equal(t, state, location.Query().Get("state"))
+}
+
+// sessionBoundGrantOnSameSession runs a second authorization on the grant's live session WITHOUT
+// offline_access and returns its id_token and refresh token. The id_token is what logout matches
+// against the session, and the refresh token is session bound, so it is the one whose survival
+// decision 3's second claim is about.
+func sessionBoundGrantOnSameSession(t *testing.T, grant *offlineGrant) (string, string) {
+	t.Helper()
+
+	const codeVerifier = "code-verifier-logout"
+	scope := "openid " + constants.AuthServerResourceIdentifier + ":" + constants.ManageAccountPermissionIdentifier
+	exchanged := grant.exchange(t, grant.codeFromSameSession(t, scope, codeVerifier), codeVerifier)
+
+	idToken, ok := exchanged["id_token"].(string)
+	require.True(t, ok, "expected an id_token to use as the logout hint: %v", exchanged)
+	require.Equal(t, grant.sessionIdentifier, claimString(t, idToken, "sid"),
+		"the hint must name the session logout is being asked to tear down")
+
+	refreshToken, ok := exchanged["refresh_token"].(string)
+	require.True(t, ok, "a session-bound auth code grant must yield a refresh token: %v", exchanged)
+	return idToken, refreshToken
+}
+
+// TestLogout_WithIdTokenHint_RevokesNoGrants is decision 3's first claim: an offline grant survives
+// logout in every case, including the one where logout deletes the session row because the departing
+// client was the only one on it.
+func TestLogout_WithIdTokenHint_RevokesNoGrants(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	first := grant.refresh(t)
+	require.NotEmpty(t, first["access_token"], "the grant should refresh before logout: %v", first)
+	grant.refreshToken = first["refresh_token"].(string)
+
+	idToken, _ := sessionBoundGrantOnSameSession(t, grant)
+	logoutWithHint(t, grant, idToken)
+
+	after := grant.refresh(t)
+	assert.NotEmpty(t, after["access_token"],
+		"logout must revoke nothing, decision 3: %v", after)
+}
+
+// TestLogout_WithIdTokenHint_OtherClientOnSession_KeepsSessionBoundTokensWorking is decision 3's
+// second claim, which is the more surprising one and the reason it is pinned: the client that just
+// logged out keeps a working session-bound refresh token, because the session row survives while
+// another client remains on it and nothing in refresh validation reads the client-session link.
+//
+// Pinned so #135, "disconnect this application", has to change it deliberately rather than by
+// accident.
+func TestLogout_WithIdTokenHint_OtherClientOnSession_KeepsSessionBoundTokensWorking(t *testing.T) {
+	grant := createOfflineGrant(t)
+	idToken, sessionBoundRefresh := sessionBoundGrantOnSameSession(t, grant)
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	// A second client on the same session, created directly as this suite already does for its
+	// session listings. What handleExistingSessionOnLogout reads is the NUMBER of clients on the
+	// session, not how each got there.
+	otherClient := &models.Client{
+		ClientIdentifier:         "logout-other-" + gofakeit.LetterN(8),
+		ClientSecretEncrypted:    []byte("encrypted-secret"),
+		Description:              "Second client sharing the session",
+		Enabled:                  true,
+		AuthorizationCodeEnabled: true,
+	}
+	require.NoError(t, database.CreateClient(nil, otherClient))
+	defer func() { _ = database.DeleteClient(nil, otherClient.Id) }()
+
+	now := time.Now().UTC()
+	require.NoError(t, database.CreateUserSessionClient(nil, &models.UserSessionClient{
+		UserSessionId: session.Id,
+		ClientId:      otherClient.Id,
+		Started:       now.Add(-time.Hour),
+		LastAccessed:  now.Add(-5 * time.Minute),
+	}))
+
+	logoutWithHint(t, grant, idToken)
+
+	data := postToTokenEndpoint(t, createHttpClient(t), config.GetAuthServer().BaseURL+"/auth/token/", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {grant.client.ClientIdentifier},
+		"client_secret": {grant.clientSecret},
+		"refresh_token": {sessionBoundRefresh},
+	})
+	assert.NotEmpty(t, data["access_token"],
+		"the logged-out client's session-bound refresh token must keep working while another client shares the session: %v", data)
 }
 
 func TestAPIAccountLogoutRequest_ValidationErrors_And_Scope(t *testing.T) {

--- a/src/authserver/tests/integration/api_account_sessions_test.go
+++ b/src/authserver/tests/integration/api_account_sessions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // GET /api/v1/account/sessions — happy path, includes isCurrent
@@ -176,6 +177,63 @@ func TestAPIAccountSessionDelete_ForbiddenOnOtherUsersSession(t *testing.T) {
 	var errResp api.ErrorResponse
 	_ = json.NewDecoder(resp.Body).Decode(&errResp)
 	assert.Equal(t, "Forbidden", errResp.ErrorDescription)
+}
+
+// TestAPIAccountSessionDelete_TerminatesTheOfflineGrantsOfThatSession is the self-service half of
+// #129's headline claim, end to end. The bearer is the offline grant's own access token, which
+// carries authserver:manage-account and no `sid`: the account API accepts that, because
+// RequireValidSession only looks a session up for a token that carries one.
+func TestAPIAccountSessionDelete_TerminatesTheOfflineGrantsOfThatSession(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	// Refreshing works to begin with, so a later failure is attributable to the termination.
+	first := grant.refresh(t)
+	require.NotEmpty(t, first["access_token"], "the grant should refresh before termination: %v", first)
+	grant.refreshToken = first["refresh_token"].(string)
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	deleteURL := config.GetAuthServer().BaseURL + "/api/v1/account/sessions/" + strconv.FormatInt(session.Id, 10)
+	resp := makeAPIRequest(t, "DELETE", deleteURL, grant.accessToken, nil)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	after := grant.refresh(t)
+	assert.Equal(t, "invalid_grant", after["error"],
+		"ending your own session must stop its offline refresh token working: %v", after)
+	assert.Empty(t, after["access_token"])
+}
+
+// TestAPIAccountSessionDelete_ForbiddenDoesNotTerminate pairs the ownership check with the new
+// consequence. KEEP THIS. TestAPIAccountSessionDelete_ForbiddenOnOtherUsersSession above asserts only
+// the status code, which a handler that terminated first and refused afterwards would still satisfy,
+// and after #129 that mistake revokes a stranger's grants.
+func TestAPIAccountSessionDelete_ForbiddenDoesNotTerminate(t *testing.T) {
+	callerToken, _ := getUserAccessTokenWithAccountScope(t)
+
+	victim := createOfflineGrant(t)
+	first := victim.refresh(t)
+	require.NotEmpty(t, first["access_token"], "the victim's grant should refresh to begin with: %v", first)
+	victim.refreshToken = first["refresh_token"].(string)
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, victim.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	deleteURL := config.GetAuthServer().BaseURL + "/api/v1/account/sessions/" + strconv.FormatInt(session.Id, 10)
+	resp := makeAPIRequest(t, "DELETE", deleteURL, callerToken, nil)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	stillThere, err := database.GetUserSessionById(nil, session.Id)
+	require.NoError(t, err)
+	assert.NotNil(t, stillThere, "a refused request must not delete the session")
+
+	stillWorks := victim.refresh(t)
+	assert.NotEmpty(t, stillWorks["access_token"],
+		"a refused request must not revoke anything: %v", stillWorks)
 }
 
 func TestAPIAccountSessions_UnauthorizedAndScope(t *testing.T) {

--- a/src/authserver/tests/integration/api_users_sessions_test.go
+++ b/src/authserver/tests/integration/api_users_sessions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestAPIUserSessionsGet tests the GET /api/v1/admin/users/{id}/sessions endpoint
@@ -303,6 +304,57 @@ func TestAPIUserSessionDelete_Success(t *testing.T) {
 	deletedSession, err := database.GetUserSessionById(nil, session.Id)
 	assert.NoError(t, err)
 	assert.Nil(t, deletedSession)
+}
+
+// TestAPIUserSessionDelete_TerminatesTheOfflineGrantsOfThatSession is #129's headline claim,
+// observed at the highest seam that can see it: the administrator ends a session and the offline
+// refresh token authorized through it stops working, without the test reaching into storage to look
+// for a marker.
+//
+// THE SURVIVOR IS THE HALF THAT CARRIES THIS TEST. Without it the case passes against a sweep that
+// revokes everything, which is the failure mode #106 exists to keep this one away from: ending one
+// session must not sign the user out everywhere. It belongs to the SAME user deliberately, so it
+// varies only the session, and so it rejects a user-scoped sweep as well as a table-wide one.
+//
+// What this cannot prove, by design: that a refresh token created AFTER the termination is also
+// refused. The sweep revokes every token that exists at termination, so both mechanisms produce this
+// result. The revoked-code marker's distinctive property is stage 8's evidence, and the column itself
+// belongs to the data tests.
+func TestAPIUserSessionDelete_TerminatesTheOfflineGrantsOfThatSession(t *testing.T) {
+	adminToken, _ := createAdminClientWithToken(t)
+
+	terminated := createOfflineGrant(t)
+	survivor := secondOfflineGrantForSameUser(t, terminated, terminated.password)
+	require.NotEqual(t, terminated.sessionIdentifier, survivor.sessionIdentifier,
+		"the second login must create a DIFFERENT session, or this test proves nothing")
+
+	// Both refresh before the termination, so a later failure is attributable to it and not to a
+	// grant that never worked.
+	first := terminated.refresh(t)
+	require.NotEmpty(t, first["access_token"], "the grant should refresh before termination: %v", first)
+	terminated.refreshToken = first["refresh_token"].(string)
+
+	firstSurvivor := survivor.refresh(t)
+	require.NotEmpty(t, firstSurvivor["access_token"], "the survivor should refresh before termination: %v", firstSurvivor)
+	survivor.refreshToken = firstSurvivor["refresh_token"].(string)
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, terminated.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	deleteURL := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + strconv.FormatInt(session.Id, 10)
+	resp := makeAPIRequest(t, "DELETE", deleteURL, adminToken, nil)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	after := terminated.refresh(t)
+	assert.Equal(t, "invalid_grant", after["error"],
+		"the offline refresh token of the terminated session must stop working: %v", after)
+	assert.Empty(t, after["access_token"])
+
+	stillWorks := survivor.refresh(t)
+	assert.NotEmpty(t, stillWorks["access_token"],
+		"the same user's OTHER session must be untouched: %v", stillWorks)
 }
 
 func TestAPIUserSessionDelete_NotFound(t *testing.T) {

--- a/src/authserver/tests/integration/credential_change_revocation_test.go
+++ b/src/authserver/tests/integration/credential_change_revocation_test.go
@@ -185,6 +185,127 @@ func secondSessionFor(t *testing.T, grant *offlineGrant, password string) (strin
 	return accessToken, sid
 }
 
+// secondOfflineGrantForSameUser is secondSessionFor with the offline scope: it logs the SAME user in
+// again through a fresh cookie jar and returns a second, independent offline grant on the same
+// client. Added by #129 stage 4, whose termination cases need a grant that must SURVIVE while
+// another session of the same user is ended. Varying only the session is what makes it reject a
+// table-wide sweep and a user-scoped one at once.
+//
+// A DISTINCT User-Agent is required rather than cosmetic, for the reason secondSessionFor states:
+// StartNewUserSession deletes other sessions of the same user sharing device name, type, OS and IP
+// address, so without it the second login silently deletes the first.
+//
+// The consent screen is reached unconditionally rather than conditionally, and that is a property of
+// the server rather than an assumption: both HandleAuthCompletedGet and HandleConsentGet route an
+// offline_access request to consent regardless of what the user already consented to, deliberately,
+// to re-confirm the refresh token grant every time.
+//
+// password must be the user's CURRENT password.
+func secondOfflineGrantForSameUser(t *testing.T, base *offlineGrant, password string) *offlineGrant {
+	t.Helper()
+
+	httpClient := createHttpClientWithUserAgent(t,
+		"Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36")
+	const codeVerifier = "code-verifier-second-offline"
+	scope := "openid offline_access " +
+		constants.AuthServerResourceIdentifier + ":" + constants.ManageAccountPermissionIdentifier
+
+	destURL := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + base.client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(base.redirectURI) +
+		"&response_type=code&code_challenge_method=S256" +
+		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
+		"&scope=" + url.QueryEscape(scope) +
+		"&state=" + gofakeit.LetterN(8) + "&nonce=" + gofakeit.LetterN(8)
+
+	resp, err := httpClient.Get(destURL)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	location := assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, location)
+	_ = resp.Body.Close()
+
+	location = assertRedirect(t, resp, "/auth/pwd")
+	resp = loadPage(t, httpClient, location)
+	csrf := getCsrfValue(t, resp)
+	_ = resp.Body.Close()
+
+	resp = authenticateWithPassword(t, httpClient, location, base.user.Email, password, csrf)
+	_ = resp.Body.Close()
+
+	location = assertRedirect(t, resp, "/auth/level1completed")
+	resp = loadPage(t, httpClient, location)
+	_ = resp.Body.Close()
+
+	location = assertRedirect(t, resp, "/auth/completed")
+	resp = loadPage(t, httpClient, location)
+	_ = resp.Body.Close()
+
+	location = assertRedirect(t, resp, "/auth/consent")
+	resp = loadPage(t, httpClient, location)
+	csrf = getCsrfValue(t, resp)
+	_ = resp.Body.Close()
+
+	consentEndpoint := config.GetAuthServer().BaseURL + "/auth/consent"
+	consentForm := url.Values{
+		"gorilla.csrf.Token": {csrf},
+		"btnSubmit":          {"submit"},
+		"consent0":           {"on"},
+		"consent1":           {"on"},
+		"consent2":           {"on"},
+		"consent3":           {"on"},
+	}
+	consentReq, err := http.NewRequest("POST", consentEndpoint, strings.NewReader(consentForm.Encode()))
+	require.NoError(t, err)
+	consentReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	consentReq.Header.Set("Referer", consentEndpoint)
+	consentReq.Header.Set("Origin", config.GetAuthServer().BaseURL)
+
+	resp, err = httpClient.Do(consentReq)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	location = assertRedirect(t, resp, "/auth/issue")
+	resp = loadPage(t, httpClient, location)
+	code, _ := getCodeAndStateFromUrl(t, resp)
+	_ = resp.Body.Close()
+	require.NotEmpty(t, code)
+
+	// The sid comes off the codes row, not the token: an offline refresh token's own
+	// session_identifier column is empty.
+	codeHash, err := hashutil.HashString(code)
+	require.NoError(t, err)
+	codeEntity, err := database.GetCodeByCodeHash(nil, codeHash, false)
+	require.NoError(t, err)
+	require.NotNil(t, codeEntity)
+	require.NotEmpty(t, codeEntity.SessionIdentifier)
+
+	data := postToTokenEndpoint(t, httpClient, config.GetAuthServer().BaseURL+"/auth/token/", url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {base.client.ClientIdentifier},
+		"client_secret": {base.clientSecret},
+		"code":          {code},
+		"redirect_uri":  {base.redirectURI},
+		"code_verifier": {codeVerifier},
+	})
+	accessToken, ok := data["access_token"].(string)
+	require.True(t, ok, "expected an access token: %v", data)
+	refreshToken, ok := data["refresh_token"].(string)
+	require.True(t, ok, "offline_access must yield a refresh token: %v", data)
+
+	return &offlineGrant{
+		client:            base.client,
+		clientSecret:      base.clientSecret,
+		user:              base.user,
+		password:          password,
+		redirectURI:       base.redirectURI,
+		accessToken:       accessToken,
+		refreshToken:      refreshToken,
+		sessionIdentifier: codeEntity.SessionIdentifier,
+		httpClient:        httpClient,
+	}
+}
+
 // exchange redeems a code for tokens on this grant's client.
 func (g *offlineGrant) exchange(t *testing.T, code string, codeVerifier string) map[string]interface{} {
 	t.Helper()

--- a/src/authserver/tests/integration/session_deletion_test.go
+++ b/src/authserver/tests/integration/session_deletion_test.go
@@ -1,7 +1,9 @@
 package integrationtests
 
 import (
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -191,6 +193,163 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 	assert.Equal(t, 1, len(userSessions2), "Should have a new session after second login")
 }
 
+// TestSessionEndedOnConsentScreen_NoCodeIsIssued is the third of this file's paired
+// ceremonies, and it covers the half of #129 gap 3 that the gate at /auth/completed cannot
+// reach (decision 6's second half, plus decision 12).
+//
+// Here the session is alive all the way through /auth/completed, which bumps or creates it,
+// so that gate passes legitimately. The user is then parked on the consent screen, which is
+// where the window widens from milliseconds to however long a person takes to click, and the
+// session is ended while they sit there. HandleConsentPost reads no session row, so the
+// submission proceeds exactly as always and hands off to /auth/issue.
+//
+// Nothing written at termination can reach the code /auth/issue would mint, because that row
+// does not exist yet when RevokeCodesBySessionIdentifier runs. Only the liveness check at
+// /auth/issue stops it, and the code is worth stopping: an empty session identifier alone
+// makes grantIsOffline true, so the refresh token that code yields would be stored as an
+// Offline one, with a max lifetime and no session for the validator to consult, whether or
+// not offline_access was ever requested.
+//
+// The pairing with the two tests around it is the point. This one varies the window rather
+// than the credential: a password really was entered in this ceremony, so a predicate keyed
+// on authentication passes and only one keyed on the session refuses.
+func TestSessionEndedOnConsentScreen_NoCodeIsIssued(t *testing.T) {
+	client := &models.Client{
+		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		Enabled:                  true,
+		AuthorizationCodeEnabled: true,
+		// The consent screen is what holds the ceremony still between /auth/completed and
+		// /auth/issue, which is the whole window this case is about.
+		ConsentRequired: true,
+		DefaultAcrLevel: enums.AcrLevel1,
+	}
+	err := database.CreateClient(nil, client)
+	assert.NoError(t, err)
+
+	redirectUri := &models.RedirectURI{
+		ClientId: client.Id,
+		URI:      gofakeit.URL(),
+	}
+	err = database.CreateRedirectURI(nil, redirectUri)
+	assert.NoError(t, err)
+
+	password := gofakeit.Password(true, true, true, true, false, 8)
+	passwordHashed, err := hashutil.HashPassword(password)
+	assert.NoError(t, err)
+
+	user := &models.User{
+		Subject:      uuid.New(),
+		Enabled:      true,
+		Email:        gofakeit.Email(),
+		PasswordHash: passwordHashed,
+	}
+	err = database.CreateUser(nil, user)
+	assert.NoError(t, err)
+
+	// One HTTP client throughout, so the cookie is shared and this is one browser's ceremony
+	// rather than two.
+	httpClient := createHttpClient(t)
+
+	requestState := gofakeit.LetterN(8)
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&scope=" + url.QueryEscape("openid profile email") +
+		"&state=" + requestState +
+		"&nonce=" + gofakeit.LetterN(8)
+
+	resp, err := httpClient.Get(destUrl)
+	assert.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation := assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/pwd")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	csrf := getCsrfValue(t, resp)
+
+	// A password IS entered here, unlike the OTP case below. That is what makes this ceremony
+	// legitimate up to the consent screen and what makes /auth/issue the only hop that can
+	// refuse it.
+	resp = authenticateWithPassword(t, httpClient, redirectLocation, user.Email, password, csrf)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/level1completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// Consent, not /auth/issue: the ceremony now waits for a person.
+	redirectLocation = assertRedirect(t, resp, "/auth/consent")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	consentCsrf := getCsrfValue(t, resp)
+
+	// The session exists at this point, created by /auth/completed while it was legitimately
+	// reached. Ending it is what the rest of the case turns on.
+	userSessions, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(userSessions), "the ceremony should have created one session before consent")
+
+	// Deleting the row directly, as this file's other tests do: that the two DELETE endpoints
+	// also revoke the session's grants is covered by api_users_sessions_test.go and
+	// api_account_sessions_test.go, and what this case needs is the session gone.
+	err = database.DeleteUserSession(nil, userSessions[0].Id)
+	assert.NoError(t, err)
+
+	consentEndpoint := config.GetAuthServer().BaseURL + "/auth/consent"
+	consentForm := url.Values{
+		"gorilla.csrf.Token": {consentCsrf},
+		"btnSubmit":          {"submit"},
+		"consent0":           {"on"},
+		"consent1":           {"on"},
+		"consent2":           {"on"},
+	}
+	consentReq, err := http.NewRequest("POST", consentEndpoint, strings.NewReader(consentForm.Encode()))
+	assert.NoError(t, err)
+	consentReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	consentReq.Header.Set("Referer", consentEndpoint)
+	consentReq.Header.Set("Origin", config.GetAuthServer().BaseURL)
+
+	resp, err = httpClient.Do(consentReq)
+	assert.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The consent submission itself succeeds, and asserting that is deliberate: it reads no
+	// session row, so the termination is invisible to it. This is what makes the next hop the
+	// load-bearing one rather than an incidental one.
+	redirectLocation = assertRedirect(t, resp, "/auth/issue")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The liveness check. Before #129 stage 6 this redirected to the client with a usable code
+	// bound to a session that no longer existed.
+	redirectLocation = assertRedirect(t, resp, "/auth/level1")
+	assert.NotContains(t, redirectLocation, "code=",
+		"no authorization code may reach the client once the session backing the ceremony is gone")
+
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// And the restart is a real one: the user is asked for a password again.
+	assertRedirect(t, resp, "/auth/pwd")
+
+	userSessionsAfter, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(userSessionsAfter),
+		"the ended session must not be recreated by a ceremony waiting on the consent screen")
+}
+
 // TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession is the pair of the test
 // above, and the case that decided #129 decision 15.
 //
@@ -303,4 +462,95 @@ func TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession(t *testing.T
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(userSessionsAfter),
 		"the ended session must not be recreated by a ceremony that only verified OTP")
+}
+
+// TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired is the fourth of this file's
+// ceremonies, and the case that decided #129 decision 16.
+//
+// It is the same window as TestSessionEndedOnConsentScreen_NoCodeIsIssued, entered by the
+// other door. handlePromptNone runs its silent checks, bumps the session and redirects to
+// /auth/issue; the session is ended in that one hop; and the liveness check at /auth/issue
+// finds the identifier gone exactly as it does for the consent-screen ceremony.
+//
+// What differs is the outcome, and that is the point of the pairing. The consent-screen
+// ceremony is restarted at level 1 and arrives at a password form. This one must never see a
+// page at all: prompt=none forbids UI, and nothing between /auth/issue and /auth/pwd reads
+// the prompt, so a restart would hand a silent-renewal iframe a login screen and no error,
+// which it cannot tell from a hang. It gets login_required instead, which is what
+// handlePromptNone itself returns when its own session lookup finds no row.
+func TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired(t *testing.T) {
+	httpClient, client, redirectUri, user := createSessionWithAcrLevel1(t)
+
+	userSessions, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(userSessions), "the level 1 login should have left one session")
+	userSession := userSessions[0]
+
+	// A second authorization on the same browser, silent this time. The client does not
+	// require consent, so with a live session behind it this goes straight to /auth/issue.
+	requestState := gofakeit.LetterN(8)
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&scope=" + url.QueryEscape("openid profile email") +
+		"&state=" + requestState +
+		"&nonce=" + gofakeit.LetterN(8) +
+		"&prompt=none"
+
+	resp, err := httpClient.Get(destUrl)
+	assert.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// handlePromptNone accepted the session and handed off. Asserting that rather than an
+	// error here is deliberate: it is what puts the whole window in the next hop.
+	redirectLocation := assertRedirect(t, resp, "/auth/issue")
+
+	// The session is ended between the 302 and the browser following it. This is the narrowest
+	// window in gap 3 and the only one prompt=none can sit in, since it never waits for a
+	// person.
+	err = database.DeleteUserSession(nil, userSession.Id)
+	assert.NoError(t, err)
+
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// Back to the client with an error, rather than on to a password form.
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	assert.Contains(t, location, redirectUri.URI,
+		"a silent ceremony must be answered at the client's redirect URI, not with a page")
+	assert.NotContains(t, location, "/auth/level1",
+		"prompt=none must not be restarted into the interactive flow")
+
+	errorCode, _, state := getErrorFromUrl(t, resp)
+	assert.Equal(t, "login_required", errorCode)
+	assert.Equal(t, requestState, state, "the client's state must survive the error response")
+
+	parsedLocation, err := url.Parse(location)
+	assert.NoError(t, err)
+	assert.Empty(t, parsedLocation.Query().Get("code"),
+		"no authorization code may reach the client once the session backing the ceremony is gone")
+
+	userSessionsAfter, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(userSessionsAfter),
+		"a refused silent ceremony must not recreate the ended session")
+
+	// The refusal also has to leave the browser with no ceremony to replay, and only a
+	// second request can see that. Clearing the auth context persists through a Set-Cookie,
+	// so it reaches this jar only if the handler cleared before committing the redirect;
+	// clearing afterwards would answer login_required again here, from a context still
+	// reading ready_to_issue_code. With the context gone the handler has nothing to resume
+	// and sends the browser to the account profile instead.
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	replayLocation := resp.Header.Get("Location")
+	assert.Contains(t, replayLocation, "/account/profile",
+		"the refusal must clear the auth context in the browser, so a replayed /auth/issue has no ceremony left")
+	assert.NotContains(t, replayLocation, redirectUri.URI,
+		"a cleared ceremony must not answer the client a second time")
 }

--- a/src/authserver/tests/integration/session_deletion_test.go
+++ b/src/authserver/tests/integration/session_deletion_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -187,4 +189,118 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 	userSessions2, err := database.GetUserSessionsByUserId(nil, user.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(userSessions2), "Should have a new session after second login")
+}
+
+// TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession is the pair of the test
+// above, and the case that decided #129 decision 15.
+//
+// The ceremony here never enters a password. It reuses an existing level 1 session, is sent
+// to /auth/otp because the client asks for level2_mandatory, and the session is ended while
+// it sits on the OTP form. HandleAuthOtpPost reads no session row, so the termination is
+// invisible to it: it verifies the code and hands off to /auth/completed with
+// AuthenticatedAt set. Only the gate there stops the ceremony, and only because it reads
+// Level1AuthCompleted rather than AuthenticatedAt.
+//
+// Without that distinction the ended session is silently recreated, which is the defect
+// #129 exists to close. The sub-case that makes it serious is a user without OTP on a
+// level2_mandatory client: the enrollment page hands the browser the secret it will be
+// tested on, so a stolen session cookie alone is enough to reach here.
+//
+// This is the same shape as TestSessionDeletedDuringAuthFlow_LoginSucceeds above, varying
+// exactly one thing: whether a password was entered in this ceremony. That pairing is what
+// pins the predicate as "this ceremony did level 1" rather than "no valid session".
+func TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession(t *testing.T) {
+	httpClient, client, redirectUri, user := createSessionWithAcrLevel1(t)
+
+	// Give the user OTP, so /auth/level2 sends the step-up to the OTP form rather than
+	// to enrollment. Either arrives at the same gate; this is the shorter route.
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "Goiabada",
+		AccountName: user.Email,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user.OTPEnabled = true
+	user.OTPSecret = key.Secret()
+	user.OTPSecretEncrypted = encryptOTPSecretForTest(t, key.Secret())
+	err = database.UpdateUser(nil, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userSessions, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(userSessions), "the level 1 login should have left one session")
+	userSession := userSessions[0]
+
+	// A second authorization request on the same browser, asking for level 2. The session
+	// is reused, so this ceremony never reaches the password handler.
+	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := gofakeit.LetterN(8)
+	requestNonce := gofakeit.LetterN(8)
+	requestScope := "openid profile email"
+
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + requestCodeChallenge +
+		"&scope=" + url.QueryEscape(requestScope) +
+		"&state=" + requestState +
+		"&nonce=" + requestNonce +
+		"&acr_values=" + enums.AcrLevel2Mandatory.String()
+
+	resp, err := httpClient.Get(destUrl)
+	assert.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// Straight to level1completed: the session covers level 1, no password is asked for.
+	redirectLocation := assertRedirect(t, resp, "/auth/level1completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/level2")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/otp")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	csrf := getCsrfValue(t, resp)
+
+	// The session is ended while the ceremony waits on the OTP form. Deleting the row is
+	// what the gate keys on, and it is how this file's other test ends a session too; that
+	// the two DELETE endpoints revoke the session's grants as well is covered by
+	// api_users_sessions_test.go and api_account_sessions_test.go.
+	err = database.DeleteUserSession(nil, userSession.Id)
+	assert.NoError(t, err)
+
+	otpCode, err := totp.GenerateCode(user.OTPSecret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp = authenticateWithOtp(t, httpClient, redirectLocation, otpCode, csrf)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The OTP itself is accepted: the handler reads no session row, so it cannot see the
+	// termination. Asserting this rather than a failure here is deliberate, because it is
+	// what makes the next hop the load-bearing one.
+	redirectLocation = assertRedirect(t, resp, "/auth/completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The gate. Before #129 this went to /auth/issue with a recreated session behind it.
+	redirectLocation = assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// And the restart is a real one: the user is asked for a password.
+	assertRedirect(t, resp, "/auth/pwd")
+
+	userSessionsAfter, err := database.GetUserSessionsByUserId(nil, user.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(userSessionsAfter),
+		"the ended session must not be recreated by a ceremony that only verified OTP")
 }

--- a/src/authserver/tests/integration/token_refresh_concurrent_test.go
+++ b/src/authserver/tests/integration/token_refresh_concurrent_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
@@ -165,4 +167,304 @@ func TestToken_Refresh_ConcurrentDoubleSpend_IssuesOnlyOnce(t *testing.T) {
 	// legitimately ends with zero or one live member, and asserting exactly one would
 	// fail on correct behaviour.
 	assert.LessOrEqual(t, len(live), 1, "at most one family member may be left live after the race")
+}
+
+// terminatedGrantMessage is what validator/refresh-code-revoked answers with, and reading it is
+// how the cases below tell WHICH gate refused a token. The handler's own revoked-row branch
+// answers the same invalid_grant with "This refresh token has been revoked.", and the marker is
+// read first because it lives in ValidateTokenRequest, ahead of the handler.
+const terminatedGrantMessage = "The refresh token is invalid because the associated session has expired or been terminated."
+
+// concurrentDelete issues an authenticated DELETE and returns rather than asserting, so it can run
+// in a goroutine beside the refresh presentations below. Same contract and same reason as
+// concurrentTokenPost: require and assert.FailNow are not safe off the test's own goroutine.
+func concurrentDelete(client *http.Client, urlStr string, accessToken string) (int, error) {
+	req, err := http.NewRequest("DELETE", urlStr, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode, nil
+}
+
+// TestToken_Refresh_ChildOfATerminatedGrantIsBornRejected is #129 gap 2's evidence, which is the
+// last thing decision 1 wants before the issue closes.
+//
+// Gap 2 is the concurrency window inside rotation: the presented token is claimed and its
+// replacement inserted as two separate commits, so a refresh that validated before a termination
+// swept the grant inserts its child AFTER that sweep committed. For an offline grant nothing else
+// invalidates that child, because the Offline branch of ValidateTokenRequest checks only the max
+// lifetime and deliberately never consults the session.
+//
+// Decision 4 closes it structurally rather than by serializing anything. A rotated child inherits
+// its parent's code_id, so marking the code marks every descendant, present and future: the child
+// is born already rejected because the fact predates its existence. This test is that claim,
+// checked both ways round, the child issued before the termination and the child issued after it.
+//
+// offline_access is required rather than incidental. A session-bound refresh token dies at the
+// Refresh branch's session lookup the moment the row is gone, so it would be refused whatever the
+// marker did and the case would prove nothing. The Offline and empty-session-identifier
+// requirements below are what keep this test out of that trap.
+func TestToken_Refresh_ChildOfATerminatedGrantIsBornRejected(t *testing.T) {
+	adminToken, _ := createAdminClientWithToken(t)
+	grant := createOfflineGrant(t)
+
+	parentRow, err := database.GetRefreshTokenByJti(nil, refreshTokenJti(t, grant.refreshToken))
+	require.NoError(t, err)
+	require.NotNil(t, parentRow, "the redeemed grant must have a refresh token row")
+
+	// Rotate once while the session is still live, so the child under test is a genuine
+	// server-minted token written by rotation rather than a fixture.
+	rotated := grant.refresh(t)
+	require.NotEmpty(t, rotated["access_token"], "the grant must refresh before the termination: %v", rotated)
+	childToken, ok := rotated["refresh_token"].(string)
+	require.True(t, ok, "rotation must return a replacement refresh token: %v", rotated)
+	grant.refreshToken = childToken
+
+	childJti := refreshTokenJti(t, childToken)
+	childRow, err := database.GetRefreshTokenByJti(nil, childJti)
+	require.NoError(t, err)
+	require.NotNil(t, childRow, "the rotated child must have been persisted")
+
+	// Decision 4's load-bearing property, asserted rather than assumed: the child hangs off the
+	// SAME code as its parent, which is what lets one marker reject a whole grant.
+	require.True(t, childRow.CodeId.Valid, "an auth-code-derived refresh token must carry a code id")
+	require.Equal(t, parentRow.CodeId.Int64, childRow.CodeId.Int64,
+		"the rotated child must inherit its parent's code id, or nothing below tests the marker")
+
+	// And the two requirements that stop this being the benign member of its class.
+	require.Equal(t, "Offline", childRow.RefreshTokenType,
+		"the grant must be offline, or the Refresh branch's session check refuses it whatever the marker does")
+	require.Empty(t, childRow.SessionIdentifier,
+		"an offline token carries no session identifier of its own, which is why only the code can reach it")
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session, "the ceremony's session must exist before it can be terminated")
+
+	deleteURL := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + strconv.FormatInt(session.Id, 10)
+	resp := makeAPIRequest(t, "DELETE", deleteURL, adminToken, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// One: the child that already existed when the termination ran. Its own row was revoked by
+	// the sweep, and its code was marked in the same transaction, so BOTH gates could refuse it.
+	// The error_description is what says which one did, and it must be the marker's: the check
+	// lives in the validator, ahead of the handler's revoked-row branch. It is also incidental
+	// evidence that termination left the user's generation alone, since moving it would answer
+	// with the generation message instead (section 4.6).
+	afterSweep := grant.refresh(t)
+	assert.Equal(t, "invalid_grant", afterSweep["error"],
+		"the child of a terminated grant must not refresh: %v", afterSweep)
+	assert.Equal(t, terminatedGrantMessage, afterSweep["error_description"],
+		"the revoked-code marker must be the gate that answers, ahead of the handler's revoked-row branch: %v", afterSweep)
+	assert.Empty(t, afterSweep["access_token"])
+
+	// Two: the child the sweep never saw, which is gap 2 itself.
+	//
+	// THE ONE COLUMN CLEARED BELOW IS THE ONLY THING THE INTERLEAVING DECIDES. A refresh whose
+	// insert lands after the sweep read refresh_tokens leaves exactly this row state: revoked =
+	// false on the child, its code_id pointing at the code the same termination marked. Nothing
+	// here fabricates a grant: the JWT was minted by the server, the row was written by rotation,
+	// the code was marked by the real DELETE above, and the session is really gone. Hand-building
+	// a signed token and its row instead would prove less, because the shape would then be this
+	// test's invention rather than rotation's.
+	//
+	// The window cannot be driven from outside the server, which is why it is reconstructed here
+	// and only approached by the racing case below.
+	swept, err := database.GetRefreshTokenByJti(nil, childJti)
+	require.NoError(t, err)
+	require.NotNil(t, swept)
+	require.True(t, swept.Revoked,
+		"the termination sweep must have revoked the child that existed when it ran, or the fixture below means nothing")
+
+	swept.Revoked = false
+	require.NoError(t, database.UpdateRefreshToken(nil, swept))
+	relived, err := database.GetRefreshTokenByJti(nil, childJti)
+	require.NoError(t, err)
+	require.False(t, relived.Revoked, "the child must be live again, or this case proves nothing")
+
+	familyBefore, err := database.GetRefreshTokensByCodeId(nil, childRow.CodeId.Int64)
+	require.NoError(t, err)
+
+	// This is the presentation that would succeed without the marker: the row is live, so the
+	// handler's compare-and-set claim wins and rotation mints a working replacement.
+	born := grant.refresh(t)
+	assert.Equal(t, "invalid_grant", born["error"],
+		"a live child of a terminated grant must still be refused, which is gap 2: %v", born)
+	assert.Equal(t, terminatedGrantMessage, born["error_description"],
+		"only the revoked-code marker can refuse a child whose own row is live: %v", born)
+	assert.Empty(t, born["access_token"], "no access token may be issued for a terminated grant")
+	assert.Empty(t, born["refresh_token"], "no replacement may be issued for a terminated grant")
+
+	familyAfter, err := database.GetRefreshTokensByCodeId(nil, childRow.CodeId.Int64)
+	require.NoError(t, err)
+	assert.Len(t, familyAfter, len(familyBefore),
+		"a refused presentation must mint no descendant")
+}
+
+// TestToken_Refresh_RacingATermination_LeavesNoUsableDescendant drives the window of gap 2 for
+// real, rather than reconstructing its outcome the way the case above does: eight presentations of
+// one offline refresh token and the administrative DELETE, all released together.
+//
+// The invariant is unconditional, and that is the point rather than a convenience. The termination
+// marks the grant's code, every descendant carries that code_id, and the marker is read from the
+// joined code on every presentation, so no interleaving can leave a usable descendant. What the
+// interleaving decides is only WHICH gate refuses a child: the handler's revoked-row branch when
+// the sweep saw it, the validator's marker when it did not.
+//
+// WHAT IT CANNOT FORCE, and must not claim to: which interleaving occurred. A race whose DELETE
+// commits first refuses all eight at the marker and shows only that nothing was minted. The
+// interesting ordering, a validation that read the code live followed by an insert landing after
+// the sweep, is not reachable from outside the server, and it is what
+// TestToken_Refresh_ChildOfATerminatedGrantIsBornRejected reconstructs. The number of replacements
+// the race produced is logged rather than asserted, so a run that proved little says so.
+func TestToken_Refresh_RacingATermination_LeavesNoUsableDescendant(t *testing.T) {
+	adminToken, _ := createAdminClientWithToken(t)
+	grant := createOfflineGrant(t)
+
+	// One clean rotation first, so a refusal after the race is attributable to the termination
+	// rather than to a grant that never worked.
+	warmup := grant.refresh(t)
+	require.NotEmpty(t, warmup["access_token"], "the grant must refresh before the race: %v", warmup)
+	racedToken, ok := warmup["refresh_token"].(string)
+	require.True(t, ok, "rotation must return a replacement refresh token: %v", warmup)
+	grant.refreshToken = racedToken
+
+	session, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	deleteURL := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + strconv.FormatInt(session.Id, 10)
+	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
+	formData := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {grant.client.ClientIdentifier},
+		"refresh_token": {racedToken},
+		"client_secret": {grant.clientSecret},
+	}
+
+	httpClient := createHttpClient(t)
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	statuses := make([]int, concurrency)
+	bodies := make([]map[string]interface{}, concurrency)
+	reqErrs := make([]error, concurrency)
+	deleteStatus := 0
+	var deleteErr error
+	release := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-release // release everything together, so the termination lands mid-rotation
+			statuses[idx], bodies[idx], reqErrs[idx] = concurrentTokenPost(httpClient, destUrl, formData)
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-release
+		// A PROBABILITY KNOB, NOT A SYNCHRONIZATION POINT. Released at the same instant the
+		// termination consistently commits before any presentation has finished verifying the
+		// refresh token's signature, so the race produces no replacement at all and the
+		// assertions below have nothing to chew on. A few milliseconds lets a rotation get as
+		// far as its insert. Every assertion in this test holds at any value including zero,
+		// which is what keeps this a knob rather than a dependency, and the log line below says
+		// what the chosen value actually produced.
+		time.Sleep(5 * time.Millisecond)
+		deleteStatus, deleteErr = concurrentDelete(createHttpClient(t), deleteURL, adminToken)
+	}()
+	close(release)
+	wg.Wait()
+
+	require.NoError(t, deleteErr, "the termination request failed at the transport level")
+	if deleteStatus != http.StatusOK {
+		// Contention with rotation can legitimately fail the termination transaction on the
+		// server engines, as a lock timeout or a deadlock. That is not what this case is about,
+		// so it is retried once, sequentially. Tolerating it weakens nothing: a failed
+		// termination mints no token, and the invariant below is asserted only once the session
+		// is verified gone.
+		t.Logf("the concurrent termination answered %d, retrying it sequentially", deleteStatus)
+		resp := makeAPIRequest(t, "DELETE", deleteURL, adminToken, nil)
+		deleteStatus = resp.StatusCode
+		_ = resp.Body.Close()
+	}
+	require.Equal(t, http.StatusOK, deleteStatus, "the session must actually have been terminated")
+
+	gone, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.Nil(t, gone, "the session must be gone before anything below means anything")
+
+	replacements := make([]string, 0, concurrency)
+	for i := 0; i < concurrency; i++ {
+		assert.NoErrorf(t, reqErrs[i], "request %d failed at the transport level", i)
+
+		refreshToken := ""
+		if bodies[i] != nil {
+			refreshToken, _ = bodies[i]["refresh_token"].(string)
+		}
+
+		if refreshToken != "" {
+			replacements = append(replacements, refreshToken)
+			assert.Equalf(t, http.StatusOK, statuses[i], "the winning request %d must be a 200", i)
+		} else {
+			assert.NotEqualf(t, http.StatusOK, statuses[i], "a refused request %d must not be a 200", i)
+			if bodies[i] != nil {
+				assert.Nilf(t, bodies[i]["access_token"], "a refused request %d must not get an access_token", i)
+				// Logged rather than asserted: which gate refuses a given presentation is
+				// exactly what the interleaving decides, and this run cannot choose it. Seeing
+				// both descriptions here is the interleaving spread visible in the log.
+				t.Logf("request %d was refused with: %v", i, bodies[i]["error_description"])
+			}
+		}
+	}
+
+	// Rotation's own invariant, which the termination racing it must not break.
+	assert.LessOrEqual(t, len(replacements), 1,
+		"one refresh token may yield at most one replacement, whichever way the race fell")
+	t.Logf("the race produced %d replacement token(s) alongside the termination", len(replacements))
+
+	// The invariant this case exists for: whatever the race handed out is unusable afterwards.
+	for i, replacement := range replacements {
+		// Which interleaving actually happened is recorded rather than asserted, because both
+		// are legitimate and this test cannot choose between them. A replacement the sweep
+		// revoked was inserted before the sweep read refresh_tokens; one still live is gap 2's
+		// own interleaving, the child the sweep never saw, and then the marker is the only thing
+		// standing between it and a working grant. Read before presenting it, since the refusal
+		// below leaves the row alone.
+		row, rowErr := database.GetRefreshTokenByJti(nil, refreshTokenJti(t, replacement))
+		require.NoError(t, rowErr)
+		require.NotNil(t, row, "a replacement the server handed out must have a row")
+		if row.Revoked {
+			t.Logf("replacement %d was revoked in storage: it landed before the termination's sweep", i)
+		} else {
+			t.Logf("replacement %d is still live in storage: the sweep never saw it, which is gap 2's own interleaving", i)
+		}
+
+		presented := postToTokenEndpoint(t, createHttpClient(t), destUrl, url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {grant.client.ClientIdentifier},
+			"refresh_token": {replacement},
+			"client_secret": {grant.clientSecret},
+		})
+		assert.Equalf(t, "invalid_grant", presented["error"],
+			"replacement %d must not be usable after the termination: %v", i, presented)
+		assert.Emptyf(t, presented["access_token"], "replacement %d must yield no access token", i)
+		t.Logf("replacement %d was refused with: %v", i, presented["error_description"])
+	}
+
+	// And the token the race contended for, which is consumed either way.
+	parent := grant.refresh(t)
+	assert.Equal(t, "invalid_grant", parent["error"],
+		"the raced refresh token must not be usable after the termination: %v", parent)
+	assert.Empty(t, parent["access_token"])
 }

--- a/src/core/constants/constants.go
+++ b/src/core/constants/constants.go
@@ -178,7 +178,26 @@ const (
 	//
 	// Deliberately NOT AuditUserDisabled, which already means "a disabled user was rejected"
 	// and is emitted from six auth paths; overloading it would make that event ambiguous.
-	AuditRevokedUserAuthState           = "revoked_user_auth_state"
+	AuditRevokedUserAuthState = "revoked_user_auth_state"
+	// AuditTerminatedUserSession records that an explicit "end this session" action durably cut
+	// off the grants that session authorized: the authorization codes issued through it are
+	// marked revoked, its refresh tokens including offline ones are revoked, and the session row
+	// is deleted. Emitted by the two session-termination endpoints AFTER their transaction
+	// commits, on success only, and emitted even when nothing was found to revoke, so the event
+	// attests that the action happened (#129 decision 9).
+	//
+	// It accompanies AuditDeletedUserSession rather than replacing it. The two carry different
+	// meanings, one a session-lifecycle fact and one a security action, and leaving the older
+	// event's payload untouched keeps any external consumer parsing it strictly working. The
+	// consequence is that both are emitted per action, so THIS is the event to count for
+	// terminations and deleted_user_session is the lifecycle record beside it.
+	//
+	// Its payload carries userId, userSessionId, sessionIdentifier, revokedRefreshTokenJtis and
+	// revokedCodeCount, plus loggedInUser. Codes get a count rather than a list of ids because no
+	// event here lists code ids, and a count answers the only question an auditor has, whether
+	// anything was revoked.
+	AuditTerminatedUserSession = "terminated_user_session"
+
 	AuditEnabledOTP                     = "enabled_otp"
 	AuditDisabledOTP                    = "disabled_otp"
 	AuditAutoRefreshedToken             = "auto_refreshed_token"
@@ -246,6 +265,7 @@ var AuditEventTypes = []string{
 	AuditSentPhoneVerificationMessage,
 	AuditSentTestEmail,
 	AuditStartedNewUserSesson,
+	AuditTerminatedUserSession,
 	AuditTokenIssuedAuthorizationCodeResponse,
 	AuditTokenIssuedClientCredentialsResponse,
 	AuditTokenIssuedImplicitResponse,

--- a/src/core/constants/constants_test.go
+++ b/src/core/constants/constants_test.go
@@ -62,7 +62,7 @@ func TestAuditEventTypes_NonEmpty(t *testing.T) {
 
 // TestAuditEventTypes_Count acts as a drift guard - update expected count when adding/removing audit events
 func TestAuditEventTypes_Count(t *testing.T) {
-	expectedCount := 94
+	expectedCount := 95
 	actualCount := len(AuditEventTypes)
 
 	require.Equal(t, expectedCount, actualCount,
@@ -98,6 +98,11 @@ func TestAuditEventTypes_ContainsCriticalEvents(t *testing.T) {
 		// (#106). Security-relevant in the same class as key revocation: if this event ever
 		// stopped being emitted, a forced logout would leave no trace.
 		AuditRevokedUserAuthState,
+		// Records that ending one session durably cut off the grants it authorized (#129). Same
+		// class as the event above, and for the same reason: deleted_user_session survives
+		// either way, so if this one stopped being emitted the security action would leave only
+		// a lifecycle record behind and nothing attesting what it revoked.
+		AuditTerminatedUserSession,
 	}
 
 	for _, critical := range criticalEvents {
@@ -173,6 +178,7 @@ func TestAuditEventTypes_MatchesConstants(t *testing.T) {
 		AuditSentPhoneVerificationMessage,
 		AuditSentTestEmail,
 		AuditStartedNewUserSesson,
+		AuditTerminatedUserSession,
 		AuditTokenIssuedAuthorizationCodeResponse,
 		AuditTokenIssuedClientCredentialsResponse,
 		AuditTokenIssuedImplicitResponse,

--- a/src/core/data/commondb/code.go
+++ b/src/core/data/commondb/code.go
@@ -344,28 +344,55 @@ func (d *CommonDatabase) DeleteCode(tx *sql.Tx, codeId int64) error {
 	return nil
 }
 
-// DeleteUsedCodesWithoutRefreshTokens deletes codes that were marked used but never
-// produced a refresh token, and that are older than createdBefore.
+// DeleteUsedCodesWithoutRefreshTokens reaps codes that can no longer produce anything,
+// and that are older than createdBefore. Two disjoint classes qualify, and the name is
+// kept for the first of them because renaming it would touch the interface, four engine
+// wrappers, the generated mocks and the worker for no behavioural gain:
 //
-// The age cutoff is not an optimisation, it is required for correctness. The token
-// endpoint marks a code used (handler_token.go, MarkCodeAsUsed) and only afterwards
-// inserts the refresh token that references it, so for the duration of token generation
-// a perfectly healthy code sits in exactly the state this predicate selects. Deleting it
-// there makes the subsequent insert fail on fk_refresh_tokens_code and the client gets a
-// 500 instead of its tokens. Observed in CI on postgres.
+//   - codes that were marked used but never produced a refresh token, and
+//   - codes revoked while still unredeemed, which is what ending a session leaves behind
+//     when the grant it marked had not been exchanged yet (#129 decision 8).
 //
-// Callers should pass a cutoff comfortably beyond the 60 second code lifetime enforced in
-// token_validator.go, since a code older than that can no longer be redeemed and so can
-// never acquire a refresh token legitimately.
+// Both share one cutoff, for different reasons. For the used class the age cutoff is not
+// an optimisation, it is required for correctness: the token endpoint marks a code used
+// (handler_token.go, MarkCodeAsUsed) and only afterwards inserts the refresh token that
+// references it, so for the duration of token generation a perfectly healthy code sits in
+// exactly the state that branch selects. Deleting it there makes the subsequent insert
+// fail on fk_refresh_tokens_code and the client gets a 500 instead of its tokens. Observed
+// in CI on postgres. For the revoked class the cutoff is simply the code lifetime: a code
+// is unredeemable 60 seconds after issuance (token_validator.go), so past that it can
+// never acquire a refresh token legitimately either. Callers should pass a cutoff
+// comfortably beyond that 60 seconds, which serves both.
+//
+// The subquery stays INSIDE the used branch rather than beside the cutoff, and that is
+// load bearing rather than formatting. ROPC refresh tokens carry code_id = NULL, and
+// `x NOT IN (…, NULL)` is UNKNOWN rather than TRUE, so the used branch already matches
+// nothing on any deployment that has issued one (#130 owns that). Since UNKNOWN OR TRUE
+// is TRUE, the revoked branch still reaps; hoisting the subquery out would make the whole
+// predicate UNKNOWN and this method would silently do nothing at all.
+//
+// The revoked branch needs no refresh-token term of its own because `used = false` is
+// stronger: MarkCodeAsUsed is the gate every redemption passes before a token is inserted,
+// and since #129 it refuses a revoked row outright, so an unused code has no descendants.
+// That term is also what keeps this sweep away from a live one, and the stake is higher
+// than losing a marker: fk_refresh_tokens_code is ON DELETE CASCADE, so reaching a used
+// code with a live refresh token would delete the very descendant the marker exists to
+// reject.
 func (d *CommonDatabase) DeleteUsedCodesWithoutRefreshTokens(tx *sql.Tx, createdBefore time.Time) error {
 	deleteBuilder := d.Flavor.NewDeleteBuilder()
 	deleteBuilder.DeleteFrom("codes")
 	deleteBuilder.Where(
-		deleteBuilder.And(
-			deleteBuilder.Equal("used", true),
-			deleteBuilder.LessThan("created_at", createdBefore),
-			deleteBuilder.NotIn("id",
-				d.Flavor.NewSelectBuilder().Select("code_id").From("refresh_tokens"),
+		deleteBuilder.LessThan("created_at", createdBefore),
+		deleteBuilder.Or(
+			deleteBuilder.And(
+				deleteBuilder.Equal("used", true),
+				deleteBuilder.NotIn("id",
+					d.Flavor.NewSelectBuilder().Select("code_id").From("refresh_tokens"),
+				),
+			),
+			deleteBuilder.And(
+				deleteBuilder.Equal("revoked", true),
+				deleteBuilder.Equal("used", false),
 			),
 		),
 	)

--- a/src/core/data/commondb/code.go
+++ b/src/core/data/commondb/code.go
@@ -76,11 +76,21 @@ func (d *CommonDatabase) UpdateCode(tx *sql.Tx, code *models.Code) error {
 }
 
 // MarkCodeAsUsed atomically transitions a code from unused to used via a
-// conditional UPDATE (`WHERE id = ? AND used = false`). It returns true only if
-// this call is the one that flipped the flag; a false return means the row was
-// already used, i.e. a concurrent request redeemed the same code first. Callers
-// treat that as authorization-code reuse. This compare-and-set closes the
-// double-spend race that a read-then-unconditional-update leaves open (#77).
+// conditional UPDATE (`WHERE id = ? AND used = false AND revoked = false`). It
+// returns true only if this call is the one that flipped the flag. This compare-and-set
+// closes the double-spend race that a read-then-unconditional-update leaves open (#77).
+//
+// A false return means **no row transitioned**, and the three ways that happens are not
+// distinguishable here: the row was already used, it was revoked, or it does not exist.
+// So false must not be read as authorization-code reuse. Reuse is detected in the
+// validator, which finds the already-used row and returns AuthCodeReusedError, and that
+// is what drives the containment cascade. The caller's job on false is to refuse
+// generically, which is what handler_token.go does.
+//
+// The revoked term is what makes session termination durable against a redemption
+// already in progress (#129). Validation and claiming are separate steps, so a code
+// validated a moment before its session was terminated would otherwise still be
+// claimed and its tokens issued.
 func (d *CommonDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) {
 
 	if codeId == 0 {
@@ -96,6 +106,7 @@ func (d *CommonDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) 
 	ub.Where(
 		ub.Equal("id", codeId),
 		ub.Equal("used", false),
+		ub.Equal("revoked", false),
 	)
 
 	query, args := ub.BuildWithFlavor(d.Flavor)
@@ -110,6 +121,52 @@ func (d *CommonDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) 
 	}
 
 	return rowsAffected == 1, nil
+}
+
+// RevokeCodesBySessionIdentifier marks every not-yet-revoked code of one session
+// revoked, and reports how many rows this call transitioned. It is the durable half
+// of ending a session (#129): the code is the grant record, and a rotated refresh
+// token inherits its parent's code_id, so marking the code marks every descendant of
+// that grant, including one inserted after this statement committed.
+//
+// The `revoked = false` term is what makes the count mean "rows this call
+// transitioned" on all four engines rather than "rows matched". MySQL reports changed
+// rows rather than matched rows, and the updated_at assignment would make an
+// already-revoked row count as changed, so without the term the same call would
+// report differently per engine and the audit event would overstate what it did.
+//
+// An empty session identifier is rejected rather than treated as a filter. Every
+// user_sessions row carries a UUID, so an empty value means a caller bug, and
+// matching on it would sweep unrelated codes.
+func (d *CommonDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+
+	if sessionIdentifier == "" {
+		return 0, errors.WithStack(errors.New("can't revoke codes with an empty session identifier"))
+	}
+
+	ub := sqlbuilder.NewUpdateBuilder()
+	ub.Update("codes")
+	ub.Set(
+		ub.Assign("revoked", true),
+		ub.Assign("updated_at", time.Now().UTC()),
+	)
+	ub.Where(
+		ub.Equal("session_identifier", sessionIdentifier),
+		ub.Equal("revoked", false),
+	)
+
+	query, args := ub.BuildWithFlavor(d.Flavor)
+	result, err := d.ExecSql(tx, query, args...)
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to revoke codes by session identifier")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to get rows affected when revoking codes by session identifier")
+	}
+
+	return rowsAffected, nil
 }
 
 func (d *CommonDatabase) getCodeCommon(tx *sql.Tx, selectBuilder *sqlbuilder.SelectBuilder,

--- a/src/core/data/commondb/code.go
+++ b/src/core/data/commondb/code.go
@@ -169,6 +169,72 @@ func (d *CommonDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdent
 	return rowsAffected, nil
 }
 
+// RevokeCodeIfSessionGone marks one code revoked, but only if the session it was issued
+// through no longer has a row, and reports whether it made that transition. It is the
+// compensating half of ending a session (#129 decision 12), and it exists because the
+// liveness read at /auth/issue and the insert that follows it are two statements: the read
+// can find the session alive, the termination can commit, and then the insert lands a code
+// bound to a session that is already gone and that RevokeCodesBySessionIdentifier could not
+// have marked, because the row did not exist when it ran.
+//
+// The two sweepers cover each other. A code committing before the termination's UPDATE reads
+// codes is marked by the termination; a code committing after it is marked here, because by
+// then the session is gone. Only a code landing between that UPDATE and its COMMIT escapes
+// both, since this statement still sees the session row. That residual is recorded in #129
+// and belongs to the same class as #131 and #132.
+//
+// The `revoked = false` term is what makes the bool mean "this call transitioned it" rather
+// than "matched a row". Unlike the count in RevokeCodesBySessionIdentifier, where the
+// difference is MySQL specific, here it is measured to matter on all four engines: the
+// updated_at assignment changes on every call, so an already-revoked row reports as affected
+// everywhere without the term. It is reachable rather than theoretical, since the
+// interleaving where the termination marked the code first is exactly the one where both
+// sweepers fire.
+//
+// An empty session identifier is rejected rather than used as a filter, and that guard is
+// load bearing: no user_sessions row carries an empty identifier, so NOT EXISTS over one is
+// trivially true and the statement would revoke whatever code it was handed.
+func (d *CommonDatabase) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+
+	if codeId == 0 {
+		return false, errors.WithStack(errors.New("can't revoke code with id 0"))
+	}
+
+	if sessionIdentifier == "" {
+		return false, errors.WithStack(errors.New("can't revoke a code with an empty session identifier"))
+	}
+
+	sessionExists := d.Flavor.NewSelectBuilder()
+	sessionExists.Select("1")
+	sessionExists.From("user_sessions")
+	sessionExists.Where(sessionExists.Equal("session_identifier", sessionIdentifier))
+
+	ub := sqlbuilder.NewUpdateBuilder()
+	ub.Update("codes")
+	ub.Set(
+		ub.Assign("revoked", true),
+		ub.Assign("updated_at", time.Now().UTC()),
+	)
+	ub.Where(
+		ub.Equal("id", codeId),
+		ub.Equal("revoked", false),
+		ub.NotExists(sessionExists),
+	)
+
+	query, args := ub.BuildWithFlavor(d.Flavor)
+	result, err := d.ExecSql(tx, query, args...)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to revoke code whose session is gone")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get rows affected when revoking a code whose session is gone")
+	}
+
+	return rowsAffected == 1, nil
+}
+
 func (d *CommonDatabase) getCodeCommon(tx *sql.Tx, selectBuilder *sqlbuilder.SelectBuilder,
 	codeStruct *sqlbuilder.Struct) (*models.Code, error) {
 

--- a/src/core/data/database.go
+++ b/src/core/data/database.go
@@ -88,6 +88,12 @@ type Database interface {
 	// every refresh token descended from it, present and future, because a rotated
 	// child inherits its parent's code_id (see #129).
 	RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error)
+	// RevokeCodeIfSessionGone marks one code revoked only if the session it was issued
+	// through no longer has a row, reporting whether it made the transition. It runs
+	// immediately after a code is inserted, so a code that lands after a termination
+	// swept the codes table is still marked (see #129). An empty session identifier is
+	// rejected: no session row carries one, so NOT EXISTS over it is trivially true.
+	RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error)
 	GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error)
 	GetCodeByCodeHash(tx *sql.Tx, codeHash string, used bool) (*models.Code, error)
 	DeleteCode(tx *sql.Tx, codeId int64) error

--- a/src/core/data/database.go
+++ b/src/core/data/database.go
@@ -99,12 +99,22 @@ type Database interface {
 	DeleteCode(tx *sql.Tx, codeId int64) error
 	CodeLoadClient(tx *sql.Tx, code *models.Code) error
 	CodeLoadUser(tx *sql.Tx, code *models.Code) error
-	// DeleteUsedCodesWithoutRefreshTokens reaps codes that were redeemed but never
-	// produced a refresh token. createdBefore is a required grace cutoff: only codes
-	// created before it are deleted. Without it the sweep races the token endpoint,
-	// which marks a code used and only then inserts the refresh token that references
-	// it, so a code mid-redemption matches the predicate and its deletion fails the
-	// insert with a foreign key violation.
+	// DeleteUsedCodesWithoutRefreshTokens reaps codes that can no longer produce
+	// anything: those redeemed but never followed by a refresh token, and those
+	// revoked while still unredeemed, which is what ending a session leaves behind
+	// when the grant it marked had not been exchanged yet (#129).
+	//
+	// createdBefore is a required grace cutoff shared by both, and only codes created
+	// before it are deleted. For the redeemed ones it is required for correctness:
+	// without it the sweep races the token endpoint, which marks a code used and only
+	// then inserts the refresh token that references it, so a code mid-redemption
+	// matches and its deletion fails the insert with a foreign key violation. For the
+	// revoked ones it is the 60 second code lifetime, past which the code can no
+	// longer be exchanged at all. A cutoff comfortably beyond 60 seconds serves both.
+	//
+	// A revoked code that WAS redeemed is deliberately out of reach here while any
+	// refresh token still references it, because that marker is what rejects the
+	// token.
 	DeleteUsedCodesWithoutRefreshTokens(tx *sql.Tx, createdBefore time.Time) error
 
 	CreateResource(tx *sql.Tx, resource *models.Resource) error

--- a/src/core/data/database.go
+++ b/src/core/data/database.go
@@ -76,8 +76,18 @@ type Database interface {
 	UpdateCode(tx *sql.Tx, code *models.Code) error
 	// MarkCodeAsUsed atomically flips a code from unused to used and reports
 	// whether this call is the one that made the transition. It is the guard
-	// against double-spending a single authorization code (see #77).
+	// against double-spending a single authorization code (see #77). A revoked
+	// code is never claimable, which is what stops a redemption that validated
+	// just before its session was terminated (see #129). False means no row
+	// transitioned, whether used, revoked or missing, and never specifically
+	// reuse: that is the validator's finding, not this one's.
 	MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error)
+	// RevokeCodesBySessionIdentifier marks every not-yet-revoked code of one session
+	// revoked and reports how many rows it transitioned. Ending a session durably
+	// cuts off the grants that session authorized, and marking the code reaches
+	// every refresh token descended from it, present and future, because a rotated
+	// child inherits its parent's code_id (see #129).
+	RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error)
 	GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error)
 	GetCodeByCodeHash(tx *sql.Tx, codeHash string, used bool) (*models.Code, error)
 	DeleteCode(tx *sql.Tx, codeId int64) error

--- a/src/core/data/mocks/database_mock.go
+++ b/src/core/data/mocks/database_mock.go
@@ -9720,6 +9720,72 @@ func (_c *Database_RefreshTokenLoadUser_Call) RunAndReturn(run func(tx *sql.Tx, 
 	return _c
 }
 
+// RevokeCodesBySessionIdentifier provides a mock function for the type Database
+func (_mock *Database) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+	ret := _mock.Called(tx, sessionIdentifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeCodesBySessionIdentifier")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, string) (int64, error)); ok {
+		return returnFunc(tx, sessionIdentifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, string) int64); ok {
+		r0 = returnFunc(tx, sessionIdentifier)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(*sql.Tx, string) error); ok {
+		r1 = returnFunc(tx, sessionIdentifier)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Database_RevokeCodesBySessionIdentifier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeCodesBySessionIdentifier'
+type Database_RevokeCodesBySessionIdentifier_Call struct {
+	*mock.Call
+}
+
+// RevokeCodesBySessionIdentifier is a helper method to define mock.On call
+//   - tx *sql.Tx
+//   - sessionIdentifier string
+func (_e *Database_Expecter) RevokeCodesBySessionIdentifier(tx any, sessionIdentifier any) *Database_RevokeCodesBySessionIdentifier_Call {
+	return &Database_RevokeCodesBySessionIdentifier_Call{Call: _e.mock.On("RevokeCodesBySessionIdentifier", tx, sessionIdentifier)}
+}
+
+func (_c *Database_RevokeCodesBySessionIdentifier_Call) Run(run func(tx *sql.Tx, sessionIdentifier string)) *Database_RevokeCodesBySessionIdentifier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *sql.Tx
+		if args[0] != nil {
+			arg0 = args[0].(*sql.Tx)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Database_RevokeCodesBySessionIdentifier_Call) Return(n int64, err error) *Database_RevokeCodesBySessionIdentifier_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *Database_RevokeCodesBySessionIdentifier_Call) RunAndReturn(run func(tx *sql.Tx, sessionIdentifier string) (int64, error)) *Database_RevokeCodesBySessionIdentifier_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RevokeRefreshTokenFamily provides a mock function for the type Database
 func (_mock *Database) RevokeRefreshTokenFamily(tx *sql.Tx, firstRefreshTokenJti string) (int64, error) {
 	ret := _mock.Called(tx, firstRefreshTokenJti)

--- a/src/core/data/mocks/database_mock.go
+++ b/src/core/data/mocks/database_mock.go
@@ -9720,6 +9720,78 @@ func (_c *Database_RefreshTokenLoadUser_Call) RunAndReturn(run func(tx *sql.Tx, 
 	return _c
 }
 
+// RevokeCodeIfSessionGone provides a mock function for the type Database
+func (_mock *Database) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+	ret := _mock.Called(tx, codeId, sessionIdentifier)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeCodeIfSessionGone")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, int64, string) (bool, error)); ok {
+		return returnFunc(tx, codeId, sessionIdentifier)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, int64, string) bool); ok {
+		r0 = returnFunc(tx, codeId, sessionIdentifier)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(*sql.Tx, int64, string) error); ok {
+		r1 = returnFunc(tx, codeId, sessionIdentifier)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Database_RevokeCodeIfSessionGone_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeCodeIfSessionGone'
+type Database_RevokeCodeIfSessionGone_Call struct {
+	*mock.Call
+}
+
+// RevokeCodeIfSessionGone is a helper method to define mock.On call
+//   - tx *sql.Tx
+//   - codeId int64
+//   - sessionIdentifier string
+func (_e *Database_Expecter) RevokeCodeIfSessionGone(tx any, codeId any, sessionIdentifier any) *Database_RevokeCodeIfSessionGone_Call {
+	return &Database_RevokeCodeIfSessionGone_Call{Call: _e.mock.On("RevokeCodeIfSessionGone", tx, codeId, sessionIdentifier)}
+}
+
+func (_c *Database_RevokeCodeIfSessionGone_Call) Run(run func(tx *sql.Tx, codeId int64, sessionIdentifier string)) *Database_RevokeCodeIfSessionGone_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *sql.Tx
+		if args[0] != nil {
+			arg0 = args[0].(*sql.Tx)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *Database_RevokeCodeIfSessionGone_Call) Return(b bool, err error) *Database_RevokeCodeIfSessionGone_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Database_RevokeCodeIfSessionGone_Call) RunAndReturn(run func(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error)) *Database_RevokeCodeIfSessionGone_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RevokeCodesBySessionIdentifier provides a mock function for the type Database
 func (_mock *Database) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
 	ret := _mock.Called(tx, sessionIdentifier)

--- a/src/core/data/mssqldb/code.go
+++ b/src/core/data/mssqldb/code.go
@@ -79,6 +79,10 @@ func (d *MsSQLDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdenti
 	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
 }
 
+func (d *MsSQLDatabase) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+	return d.CommonDB.RevokeCodeIfSessionGone(tx, codeId, sessionIdentifier)
+}
+
 func (d *MsSQLDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/mssqldb/code.go
+++ b/src/core/data/mssqldb/code.go
@@ -75,6 +75,10 @@ func (d *MsSQLDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) {
 	return d.CommonDB.MarkCodeAsUsed(tx, codeId)
 }
 
+func (d *MsSQLDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
+}
+
 func (d *MsSQLDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/mssqldb/migrations/000026_add_code_revoked.down.sql
+++ b/src/core/data/mssqldb/migrations/000026_add_code_revoked.down.sql
@@ -1,0 +1,3 @@
+-- Constraint before column: see the up migration for why.
+ALTER TABLE [codes] DROP CONSTRAINT [df_codes_revoked];
+ALTER TABLE [codes] DROP COLUMN [revoked];

--- a/src/core/data/mssqldb/migrations/000026_add_code_revoked.up.sql
+++ b/src/core/data/mssqldb/migrations/000026_add_code_revoked.up.sql
@@ -1,0 +1,9 @@
+-- Durable session termination (#129). See the sqlite migration of the same number
+-- for what the column means, why the marker sits on the code, and why existing rows
+-- land at false.
+--
+-- The default constraint is NAMED deliberately, for the reason 000024 gives: SQL
+-- Server refuses to drop a column while a default constraint depends on it, so the
+-- down migration has to drop the constraint by name first.
+ALTER TABLE [codes] ADD [revoked] BIT NOT NULL
+    CONSTRAINT [df_codes_revoked] DEFAULT 0;

--- a/src/core/data/mssqldb/schema.sql
+++ b/src/core/data/mssqldb/schema.sql
@@ -66,6 +66,7 @@ CREATE TABLE [codes] (
     [acr_level] NVARCHAR(128) NOT NULL,
     [auth_methods] NVARCHAR(64) NOT NULL,
     [used] BIT NOT NULL,
+    [revoked] BIT NOT NULL CONSTRAINT [df_codes_revoked] DEFAULT 0,
     [auth_state_generation] BIGINT NOT NULL CONSTRAINT [df_codes_auth_state_generation] DEFAULT 0,
     CONSTRAINT [PK_codes] PRIMARY KEY ([id])
 );

--- a/src/core/data/mysqldb/code.go
+++ b/src/core/data/mysqldb/code.go
@@ -19,6 +19,10 @@ func (d *MySQLDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) {
 	return d.CommonDB.MarkCodeAsUsed(tx, codeId)
 }
 
+func (d *MySQLDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
+}
+
 func (d *MySQLDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/mysqldb/code.go
+++ b/src/core/data/mysqldb/code.go
@@ -23,6 +23,10 @@ func (d *MySQLDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdenti
 	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
 }
 
+func (d *MySQLDatabase) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+	return d.CommonDB.RevokeCodeIfSessionGone(tx, codeId, sessionIdentifier)
+}
+
 func (d *MySQLDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/mysqldb/migrations/000026_add_code_revoked.down.sql
+++ b/src/core/data/mysqldb/migrations/000026_add_code_revoked.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `codes` DROP COLUMN `revoked`;

--- a/src/core/data/mysqldb/migrations/000026_add_code_revoked.up.sql
+++ b/src/core/data/mysqldb/migrations/000026_add_code_revoked.up.sql
@@ -1,0 +1,4 @@
+-- Durable session termination (#129). See the sqlite migration of the same number
+-- for what the column means, why the marker sits on the code, and why existing rows
+-- land at false.
+ALTER TABLE `codes` ADD COLUMN `revoked` tinyint(1) NOT NULL DEFAULT 0;

--- a/src/core/data/mysqldb/schema.sql
+++ b/src/core/data/mysqldb/schema.sql
@@ -348,6 +348,7 @@ CREATE TABLE `codes` (
   `acr_level` varchar(128) NOT NULL,
   `auth_methods` varchar(64) NOT NULL,
   `used` tinyint(1) NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT 0,
   `auth_state_generation` bigint NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_code_hash` (`code_hash`),

--- a/src/core/data/postgresdb/code.go
+++ b/src/core/data/postgresdb/code.go
@@ -74,6 +74,10 @@ func (d *PostgresDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIde
 	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
 }
 
+func (d *PostgresDatabase) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+	return d.CommonDB.RevokeCodeIfSessionGone(tx, codeId, sessionIdentifier)
+}
+
 func (d *PostgresDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/postgresdb/code.go
+++ b/src/core/data/postgresdb/code.go
@@ -70,6 +70,10 @@ func (d *PostgresDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error
 	return d.CommonDB.MarkCodeAsUsed(tx, codeId)
 }
 
+func (d *PostgresDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
+}
+
 func (d *PostgresDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/postgresdb/migrations/000026_add_code_revoked.down.sql
+++ b/src/core/data/postgresdb/migrations/000026_add_code_revoked.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE codes DROP COLUMN revoked;

--- a/src/core/data/postgresdb/migrations/000026_add_code_revoked.up.sql
+++ b/src/core/data/postgresdb/migrations/000026_add_code_revoked.up.sql
@@ -1,0 +1,4 @@
+-- Durable session termination (#129). See the sqlite migration of the same number
+-- for what the column means, why the marker sits on the code, and why existing rows
+-- land at false.
+ALTER TABLE codes ADD COLUMN revoked boolean NOT NULL DEFAULT false;

--- a/src/core/data/postgresdb/schema.sql
+++ b/src/core/data/postgresdb/schema.sql
@@ -136,6 +136,7 @@ CREATE TABLE public.codes (
     acr_level character varying(128) NOT NULL,
     auth_methods character varying(64) NOT NULL,
     used boolean NOT NULL,
+    revoked boolean DEFAULT false NOT NULL,
     auth_state_generation bigint DEFAULT 0 NOT NULL
 );
 

--- a/src/core/data/sqlitedb/code.go
+++ b/src/core/data/sqlitedb/code.go
@@ -23,6 +23,10 @@ func (d *SQLiteDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdent
 	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
 }
 
+func (d *SQLiteDatabase) RevokeCodeIfSessionGone(tx *sql.Tx, codeId int64, sessionIdentifier string) (bool, error) {
+	return d.CommonDB.RevokeCodeIfSessionGone(tx, codeId, sessionIdentifier)
+}
+
 func (d *SQLiteDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/sqlitedb/code.go
+++ b/src/core/data/sqlitedb/code.go
@@ -19,6 +19,10 @@ func (d *SQLiteDatabase) MarkCodeAsUsed(tx *sql.Tx, codeId int64) (bool, error) 
 	return d.CommonDB.MarkCodeAsUsed(tx, codeId)
 }
 
+func (d *SQLiteDatabase) RevokeCodesBySessionIdentifier(tx *sql.Tx, sessionIdentifier string) (int64, error) {
+	return d.CommonDB.RevokeCodesBySessionIdentifier(tx, sessionIdentifier)
+}
+
 func (d *SQLiteDatabase) GetCodeById(tx *sql.Tx, codeId int64) (*models.Code, error) {
 	return d.CommonDB.GetCodeById(tx, codeId)
 }

--- a/src/core/data/sqlitedb/migrations/000026_add_code_revoked.down.sql
+++ b/src/core/data/sqlitedb/migrations/000026_add_code_revoked.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE codes DROP COLUMN revoked;

--- a/src/core/data/sqlitedb/migrations/000026_add_code_revoked.up.sql
+++ b/src/core/data/sqlitedb/migrations/000026_add_code_revoked.up.sql
@@ -1,0 +1,18 @@
+-- Durable session termination (#129).
+--
+-- codes.revoked is the termination boundary. Ending a session at either explicit
+-- "end session" endpoint marks every code of that session revoked, and redemption
+-- then rejects a revoked code as well as any refresh token descended from one.
+--
+-- The marker sits on the code rather than on the session because a rotated refresh
+-- token inherits its parent's code_id, so marking the code marks every present and
+-- future descendant of that grant, including a child inserted after the termination
+-- committed. A sweep over the rows that happen to exist cannot do that.
+--
+-- Existing rows land at false, which is what keeps authorizations already in flight
+-- working across the deployment: no code issued before this migration was terminated.
+--
+-- No index is added. The termination sweep is keyed on session_identifier, which
+-- idx_codes_session_identifier (000024) already covers, and the reaper for unused
+-- revoked codes scans by created_at.
+ALTER TABLE codes ADD COLUMN revoked numeric NOT NULL DEFAULT 0;

--- a/src/core/data/sqlitedb/schema.sql
+++ b/src/core/data/sqlitedb/schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE codes (
   acr_level TEXT NOT NULL,
   auth_methods TEXT NOT NULL,
   used numeric NOT NULL,  
+  revoked numeric NOT NULL DEFAULT 0,
   auth_state_generation INTEGER NOT NULL DEFAULT 0,
   CONSTRAINT fk_codes_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE,
   CONSTRAINT fk_codes_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE

--- a/src/core/i18n/catalogs/active.en.toml
+++ b/src/core/i18n/catalogs/active.en.toml
@@ -448,6 +448,7 @@
 "adminconsole.account.sessions.modal_confirm_title" = "Are you sure?"
 "adminconsole.account.sessions.modal_confirm_body_prefix" = "Would you like to end the session on device <span class='text-accent'>"
 "adminconsole.account.sessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.account.sessions.modal_revocation_note" = " <br /><br />Applications you authorized from this session, including ones that keep working in the background, will need to sign in again."
 "adminconsole.account.sessions.modal_current_warning" = " <br /><br />Be aware that ending your current session will result in an immediate logout."
 
 # === Adminconsole — admin clients =============================================
@@ -542,6 +543,7 @@
 "adminconsole.admin_clients.usersessions.modal_confirm_title" = "Are you sure?"
 "adminconsole.admin_clients.usersessions.modal_confirm_body_prefix" = "Do you want to end the session for user <span class='text-accent'>"
 "adminconsole.admin_clients.usersessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.admin_clients.usersessions.modal_revocation_note" = " <br /><br />Applications the user authorized from this session, including ones that keep working in the background, will need to sign in again."
 "adminconsole.admin_clients.usersessions.modal_current_warning" = " <br /><br />Be aware that ending your current session will result in an immediate logout."
 
 # --- Common modal strings used across client management pages --------------
@@ -878,6 +880,7 @@
 "adminconsole.admin_users.sessions.modal_confirm_title" = "Are you sure?"
 "adminconsole.admin_users.sessions.modal_confirm_body_prefix" = "Would you like to end the session on device <span class='text-accent'>"
 "adminconsole.admin_users.sessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.admin_users.sessions.modal_revocation_note" = " <br /><br />Applications the user authorized from this session, including ones that keep working in the background, will need to sign in again."
 "adminconsole.admin_users.sessions.modal_confirm_current_warning" = " <br /><br />Be aware that ending your current session will result in an immediate logout."
 "adminconsole.admin_users.sessions.col_device" = "Device"
 "adminconsole.admin_users.sessions.col_clients" = "Clients"

--- a/src/core/i18n/catalogs/active.pt-BR.toml
+++ b/src/core/i18n/catalogs/active.pt-BR.toml
@@ -446,6 +446,7 @@
 "adminconsole.account.sessions.modal_confirm_title" = "Tem certeza?"
 "adminconsole.account.sessions.modal_confirm_body_prefix" = "Deseja encerrar a sessão no dispositivo <span class='text-accent'>"
 "adminconsole.account.sessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.account.sessions.modal_revocation_note" = " <br /><br />Os aplicativos que você autorizou nesta sessão, incluindo os que continuam funcionando em segundo plano, precisarão se autenticar novamente."
 "adminconsole.account.sessions.modal_current_warning" = " <br /><br />Atenção: encerrar a sessão atual provocará logout imediato."
 
 # === Adminconsole — clientes admin ===========================================
@@ -529,6 +530,7 @@
 "adminconsole.admin_clients.usersessions.modal_confirm_title" = "Tem certeza?"
 "adminconsole.admin_clients.usersessions.modal_confirm_body_prefix" = "Deseja encerrar a sessão do usuário <span class='text-accent'>"
 "adminconsole.admin_clients.usersessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.admin_clients.usersessions.modal_revocation_note" = " <br /><br />Os aplicativos que o usuário autorizou nesta sessão, incluindo os que continuam funcionando em segundo plano, precisarão se autenticar novamente."
 "adminconsole.admin_clients.usersessions.modal_current_warning" = " <br /><br />Atenção: encerrar a sessão atual provocará logout imediato."
 
 "adminconsole.admin_clients.modal.are_you_sure" = "Tem certeza?"
@@ -845,6 +847,7 @@
 "adminconsole.admin_users.sessions.modal_confirm_title" = "Tem certeza?"
 "adminconsole.admin_users.sessions.modal_confirm_body_prefix" = "Deseja encerrar a sessão no dispositivo <span class='text-accent'>"
 "adminconsole.admin_users.sessions.modal_confirm_body_suffix" = "</span>?"
+"adminconsole.admin_users.sessions.modal_revocation_note" = " <br /><br />Os aplicativos que o usuário autorizou nesta sessão, incluindo os que continuam funcionando em segundo plano, precisarão se autenticar novamente."
 "adminconsole.admin_users.sessions.modal_confirm_current_warning" = " <br /><br />Atenção: encerrar a sessão atual provocará logout imediato."
 "adminconsole.admin_users.sessions.col_device" = "Dispositivo"
 "adminconsole.admin_users.sessions.col_clients" = "Clientes"

--- a/src/core/models/code.go
+++ b/src/core/models/code.go
@@ -29,6 +29,11 @@ type Code struct {
 	AcrLevel            string         `db:"acr_level"`
 	AuthMethods         string         `db:"auth_methods"`
 	Used                bool           `db:"used"`
+	// Revoked records that the session this code was issued through was explicitly
+	// terminated. Redemption rejects a revoked code, and so does any refresh token
+	// descended from it, since a rotated child inherits its parent's CodeId. Tagged
+	// dont-update so an ordinary full-row UpdateCode cannot regress it (#129).
+	Revoked bool `db:"revoked" fieldtag:"dont-update"`
 	// AuthStateGeneration records the user's generation when this code was issued,
 	// inherited from the AuthContext. Redemption rejects a mismatch against the
 	// user's current value. Tagged dont-update so an ordinary full-row UpdateCode

--- a/src/core/oauth/auth_context.go
+++ b/src/core/oauth/auth_context.go
@@ -47,6 +47,19 @@ type AuthContext struct {
 	Prompt                        string     // Normalized prompt values (space-delimited, deduplicated)
 	AuthenticatedAt               *time.Time // Optional: override for auth_time in code issuance (used by prompt=none)
 	IdTokenHintSub                string     // sub claim from id_token_hint (empty if no hint provided)
+	// Level1AuthCompleted records that level 1 authentication happened in THIS ceremony,
+	// as opposed to being inherited from a session the ceremony reused. It is written only
+	// where level 1 is performed, today only handler_auth_pwd, and read by
+	// handler_auth_completed to decide whether a ceremony with no valid session may create
+	// one (#129 decision 15).
+	//
+	// AuthenticatedAt cannot answer that question, which is why this field exists: the OTP
+	// handler sets it too, so a ceremony that stepped up to level 2 by reusing a session
+	// and never saw the password form satisfies it on OTP alone. Any future level 1 method
+	// must set this, or a ceremony using it is sent back to /auth/level1 when its session
+	// is gone. Absent from an older cookie it unmarshals as false, which is the safe
+	// direction.
+	Level1AuthCompleted bool
 	// AuthStateGeneration is the user's authentication generation as it stood when this
 	// ceremony authenticated. Captured from the user at password verification, or
 	// inherited from the reused session on the SSO path, and NEVER read from the current

--- a/src/core/validators/token_validator.go
+++ b/src/core/validators/token_validator.go
@@ -262,6 +262,26 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 			}
 		}
 
+		// The termination boundary (#129 decision 4). Ending a session marks every code
+		// that session authorized, so a code marked here belongs to a grant that was
+		// explicitly cut off.
+		//
+		// Deliberately NOT up in the !wasReused block with the user-enabled, generation
+		// and expiry checks, even though it reads like one of them. That block runs before
+		// client authentication and before PKCE, so a presenter holding a stolen code
+		// learns from it whether the account's state moved without proving anything, which
+		// is the disclosure #137 exists to close. Adding a new member to that class would
+		// be going backwards.
+		//
+		// It also sits AFTER the wasReused return above, so #77's containment cascade is
+		// not pre-empted. Reuse is the stronger signal and already revokes everything a
+		// revoked-code rejection would have refused, and the reuse error carries the code
+		// entity that drives revokeAndAuditAuthCodeReuse.
+		if codeEntity.Revoked {
+			return nil, customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant",
+				"Code is invalid.", http.StatusBadRequest)
+		}
+
 		return &ValidateTokenRequestResult{
 			CodeEntity: codeEntity,
 		}, nil
@@ -503,6 +523,31 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 				"The refresh token is invalid because it does not belong to the client.", http.StatusBadRequest)
 		}
 
+		// One message for both ways a grant's session can stop backing it, so the two
+		// cannot drift into two spellings of one fact. Declared here rather than inside the
+		// Refresh branch because the revoked check below needs it too.
+		const invalidTokenMessage = "The refresh token is invalid because the associated session has expired or been terminated."
+
+		// The termination boundary (#129 decision 4), the half that closes gap 2 for free.
+		// A rotated child inherits its parent's code_id, so a marked code rejects every
+		// descendant of that grant, including one inserted after the termination committed:
+		// the child is born already rejected rather than caught by a sweep.
+		//
+		// This is what reaches an OFFLINE token, which the typ switch below never can. Its
+		// Offline branch checks only the max lifetime and deliberately does not consult the
+		// session, because a session merely expiring must leave an offline grant working
+		// (decision 2). Termination has to be a positive fact for exactly that reason.
+		//
+		// ROPC is excluded because it has no grant origin to terminate: code_id is NULL,
+		// there is no session, and refreshToken.Code is the zero value on that path.
+		//
+		// Placed after the ownership check above so an unauthenticated presenter of someone
+		// else's token cannot learn from it that a session was ended (decision 7).
+		if !isROPCToken && refreshToken.Code.Revoked {
+			return nil, customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant",
+				invalidTokenMessage, http.StatusBadRequest)
+		}
+
 		refreshTokenType := refreshTokenInfo.GetStringClaim("typ")
 		switch refreshTokenType {
 		case "Refresh":
@@ -513,7 +558,6 @@ func (val *TokenValidator) ValidateTokenRequest(ctx context.Context, input *Vali
 			if err != nil {
 				return nil, err
 			}
-			const invalidTokenMessage = "The refresh token is invalid because the associated session has expired or been terminated."
 			if userSession == nil {
 				return nil, customerrors.NewErrorDetailWithHttpStatusCode("invalid_grant", invalidTokenMessage,
 					http.StatusBadRequest)

--- a/src/core/validators/token_validator_test.go
+++ b/src/core/validators/token_validator_test.go
@@ -5166,3 +5166,449 @@ func TestValidateTokenRequest_RefreshToken_ExpiryPrecedesTheLookup(t *testing.T)
 	mockDB.AssertExpectations(t)
 	mockTokenParser.AssertExpectations(t)
 }
+
+// TestValidateTokenRequest_RevokedCode covers the termination boundary at both redemption
+// sites (#129 decisions 4 and 7): a code marked revoked cannot be redeemed, and neither can
+// a refresh token descended from one.
+//
+// Half of these subtests are about ORDERING rather than rejection, and they are the only
+// testable content of decision 7. The revoked check deliberately sits apart from the
+// user-enabled, generation and expiry checks in the same function, behind client
+// authentication and PKCE, because that earlier block discloses account state to an
+// unauthenticated presenter of a stolen code and #137 exists to close it. Nothing else would
+// notice the check drifting up into that block: every rejection row would still pass, since
+// the request is still refused, just earlier and to a caller who has proved nothing. Each
+// ordering row therefore varies exactly ONE thing from an otherwise-valid revoked request and
+// names the gate that must answer instead.
+//
+// Two positive controls, one per grant type, because a check that rejected everything would
+// satisfy every negative row here.
+func TestValidateTokenRequest_RevokedCode(t *testing.T) {
+	newValidator := func(t *testing.T) (*TokenValidator, *mocks_data.Database, *mocks_oauth.TokenParser) {
+		mockDB := mocks_data.NewDatabase(t)
+		mockTokenParser := mocks_oauth.NewTokenParser(t)
+		mockPermissionChecker := mocks_user.NewPermissionChecker(t)
+		return NewTokenValidator(mockDB, mockTokenParser, mockPermissionChecker), mockDB, mockTokenParser
+	}
+
+	t.Run("authorization code redemption", func(t *testing.T) {
+		t.Run("a revoked code is refused", func(t *testing.T) {
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: true,
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI: "https://example.com/cb",
+				Scope:       "openid",
+				CreatedAt:   sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Revoked:     true,
+				Client:      *client,
+				User:        models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:   "authorization_code",
+				ClientId:    "test_client",
+				Code:        "the-code",
+				RedirectURI: "https://example.com/cb",
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				assert.Equal(t, "invalid_grant", customErr.GetCode())
+				// Generic on purpose: the message must not tell a caller that the session was
+				// terminated, which is the disclosure position the neighbouring checks take.
+				assert.Equal(t, "Code is invalid.", customErr.GetDescription())
+			}
+		})
+
+		t.Run("the same code unrevoked is redeemable", func(t *testing.T) {
+			// The positive control. Varies exactly one field from the row above.
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: true,
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI: "https://example.com/cb",
+				Scope:       "openid",
+				CreatedAt:   sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Revoked:     false,
+				Client:      *client,
+				User:        models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:   "authorization_code",
+				ClientId:    "test_client",
+				Code:        "the-code",
+				RedirectURI: "https://example.com/cb",
+			})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+
+		t.Run("ordering: a wrong PKCE verifier answers before the revoked check", func(t *testing.T) {
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: true,
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI:   "https://example.com/cb",
+				Scope:         "openid",
+				CreatedAt:     sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Revoked:       true,
+				CodeChallenge: sql.NullString{String: oauth.GeneratePKCECodeChallenge("the_correct_verifier_long_enough_x"), Valid: true},
+				Client:        *client,
+				User:          models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:    "authorization_code",
+				ClientId:     "test_client",
+				Code:         "the-code",
+				RedirectURI:  "https://example.com/cb",
+				CodeVerifier: "the_wrong_verifier_long_enough_yyy",
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				// PKCE, not the revoked check. If this reads "Code is invalid." the revoked
+				// check has moved ahead of PKCE, which is what decision 7 forbids.
+				assert.Equal(t, "Invalid code_verifier (PKCE).", customErr.GetDescription())
+			}
+		})
+
+		t.Run("ordering: a missing client secret answers before the revoked check", func(t *testing.T) {
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			clientSecretEncrypted, err := encryption.EncryptData("the_client_secret")
+			require.NoError(t, err)
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: false,
+				ClientSecretEncrypted: []byte(clientSecretEncrypted),
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI: "https://example.com/cb",
+				Scope:       "openid",
+				CreatedAt:   sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Revoked:     true,
+				Client:      *client,
+				User:        models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:   "authorization_code",
+				ClientId:    "test_client",
+				Code:        "the-code",
+				RedirectURI: "https://example.com/cb",
+				// No ClientSecret, on a confidential client.
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				// Client authentication, not the revoked check. An unauthenticated presenter
+				// of a stolen code must not learn that its session was terminated.
+				assert.Equal(t, "invalid_client", customErr.GetCode())
+			}
+		})
+
+		t.Run("ordering: a wrong client secret answers before the revoked check", func(t *testing.T) {
+			// KEEP THIS ROW. It is the one that actually pins decision 7 on the confidential
+			// path, and the row above is the benign member of its class: a MISSING secret is
+			// refused by a length check that runs before decryption, so that row stays green
+			// if the revoked check is moved to just after it and before the constant-time
+			// comparison. That placement would hand a termination-state oracle to anyone
+			// holding a stolen code and any nonempty string, which is exactly what decision 7
+			// exists to prevent. A PRESENT but wrong secret is the only input that fails if
+			// the check moves anywhere ahead of authentication completing.
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			clientSecretEncrypted, err := encryption.EncryptData("the_real_client_secret")
+			require.NoError(t, err)
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: false,
+				ClientSecretEncrypted: []byte(clientSecretEncrypted),
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI: "https://example.com/cb",
+				Scope:       "openid",
+				CreatedAt:   sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Revoked:     true,
+				Client:      *client,
+				User:        models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:    "authorization_code",
+				ClientId:     "test_client",
+				Code:         "the-code",
+				RedirectURI:  "https://example.com/cb",
+				ClientSecret: "not_the_real_client_secret",
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				assert.Equal(t, "invalid_client", customErr.GetCode())
+				assert.Equal(t, "Client authentication failed. Please review your client_secret.",
+					customErr.GetDescription())
+			}
+		})
+
+		t.Run("ordering: reuse answers before the revoked check", func(t *testing.T) {
+			// A revoked code that was ALSO already used. Reuse must win, because its error
+			// carries the code entity that drives #77's containment cascade, and a
+			// revoked-code rejection landing first would suppress it.
+			validator, mockDB, _ := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: true,
+			}
+			code := &models.Code{
+				Id: 5, ClientId: 1, UserId: 7,
+				RedirectURI: "https://example.com/cb",
+				Scope:       "openid",
+				CreatedAt:   sql.NullTime{Time: time.Now().UTC(), Valid: true},
+				Used:        true,
+				Revoked:     true,
+				Client:      *client,
+				User:        models.User{Id: 7, Enabled: true},
+			}
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			// Not among unused codes, then found among used ones: that is the reuse path.
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, false).Return(nil, nil)
+			mockDB.On("GetCodeByCodeHash", mock.Anything, mock.Anything, true).Return(code, nil)
+			mockDB.On("CodeLoadClient", mock.Anything, code).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:   "authorization_code",
+				ClientId:    "test_client",
+				Code:        "the-code",
+				RedirectURI: "https://example.com/cb",
+			})
+
+			assert.Nil(t, result)
+			reuseErr, ok := err.(*customerrors.AuthCodeReusedError)
+			if assert.True(t, ok, "expected *customerrors.AuthCodeReusedError, got %T: %v", err, err) {
+				assert.Equal(t, code, reuseErr.Code,
+					"the reuse error must carry the code entity, or the containment cascade has nothing to act on")
+			}
+		})
+	})
+
+	t.Run("auth code refresh", func(t *testing.T) {
+		// Fixtures shared by the three rows below. An OFFLINE token deliberately: the typ
+		// switch's Offline branch never consults the session, so this is the case the
+		// pre-existing checks cannot reach and the marker exists for.
+		build := func(revoked bool, clientIdOnCode int64) (*models.Client, *models.RefreshToken, models.User) {
+			client := &models.Client{
+				Id: 1, ClientIdentifier: "test_client", Enabled: true,
+				AuthorizationCodeEnabled: true, IsPublic: true,
+			}
+			user := models.User{Id: 7, Enabled: true}
+			refreshToken := &models.RefreshToken{
+				RefreshTokenJti:   "the-jti",
+				CodeId:            sql.NullInt64{Int64: 5, Valid: true},
+				SessionIdentifier: "",
+				Code: models.Code{
+					Id: 5, ClientId: clientIdOnCode, UserId: 7, Scope: "openid offline_access",
+					SessionIdentifier: "sid-1",
+					Revoked:           revoked,
+					User:              user,
+				},
+			}
+			return client, refreshToken, user
+		}
+
+		offlineClaims := func() *oauth.JwtToken {
+			return &oauth.JwtToken{Claims: jwt.MapClaims{
+				"jti": "the-jti", "typ": "Offline", "sub": "user_subject",
+				"offline_access_max_lifetime": float64(time.Now().UTC().Add(24 * time.Hour).Unix()),
+			}}
+		}
+
+		t.Run("an offline token whose code was revoked is refused", func(t *testing.T) {
+			validator, mockDB, mockTokenParser := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+			client, refreshToken, _ := build(true, 1)
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockTokenParser.On("DecodeAndValidateTokenString", "the-refresh-token", (*rsa.PublicKey)(nil), true).
+				Return(offlineClaims(), nil)
+			mockDB.On("GetRefreshTokenByJti", mock.Anything, "the-jti").Return(refreshToken, nil)
+			mockDB.On("RefreshTokenLoadCode", mock.Anything, refreshToken).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, &refreshToken.Code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:    "refresh_token",
+				ClientId:     "test_client",
+				RefreshToken: "the-refresh-token",
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				assert.Equal(t, "invalid_grant", customErr.GetCode())
+			}
+		})
+
+		t.Run("the same token with an unrevoked code still refreshes", func(t *testing.T) {
+			// The positive control, and the row that proves the marker rather than the
+			// Offline branch is what refused above: an offline grant is designed to outlive
+			// its browser session, so this must keep working (decision 2).
+			validator, mockDB, mockTokenParser := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+			client, refreshToken, user := build(false, 1)
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockTokenParser.On("DecodeAndValidateTokenString", "the-refresh-token", (*rsa.PublicKey)(nil), true).
+				Return(offlineClaims(), nil)
+			mockDB.On("GetRefreshTokenByJti", mock.Anything, "the-jti").Return(refreshToken, nil)
+			mockDB.On("RefreshTokenLoadCode", mock.Anything, refreshToken).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, &refreshToken.Code).Return(nil)
+			mockDB.On("GetUserBySubject", mock.Anything, "user_subject").Return(&user, nil)
+			// An Offline refresh always re-checks consent, whatever the client's
+			// ConsentRequired says, so the accepted path needs a live consent row covering
+			// the scopes. None of the rejection rows reach this far.
+			mockDB.On("GetConsentByUserIdAndClientId", mock.Anything, int64(7), int64(1)).
+				Return(&models.UserConsent{UserId: 7, ClientId: 1, Scope: "openid offline_access"}, nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:    "refresh_token",
+				ClientId:     "test_client",
+				RefreshToken: "the-refresh-token",
+			})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+		})
+
+		t.Run("ordering: the wrong client answers before the revoked check", func(t *testing.T) {
+			// The code belongs to client 2 while client 1 presents the token. Ownership must
+			// answer, so a client that does not hold the grant cannot learn from this
+			// endpoint that somebody's session was terminated.
+			validator, mockDB, mockTokenParser := newValidator(t)
+			ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+			client, refreshToken, _ := build(true, 2)
+
+			mockDB.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+			mockTokenParser.On("DecodeAndValidateTokenString", "the-refresh-token", (*rsa.PublicKey)(nil), true).
+				Return(offlineClaims(), nil)
+			mockDB.On("GetRefreshTokenByJti", mock.Anything, "the-jti").Return(refreshToken, nil)
+			mockDB.On("RefreshTokenLoadCode", mock.Anything, refreshToken).Return(nil)
+			mockDB.On("CodeLoadUser", mock.Anything, &refreshToken.Code).Return(nil)
+
+			result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+				GrantType:    "refresh_token",
+				ClientId:     "test_client",
+				RefreshToken: "the-refresh-token",
+			})
+
+			assert.Nil(t, result)
+			customErr, ok := err.(*customerrors.ErrorDetail)
+			if assert.True(t, ok, "expected *customerrors.ErrorDetail, got %T: %v", err, err) {
+				assert.Equal(t, "invalid_request", customErr.GetCode())
+				assert.Equal(t, "The refresh token is invalid because it does not belong to the client.",
+					customErr.GetDescription())
+			}
+		})
+	})
+
+	t.Run("ROPC refresh is unaffected", func(t *testing.T) {
+		// A ROPC token has code_id NULL and no session, so there is no grant origin to
+		// terminate and refreshToken.Code is the zero value. Reading Revoked off it would be
+		// meaningless, and the !isROPCToken guard is what keeps this path out of the check.
+		// Its own zero value is false, so this row would pass with the guard deleted; it is
+		// here to pin the branch as deliberate and to fail if the guard is ever inverted.
+		validator, mockDB, mockTokenParser := newValidator(t)
+		ctx := context.WithValue(context.Background(), constants.ContextKeySettings, &models.Settings{})
+
+		client := &models.Client{
+			Id: 1, ClientIdentifier: "ropc_client", Enabled: true,
+			AuthorizationCodeEnabled: true, IsPublic: true,
+		}
+		user := models.User{Id: 7, Enabled: true}
+		refreshToken := &models.RefreshToken{
+			RefreshTokenJti: "ropc_jti",
+			CodeId:          sql.NullInt64{Valid: false},
+			UserId:          sql.NullInt64{Int64: 7, Valid: true},
+			ClientId:        sql.NullInt64{Int64: 1, Valid: true},
+			Scope:           "openid",
+			User:            user,
+			Client:          *client,
+		}
+
+		mockDB.On("GetClientByClientIdentifier", mock.Anything, "ropc_client").Return(client, nil)
+		mockTokenParser.On("DecodeAndValidateTokenString", "ropc_refresh_token", (*rsa.PublicKey)(nil), true).
+			Return(&oauth.JwtToken{Claims: jwt.MapClaims{
+				"jti": "ropc_jti", "typ": "Offline", "sub": "ropc_user_subject",
+				"offline_access_max_lifetime": float64(time.Now().UTC().Add(24 * time.Hour).Unix()),
+			}}, nil)
+		mockDB.On("GetRefreshTokenByJti", mock.Anything, "ropc_jti").Return(refreshToken, nil)
+		mockDB.On("RefreshTokenLoadUser", mock.Anything, refreshToken).Return(nil)
+		mockDB.On("RefreshTokenLoadClient", mock.Anything, refreshToken).Return(nil)
+		mockDB.On("GetUserBySubject", mock.Anything, "ropc_user_subject").Return(&user, nil)
+
+		result, err := validator.ValidateTokenRequest(ctx, &ValidateTokenRequestInput{
+			GrantType:    "refresh_token",
+			ClientId:     "ropc_client",
+			RefreshToken: "ropc_refresh_token",
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+}


### PR DESCRIPTION
Closes #129. Built by `/leo-run` from the sealed agreement, eight stages, each reviewed by a second
agent before it was committed.

**Issue:** #129, ending a user session does not durably cut off access (`bug`, `security`)
**Agreement:** written and reviewed alongside this change and deliberately not tracked in the repository. The decisions that constrain future edits live in the code comments beside the code they constrain.
**Read first:** [the deferred decisions comment](https://github.com/leodip/goiabada/pull/138#issuecomment-5196348942)
(nothing was deferred, and it says what came to you instead), then
[the follow-ups comment](https://github.com/leodip/goiabada/pull/138#issuecomment-5196349557)
(four drafted issues, since reviewed and filed as #139, #140, #141 and a comment on #109, see
"Follow-ups filed" at the bottom).

## What the change does

Ending a session at either explicit "end session" endpoint becomes a security action with a durable
consequence. Three gaps closed, all of which failed open, meaning they preserved access somebody
believed they had removed:

1. **An offline grant outlived its session.** `codes.revoked` now carries the boundary: terminating a
   session marks every authorization code that session issued, in one transaction with the sid-scoped
   refresh-token sweep and the session delete. Redemption rejects a revoked code, and so does any
   refresh token descended from one.
2. **A refresh racing the termination inserted a surviving replacement.** Closed structurally rather
   than by serializing anything: a rotated refresh token inherits its parent's `code_id`, so marking the
   code marks every present and future descendant. The racing child is born already rejected, because
   the fact predates its existence.
3. **An in-flight ceremony recreated the session it rode.** `/auth/completed` now requires that this
   ceremony performed level 1 authentication before it mints a session, and `/auth/issue` refuses to
   bind a code to a session that no longer resolves, with a compensating `UPDATE` covering the insert
   that lands just after a termination.

A session **expiring** still leaves an offline grant working, which is what `offline_access` is for. A
session **explicitly ended** does not. That distinction is the one the whole design rests on, and the
documentation now draws it.

The 16 decisions behind this, including the alternatives that lost and why, are in section 3 of the
agreement. Section 4 states the property that makes it safe; section 1 has the three gaps in full.

## What landed, stage by stage

| Stage | What landed | Commit |
|---|---|---|
| 1 | `codes.revoked` and its sweep: migration 000026 on four engines, `RevokeCodesBySessionIdentifier`, and `AND revoked = false` on the code claim. Inert by construction, nothing reads it yet | `066d289` |
| 2 | The two rejections in `ValidateTokenRequest`, at redemption and at refresh, placed behind client authentication and PKCE per decision 7 | `266615b` |
| 3 | `TerminateUserSessionTx`, the three writes in one transaction, plus the `terminated_user_session` audit event. Still uncalled | `d19d8b5` |
| 4 | **The behaviour changes here.** Both endpoints terminate, both audit events fire after the commit, and everything that describes the action lands in the same commit: three confirmation modals in both locales, and four documentation pages | `f964e54` |
| 5 | The `/auth/completed` gate, on a dedicated level 1 proof rather than on `AuthenticatedAt`, per decision 15 | `5a7c280` |
| 6 | The `/auth/issue` liveness check, the compensating revoke, and `login_required` rather than a login form for a `prompt=none` ceremony whose session ended, per decision 16 | `422dd8a` |
| 7 | Retention: unused revoked codes are reaped, so the new state cannot accumulate | `803f593` |
| 8 | Gap 2's evidence, two integration tests and no production line | `682d51e` |

26 commits over 60 files, one code commit per stage plus the agreement following it. The agreement's
section 7 is the run log: what landed, which tiers ran, every deviation, every review finding with its
evidence and disposition, and the mutations measured at each gate.

## Tests

**Full suite at the close, every tier, all four engines, green.** `where.sh test --type all`, exit 0,
zero `FAIL` and zero panics, "All tests completed successfully". Modules across all three Go modules;
the data tier on mysql, postgres, mssql and sqlite; the integration tier on the same four (64.8s, 74.3s,
99.2s, 43.2s), 9022 passing test lines in total.

Per tier, this change adds: migration and data-layer coverage on four engines for both new methods and
for the marker's `dont-update` protection; unit coverage for both validator rejections including the
ordering rows that pin them behind client authentication; unit coverage for the termination helper's
transaction threading and its zero result on every failure path; two new handler test files that did not
exist before, covering the audit payloads and that a 403 terminates nothing; and integration coverage of
both endpoints, the three ceremonies that must not recreate a session, the `prompt=none` refusal, and
gap 2 both reconstructed and raced.

**The race reaches the window rather than approaching it.** In the closing run every engine produced one
replacement token alongside the termination, and on mssql and sqlite that replacement was still live in
storage when it was presented, so the sweep never saw it and the code marker was the only thing between
it and a working grant. On mysql and postgres it landed before the sweep. Both are legitimate and
neither is asserted, so the test logs which happened.

**Mutation-tested at every gate**, 16 in all, each applied to the real code and reverted. The two for
stage 8 are the argument for that stage existing: with the marker's read removed, and separately with
its write removed, stage 4's headline endpoint case and stage 6's consent ceremony both stayed green,
and only stage 8's two tests failed, answering a terminated grant with a working access token.

## Deviations from the plan

Recorded per stage in section 7, and none changed what the change does. The load-bearing ones:

- **Stage 2** shipped ten test rows rather than nine. Review round 1 showed the planned missing-secret
  row could not pin what it claimed, because a missing secret is refused by an earlier guard, so a
  present-but-wrong secret row was added. Demonstrated by relocating the check and watching the new row
  fail while the old one passed.
- **Stage 3** corrected a claim the implementation session had made in the mailbox: four failure rows
  catch a partially populated result, not one. The prediction was left in place and the measurement
  recorded beside it, because editing the prediction would erase the evidence that it was wrong.
- **Stage 5** stopped the run and escalated decision 15: the gate the seal specified was satisfied by
  OTP alone. Rebuilt on a dedicated level 1 proof after you answered.
- **Stage 6** stopped the run and escalated decision 16 (`prompt=none` cannot be restarted into a login
  form), and its round 2 found the new branch clearing the auth context *after* committing the client
  response, so the clear reached nothing. Fixed inside the stage, with assertions that read the
  committed response rather than a mock expectation. That defect turned out to exist at seven
  pre-existing sites, now #141.
- **Stage 8** staggers its race by 5 milliseconds. Released at the same instant, sqlite consistently
  produced no replacement at all, so the interesting assertions never ran. Every assertion holds at any
  value including zero, which is what keeps it a probability knob rather than a synchronization point.

## Known limits, stated rather than implied

- **An offline grant's access token stays valid until it expires**, 5 minutes by default, because it
  carries no `sid` for the session middleware to check and termination must not move the user's
  generation. Decision 11, and the documentation says so rather than letting the credential-change
  sentence be read as covering this case too.
- **One interleaving is still open**, a code insert landing between a termination's `UPDATE` and its
  `COMMIT`. Decision 12 accepted it, and it is now #139: closing it needs the same portable
  order-a-write-against-a-sweep primitive that #131 and #132 want.
- **RP-initiated logout is unchanged**, deliberately, and now pinned by tests. Decision 3, with
  decision 13 leaving the interactive path's own defect to #109, where it is now recorded as a
  [comment](https://github.com/leodip/goiabada/issues/109#issuecomment-5197711587).

## Follow-ups filed

The four drafted follow-ups were re-verified against the code after the run closed, then filed. Two
bodies changed on the way in, and both changes narrow a claim rather than widen it.

| Drafted as | Filed as | Change on the way in |
|---|---|---|
| 1, the `UPDATE`/`COMMIT` window | **#139** (`bug`, `security`, `go`) | Body now says the window is **not uniform across engines**. It is open on PostgreSQL; on MySQL, SQL Server and SQLite it is closed incidentally, by InnoDB next-key locks over `idx_codes_session_identifier`, by a blocking READ COMMITTED read, and by writer serialization respectively. Reframed as "correctness rests on three engines' defaults by accident", which is the standard #132's criterion 4 already sets. Without this a reader reproducing on SQLite would conclude the issue is wrong |
| 2, the logout path that writes nothing | **[comment on #109](https://github.com/leodip/goiabada/issues/109#issuecomment-5197711587)** | Two reachability claims in the draft were **wrong and are removed**. The admin console's account menu does *not* take this path: it mints a signed `id_token_hint` through `/api/v1/account/logout-request` and lands on `doLogoutWithIdToken`, which does tear down. And no first-party UI reaches the no-hint POST at all, since the auth server has no logout link of its own. The reachable callers are an RP omitting `id_token_hint`, which is conforming, and a direct request |
| 3, the stale `amr` | **#140** (`bug`, `security`, `go`) | Unchanged in substance. Severity stated as low: `acr` stays correct, so the token is internally inconsistent rather than silently over-claiming, and the narrow reachability the draft gave was confirmed, since the `AuthMethods` copy sits inside the `hasValidUserSession` block and an idle-expired session therefore leaks nothing |
| 4, `ClearAuthContext` after the response | **#141** (`bug`, `security`, `go`) | All seven sites re-read and confirmed, as were the two success paths that get the order right. Body gains a second defect on the same lines: two of the seven also miss a `return` after `httpHelper.InternalServerError`, so a failed redirect writes a 500 and falls through |

Each was checked for duplicates against the open and closed tracker. #139 is distinct from #131 and
#132 (session-scoped code issuance, versus a user-scoped generation sweep and a family-scoped
containment cascade), and #134 held its previous shape but was closed as moot when decision 4 moved
the marker onto `codes.revoked`, so nothing tracked it. Nothing at all tracked #140 or #141.

Refs #129

