### PR TITLE
fix(authserver): make RP-initiated logout conform to OpenID Connect RP-Initiated Logout 1.0

### DIFF
--- a/site/src/content/docs/concepts/user-sessions.mdx
+++ b/site/src/content/docs/concepts/user-sessions.mdx
@@ -73,7 +73,7 @@ Nor can a sign-in that had already reached the consent screen. Goiabada checks t
 
 An application renewing quietly in the background with [`prompt=none`](/concepts/prompt-parameter/) hits the same check and is told rather than shown: it gets a `login_required` error back, never a login page, so it can decide when to ask the person to sign in again.
 
-Logging out is not the same thing. It is navigation rather than a security decision, so it leaves refresh tokens alone.
+Logging out is not the same thing. It revokes nothing: no refresh token is marked revoked and no authorization code is touched. It can still end the session itself, and a normal refresh token stops working once the session behind it is gone. Offline refresh tokens are not tied to a session and keep working either way. See [/auth/logout](/integration/endpoints/) for which logout requests end the whole session.
 
 Each termination writes two entries to the [audit log](/concepts/audit-log/): `terminated_user_session`, recording what was revoked, and `deleted_user_session`, the lifecycle record beside it. Count `terminated_user_session` if you want to know how many sessions were ended.
 

--- a/site/src/content/docs/integration/endpoints.mdx
+++ b/site/src/content/docs/integration/endpoints.mdx
@@ -366,6 +366,24 @@ You can still be redirected back to your application on this path, by sending `p
 Sending `post_logout_redirect_uri` with neither `id_token_hint` nor `client_id` never redirects. The spec requires the OP to confirm the legitimacy of the redirection target first, and with neither parameter there is nothing to confirm it against.
 </Aside>
 
+### Choosing GET or POST
+
+Both bindings accept the same parameter names. Send them where the method puts them: in the query string on a GET, and in an `application/x-www-form-urlencoded` body on a POST. A GET's body is never read, so a parameter sent only there is ignored.
+
+A POST reads the query string as well as its body, so send each parameter once. Which copy wins when the same one arrives in both places is not worth relying on.
+
+What differs between the two methods is not the parameters but whether the request is accepted at all, which is what the rest of this section is about.
+
+POST is worth using when you have an `id_token_hint`, because it keeps the ID token out of the browser's address bar, its history and the referrer headers it sends on to other sites. A self-submitting form from your own page is the usual way to do it, and that form is a cross-site request: it comes from your origin and posts to Goiabada's.
+
+**A cross-site POST needs an `id_token_hint`.** Without one Goiabada answers `403 Forbidden`, because a POST with no hint is exactly what the logout consent screen submits, and treating an arbitrary site's request as a user's confirmation would let any page sign your users out. With a hint the request is accepted and evaluated on the hint's merits: a hint Goiabada can confirm logs the user straight out, and one it cannot is answered with a `303 See Other` back to `GET /auth/logout`, which is where the consent screen comes from. Follow the redirect and the user is asked to confirm, as they would have been on a GET.
+
+That `303` carries your `post_logout_redirect_uri`, `state` and `ui_locales` onward, and deliberately drops `id_token_hint` and `client_id`. Dropping `client_id` is why a hint that fails validation earns no redirect even when a valid `client_id` was sent beside it.
+
+<Aside>
+This is the only reason to think about the method at all. A GET is never refused, so if you are sending users to `/auth/logout` with a link or a browser redirect, nothing here applies to you.
+</Aside>
+
 ### RP-initiated logout (with parameters)
 
 For proper logout with redirection back to your application, use either GET or POST with the following parameters:
@@ -402,7 +420,7 @@ For proper logout with redirection back to your application, use either GET or P
     <tr>
       <td style="white-space: nowrap;"><code>ui_locales</code></td>
       <td>No</td>
-      <td>Space-separated list of preferred locales for the pages this endpoint renders, such as <code>pt-BR en</code>. Read from the query string or the form body.</td>
+      <td>Space-separated list of preferred locales for the pages this endpoint renders, such as <code>pt-BR en</code>. Read from the query string, and on a POST from the form body as well.</td>
     </tr>
   </tbody>
 </table>

--- a/site/src/content/docs/integration/endpoints.mdx
+++ b/site/src/content/docs/integration/endpoints.mdx
@@ -349,10 +349,22 @@ The response body contains error details:
 
 This endpoint enables the client application to initiate a logout. This implementation aligns with the [OpenID Connect RP-Initiated Logout 1.0 protocol](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
 
-### Basic logout (no parameters)
+### Logout without an id_token_hint
 
-- **GET /auth/logout** - Displays a logout consent screen, prompting the user to confirm their intention to log out. No redirection occurs.
-- **POST /auth/logout** - Immediately logs out the user and redirects to the auth server base URL.
+`id_token_hint` is recommended but not required. Without one, Goiabada cannot tell which client is asking, so it asks the user instead:
+
+- **GET /auth/logout** - Displays a logout consent screen, prompting the user to confirm their intention to log out.
+- **POST /auth/logout** - What that screen submits. The user is logged out: the session record is deleted and the session cookie is cleared.
+
+Once the user confirms, they land on a page telling them they have been logged out.
+
+Ending the session reaches the tokens that depend on it, and no further. A normal refresh token from that session stops working, because there is no session behind it any more. Offline refresh tokens are not tied to a browser session and keep working. Access tokens that were already issued stay cryptographically valid: Goiabada's own endpoints, `/userinfo` and the account and admin APIs, reject one whose session is gone on the very next request, but a third-party resource server validating a token by signature alone cannot see that the session ended and keeps accepting it until it expires.
+
+You can still be redirected back to your application on this path, by sending `post_logout_redirect_uri` together with `client_id`. The URI must exactly match one registered for that client, and only `state` is added to it. Your `state` comes back byte for byte, including any `+`, `/`, `=`, `#` or `&`; sending it empty gives you back an empty `state`, and not sending it gives you no `state` at all. If the URI cannot be validated, because `client_id` is missing or unknown, or because the URI is not registered for that client, the user is **still logged out** and lands on the logged-out page with a short note saying we could not return them to the application.
+
+<Aside>
+Sending `post_logout_redirect_uri` with neither `id_token_hint` nor `client_id` never redirects. The spec requires the OP to confirm the legitimacy of the redirection target first, and with neither parameter there is nothing to confirm it against.
+</Aside>
 
 ### RP-initiated logout (with parameters)
 
@@ -369,28 +381,33 @@ For proper logout with redirection back to your application, use either GET or P
   <tbody>
     <tr>
       <td style="white-space: nowrap;"><code>id_token_hint</code></td>
-      <td>Yes</td>
-      <td>The previously issued ID token (can be encrypted or unencrypted).</td>
+      <td>Recommended</td>
+      <td>The previously issued ID token (can be encrypted or unencrypted). Send it when you have it: it identifies the client and session, so the user is not asked to confirm. Without it, the logout still happens, after the consent screen.</td>
     </tr>
     <tr>
       <td style="white-space: nowrap;"><code>post_logout_redirect_uri</code></td>
-      <td>Yes</td>
-      <td>A redirect URI that must be pre-registered with the client.</td>
+      <td>Conditional</td>
+      <td>A redirect URI that must be pre-registered with the client. Required when you send an <code>id_token_hint</code>. Without a hint it is optional: leave it out and the user is logged out and lands on the logged-out page.</td>
     </tr>
     <tr>
       <td style="white-space: nowrap;"><code>client_id</code></td>
       <td>Conditional</td>
-      <td>Required only if <code>id_token_hint</code> is encrypted with the client secret.</td>
+      <td>Required if <code>id_token_hint</code> is encrypted with the client secret, to select whose secret derives the key. Also required to authorize <code>post_logout_redirect_uri</code> when you send no <code>id_token_hint</code>.</td>
     </tr>
     <tr>
       <td style="white-space: nowrap;"><code>state</code></td>
       <td>No</td>
       <td>Any arbitrary string that will be echoed back in the redirect.</td>
     </tr>
+    <tr>
+      <td style="white-space: nowrap;"><code>ui_locales</code></td>
+      <td>No</td>
+      <td>Space-separated list of preferred locales for the pages this endpoint renders, such as <code>pt-BR en</code>. Read from the query string or the form body.</td>
+    </tr>
   </tbody>
 </table>
 
-### Response
+### Response (with an id_token_hint)
 
 After successful logout, the user is redirected to the `post_logout_redirect_uri` with the following query parameters:
 

--- a/site/src/content/docs/integration/endpoints.mdx
+++ b/site/src/content/docs/integration/endpoints.mdx
@@ -386,8 +386,8 @@ For proper logout with redirection back to your application, use either GET or P
     </tr>
     <tr>
       <td style="white-space: nowrap;"><code>post_logout_redirect_uri</code></td>
-      <td>Conditional</td>
-      <td>A redirect URI that must be pre-registered with the client. Required when you send an <code>id_token_hint</code>. Without a hint it is optional: leave it out and the user is logged out and lands on the logged-out page.</td>
+      <td>No</td>
+      <td>A redirect URI that must be pre-registered with the client. Optional in every case: leave it out and the user is logged out and lands on the logged-out page.</td>
     </tr>
     <tr>
       <td style="white-space: nowrap;"><code>client_id</code></td>
@@ -407,14 +407,27 @@ For proper logout with redirection back to your application, use either GET or P
   </tbody>
 </table>
 
-### Response (with an id_token_hint)
+### Response
 
-After successful logout, the user is redirected to the `post_logout_redirect_uri` with the following query parameters:
+When a `post_logout_redirect_uri` is supplied and can be validated, the user is redirected to it after the logout. Exactly one parameter is added:
 
-- `sid` - The session identifier from the ID token
-- `state` - The state parameter if provided in the request
+- `state` - only if you sent one, and byte for byte what you sent
 
-Example redirect: `https://your-app.com/logged-out?sid=abc123&state=xyz`
+Anything the registered URI already carried in its own query is preserved.
+
+Example redirect: `https://your-app.com/logged-out?state=xyz`
+
+With no `post_logout_redirect_uri`, or when the URI cannot be validated, the user lands on Goiabada's logged-out page instead. Either way the logout has already happened.
+
+### When the id_token_hint cannot be used
+
+Goiabada checks the hint's signature, issuer, audience, session and expiry, and that `client_id` matches the audience when you send both. If any of those fail, the request is not an error: the user sees the logout consent screen, and once they confirm, they are logged out.
+
+A hint that fails these checks earns no redirect, even if you also sent `client_id` and a registered `post_logout_redirect_uri`. The user is logged out and lands on the logged-out page with the note. Send a hint you can vouch for, or send none at all and let `client_id` authorize the redirect.
+
+<Aside>
+An **expired** `id_token_hint` is still accepted, as long as the session it names is still alive. This is deliberate, and the spec recommends it: hints are short lived, and a user who pauses between receiving one and following it should not have their logout fail. A hint whose session has already ended is treated as one that cannot be confirmed.
+</Aside>
 
 ### Encrypting the ID token hint
 

--- a/src/authserver/internal/handlers/handler_account_logout.go
+++ b/src/authserver/internal/handlers/handler_account_logout.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gorilla/csrf"
@@ -351,4 +352,84 @@ func doLogoutWithIdToken(
 		logoutUri += "&state=" + state
 	}
 	http.Redirect(w, r, logoutUri, http.StatusFound)
+}
+
+// buildPostLogoutRedirect returns the Location value for a post-logout redirect: the
+// registered URI with the RP's state written into its query, properly escaped. Building
+// it by string concatenation instead is what let a state containing "+", "/", "=", "#"
+// or "&" reach the RP altered or truncated, and let a registered URI that already
+// carried a query gain a second "?" (#109).
+//
+// The registered query is copied field by field, verbatim and in order, empty fields
+// included, and only the RP's state is encoded. Decoding it into url.Values and
+// re-encoding it, which is what
+// redirToClientWithError does in handler_authorize.go, does not round-trip: url.Query
+// discards the error from url.ParseQuery, so a field separated by a literal semicolon
+// ("?lang=en;mode=dark") is deleted outright and the caller never learns; Encode sorts
+// by key, so a query whose order the RP signs over comes back reordered; a valueless
+// field ("?flag") gains an "="; and percent-escapes are normalised ("%7E" to "~"). The
+// registered URI is an operator-registered target that was just matched exactly, so
+// altering its query sends the RP somewhere it did not register. None of those shapes is
+// rejected at registration: validateRedirectURI's excluded-character set is
+// "<>\"{}|\\^` " and admits a semicolon.
+//
+// Copying registered bytes into a Location header is safe here because url.Parse above
+// rejects CR, LF and NUL outright ("net/url: invalid control character in URL"), so a
+// registered URI that reaches this point cannot carry a header-splitting byte. The RP's
+// state is attacker-influenced and is escaped, never copied.
+//
+// Three further properties, each load-bearing, so changing one back is a behaviour
+// change rather than a tidy-up:
+//
+//   - Exactly one state reaches the RP. Every registered field whose decoded name is
+//     "state" is dropped and one is appended, so the RP reads the value it sent rather
+//     than the registered one, and never both with the choice left to its parser.
+//   - No TrimSpace. OpenID Connect RP-Initiated Logout 1.0 section 2 calls state an
+//     "Opaque value used by the RP to maintain state between the logout request and the
+//     callback", so the OP has no licence to alter it. Trimming would turn a
+//     whitespace-only state into no state at all.
+//   - url.Parse rather than url.ParseRequestURI. A fragment is not part of an HTTP
+//     request URI, so ParseRequestURI keeps a literal "#" in the path and the result
+//     comes back as ".../out%23frag?state=abc". url.Parse still rejects the genuinely
+//     malformed, so the looser parse gives up nothing.
+//
+// statePresent, rather than a len(state) > 0 guard, is what keeps three cases distinct:
+// a state that was absent writes nothing, a state supplied empty comes back as "state=",
+// and a whitespace-only state survives byte-identical.
+func buildPostLogoutRedirect(registeredURI string, state string, statePresent bool) (string, error) {
+	redirUrl, err := url.Parse(registeredURI)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse post-logout redirect URI")
+	}
+
+	if !statePresent {
+		return redirUrl.String(), nil
+	}
+
+	fields := make([]string, 0, 4)
+	// An empty RawQuery is the only field the loop must not see. strings.Split("", "&")
+	// yields one empty string rather than nothing, so iterating unconditionally would
+	// append a leading "&" to a URI that had no query at all. Guarding here rather than
+	// skipping empty fields inside the loop is what keeps the empty fields a registered
+	// query really did carry: "?a=1&&b=2" stays that way instead of collapsing to
+	// "?a=1&b=2", which is a different target from the one the operator registered and
+	// the OP just matched exactly (#109).
+	if redirUrl.RawQuery != "" {
+		for _, field := range strings.Split(redirUrl.RawQuery, "&") {
+			name := field
+			if i := strings.IndexByte(field, '='); i >= 0 {
+				name = field[:i]
+			}
+			// An unescapable name cannot be "state", and is kept as it stands rather than
+			// dropped, since the point is to preserve what was registered.
+			if decoded, err := url.QueryUnescape(name); err == nil && decoded == "state" {
+				continue
+			}
+			fields = append(fields, field)
+		}
+	}
+	fields = append(fields, "state="+url.QueryEscape(state))
+
+	redirUrl.RawQuery = strings.Join(fields, "&")
+	return redirUrl.String(), nil
 }

--- a/src/authserver/internal/handlers/handler_account_logout.go
+++ b/src/authserver/internal/handlers/handler_account_logout.go
@@ -646,7 +646,12 @@ func doLogout(
 // class of defect this endpoint was rewritten to remove. The GET binding is never exempt, so the page
 // it renders has a real token and a real cookie (#109).
 //
-// id_token_hint is dropped because sending it back would land on this branch again, forever.
+// id_token_hint is dropped, and not to prevent a loop: the follow-up is a GET, and the switch above
+// sends a rejected hint on any method but POST to the consent page, so sending the hint back would
+// terminate rather than return here. It is dropped because carrying it puts an ID token in the
+// address bar of a top-level navigation, its history and its referrers, which is the exposure the
+// POST binding exists to avoid, and because feeding input already judged unusable into the next
+// request gives that request nothing it can act on anyway.
 // client_id is dropped because the follow-up GET is then the hint-absent shape, where client_id is
 // what authorizes a post-logout redirect: keeping it would hand the request the redirect authority a
 // rejected hint is specifically denied. With no client_id nothing validates the target, so the

--- a/src/authserver/internal/handlers/handler_account_logout.go
+++ b/src/authserver/internal/handlers/handler_account_logout.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/encryption"
+	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/i18n"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
@@ -157,6 +159,270 @@ func decryptIDTokenHint(idTokenHint, clientID string, database data.Database) (s
 	}
 
 	return decryptedToken, nil
+}
+
+// hintState is what classifyIdTokenHint decided about a request's id_token_hint, and it has three
+// values rather than two on purpose. Collapsing "supplied and rejected" into "absent" is what let a
+// detected client_id/aud mismatch go on to authorize a post-logout redirect: the rejected hint
+// vanished, the unauthenticated client_id beside it survived, and client_id then chose the target.
+// OpenID Connect RP-Initiated Logout 1.0 section 4 forbids that twice over, once as "any operations
+// requiring the information that failed to correctly validate MUST be aborted and the information
+// that failed to validate MUST NOT be used", and once as "the OP MUST not perform post-logout
+// redirection to an RP" upon detecting errors (#109).
+type hintState int
+
+const (
+	// hintRejected is the zero value deliberately. A classification nobody filled in then asks the
+	// End-User and earns no redirect, which is the fail-safe direction of the three: the worst it can
+	// do is show a consent page to somebody who need not have seen one.
+	hintRejected hintState = iota
+	hintAbsent
+	hintConfirmed
+)
+
+func (h hintState) String() string {
+	switch h {
+	case hintAbsent:
+		return "absent"
+	case hintConfirmed:
+		return "confirmed"
+	default:
+		return "rejected"
+	}
+}
+
+// hintClassification is classifyIdTokenHint's answer. client and sessionIdentifier are populated for
+// hintConfirmed and left empty otherwise, so a caller that forgets to check the state still cannot
+// scope a teardown or authorize a redirect from a hint that failed to validate.
+type hintClassification struct {
+	state             hintState
+	client            *models.Client
+	sessionIdentifier string
+}
+
+// nonIdTokenTypValues are the "typ" claim values Goiabada stamps on tokens that are NOT ID Tokens:
+// enums.TokenTypeBearer on access tokens, and the two refresh-token markers "Offline" and "Refresh",
+// which are unexported constants in src/core/oauth/token_issuer.go. generateIdTokenCore emits no typ
+// at all, and neither does the short-lived hint HandleAPIAccountLogoutRequestPost mints, so this
+// rejects nothing an RP can legitimately present.
+//
+// It is a denylist rather than a requirement that typ be "ID" for exactly that reason: no ID Token
+// this server issues carries the claim, so requiring it would reject every real hint.
+var nonIdTokenTypValues = map[string]bool{
+	enums.TokenTypeBearer.String():  true, // "Bearer", access tokens
+	enums.TokenTypeRefresh.String(): true, // "Refresh", session-bound refresh tokens
+	"Offline":                       true, // offline refresh tokens; the constant is unexported
+}
+
+// classifyIdTokenHint decides whether a request's id_token_hint can be trusted, and returns which of
+// the three states it is in along with the client and session a confirmed hint names.
+//
+// The error return is reserved for one thing: a database failure while deciding whether an expired
+// hint's session is still alive. Every other failure is a rejection, because a hint the OP cannot
+// confirm is not an error to report, it is a reason to ask the End-User. RP-Initiated Logout 1.0
+// section 2: "the OP MUST ask the End-User this question if an id_token_hint was not provided or if
+// the supplied ID Token does not belong to the current OP session with the RP and/or currently
+// logged in End-User".
+//
+// Two properties are worth stating because losing either turns this into a hole rather than a bug.
+//
+// The hint is read for PRESENCE, not for a value. An id_token_hint supplied empty is Rejected rather
+// than Absent, because the CSRF middleware exempts a cross-site POST on presence and cannot judge
+// validity. If this helper read "id_token_hint=" as no hint at all, an exempted POST would take the
+// no-hint branch, which tears the whole session down without consent (#109 decision 13).
+//
+// The claims are checked BY HAND, all of them, because the parse deliberately runs with the
+// library's claims validation off. That flag is jwt.WithoutClaimsValidation() rather than an exp
+// switch, so it disables every claim check the library performs; the signature survives it, since a
+// signature is not a claim. Turning it off is what lets an expired hint reach the tolerance gate
+// below instead of being refused before the OP has looked at the session, per RP-Initiated Logout
+// 1.0 section 2: "The OP SHOULD accept ID Tokens when the RP identified by the ID Token's aud claim
+// and/or sid claim has a current session or had a recent session at the OP, even when the exp time
+// has passed."
+func classifyIdTokenHint(
+	r *http.Request,
+	httpHelper HttpHelper,
+	database data.Database,
+	tokenParser TokenParser,
+) (hintClassification, error) {
+
+	reject := func(gate string, args ...interface{}) (hintClassification, error) {
+		slog.Error("logout: id_token_hint rejected at the "+gate+" gate", args...)
+		return hintClassification{state: hintRejected}, nil
+	}
+
+	hint, present := httpHelper.LookupFromUrlQueryOrFormPost(r, "id_token_hint")
+	if !present {
+		return hintClassification{state: hintAbsent}, nil
+	}
+	if len(hint) == 0 {
+		return reject("presence", "reason", "id_token_hint was supplied with an empty value")
+	}
+
+	// Presence-aware, like the hint above and for the same reason: the client_id gate further down
+	// fires when the parameter is PRESENT, and a value-only read cannot tell "client_id=" from no
+	// client_id at all. See the comment on that gate for why the difference matters (#109).
+	clientId, clientIdPresent := httpHelper.LookupFromUrlQueryOrFormPost(r, "client_id")
+
+	// An encrypted hint is a Nested JWT (OpenID Connect Core 1.0 section 2) and must be decrypted
+	// before anything can be read from it. The key derives from a client secret, so client_id is what
+	// says whose. This one reads the value rather than the presence, correctly: an empty client_id
+	// selects no key whether it was supplied empty or left out.
+	if isEncryptedIDTokenHint(hint) {
+		if len(clientId) == 0 {
+			return reject("JWE key selection", "reason", "an encrypted id_token_hint needs client_id to select the key")
+		}
+		decrypted, locErr := decryptIDTokenHint(hint, clientId, database)
+		if locErr != nil {
+			// decryptIDTokenHint has already logged which half failed.
+			return reject("JWE decryption")
+		}
+		hint = decrypted
+	}
+
+	idToken, err := tokenParser.DecodeAndValidateTokenString(hint, nil, false)
+	if err != nil || idToken == nil {
+		return reject("parse and signature", "err", err)
+	}
+
+	// Is this an ID Token at all? Without this gate a session-bound ACCESS token satisfies every
+	// other check here whenever a resource identifier happens to equal a client identifier, which
+	// nothing in the product prevents: client identifiers are checked for uniqueness against clients
+	// and resource identifiers against resources, and no code compares the two namespaces. An access
+	// token carries iss, sub, iat, nbf, exp and a session-bound sid, and its aud is the resource
+	// identifier, so GetClientByClientIdentifier resolves it under the collision. Confirming it would
+	// skip the consent page entirely and end that client's half of the session (#109).
+	if typ := idToken.GetStringClaim("typ"); nonIdTokenTypValues[typ] {
+		return reject("ID-Token shape", "reason", "typ names a token that is not an ID Token", "typ", typ)
+	}
+
+	// sub and iat are REQUIRED on an ID Token by OpenID Connect Core 1.0 section 2, and RP-Initiated
+	// Logout 1.0 section 2 defines this parameter as an "ID Token previously issued by the OP", so
+	// establishing ID-Token shape belongs here. They do not close the access-token hole above on
+	// their own, since an access token carries both.
+	if len(idToken.GetStringClaim("sub")) == 0 {
+		return reject("ID-Token shape", "reason", "sub is missing or empty")
+	}
+	if _, ok := idToken.GetIntClaim("iat"); !ok {
+		return reject("ID-Token shape", "reason", "iat is missing or is not an integral number")
+	}
+
+	settings := r.Context().Value(constants.ContextKeySettings).(*models.Settings)
+	issuer := idToken.GetStringClaim("iss")
+	if len(issuer) == 0 {
+		return reject("iss", "reason", "iss is missing")
+	}
+	if issuer != settings.Issuer {
+		return reject("iss", "reason", "iss is not this server", "iss", issuer)
+	}
+
+	// GetStringClaim yields "" for an aud that arrived as an array, which is right for a hint: an ID
+	// Token this server issues has exactly one audience, the client identifier.
+	clientIdentifier := idToken.GetStringClaim("aud")
+	if len(clientIdentifier) == 0 {
+		return reject("aud", "reason", "aud is missing, or is not a single string")
+	}
+
+	// RP-Initiated Logout 1.0 section 2: "When both client_id and id_token_hint are present, the OP
+	// MUST verify that the Client Identifier matches the one used when issuing the ID Token."
+	//
+	// PRESENT, not non-empty. "client_id=" is a parameter the request carried, and an empty string is
+	// not a Client Identifier valid at this server, so it fails the check and rejects the hint exactly
+	// as a wrong client_id does. Reading it as absent would skip a MUST on a parameter that arrived.
+	// RP-Initiated Logout is silent on empty-valued parameters; RFC 6749 section 3.1's "Parameters
+	// sent without a value MUST be treated as if they were omitted from the request" is stated for the
+	// OAuth authorization endpoint and is not carried into this one, which serializes per OpenID
+	// Connect Core's Query String and Form Serialization instead.
+	//
+	// What it costs a caller who sends "client_id=" beside an otherwise good hint: a consent page
+	// instead of a silent logout, a whole-session teardown instead of a per-client one, and no
+	// post-logout redirect. That is the same price any non-matching client_id already pays here, and
+	// the fail-safe direction of both (#109).
+	//
+	// Compared before the lookup so a mismatch costs no query.
+	if clientIdPresent && clientId != clientIdentifier {
+		return reject("client_id", "reason", "client_id does not match the aud the hint is signed over",
+			"clientId", clientId, "aud", clientIdentifier)
+	}
+
+	client, err := database.GetClientByClientIdentifier(nil, clientIdentifier)
+	if err != nil {
+		// Rejected rather than propagated, unlike the expiry lookup below. This runs before any
+		// teardown, so a 500 here would put the End-User on a terminal page while still signed in,
+		// which is the defect #109 exists to remove. Rejecting instead widens the teardown from
+		// per-client to whole-session and forbids the redirect, which is the fail-safe direction.
+		return reject("aud", "reason", "the client lookup failed", "aud", clientIdentifier, "err", err)
+	}
+	if client == nil {
+		return reject("aud", "reason", "aud names no client", "aud", clientIdentifier)
+	}
+
+	now := time.Now().UTC()
+
+	// nbf is optional on an ID Token, but a present one still binds. Raw map presence rather than a
+	// zero-value test, so a present-but-malformed nbf is refused instead of read as absent.
+	if _, hasNbf := idToken.Claims["nbf"]; hasNbf {
+		nbf, ok := idToken.GetIntClaim("nbf")
+		if !ok {
+			return reject("nbf", "reason", "nbf is present and is not an integral number")
+		}
+		if time.Unix(nbf, 0).After(now) {
+			return reject("nbf", "reason", "nbf is in the future")
+		}
+	}
+
+	// exp must still be THERE. Decision 14 tolerates a past exp, not a missing one: a hint with no
+	// expiry at all is an indefinitely replayable forced-logout token, which is what the tolerance
+	// below is bounded to avoid becoming.
+	exp, ok := idToken.GetIntClaim("exp")
+	if !ok {
+		return reject("exp", "reason", "exp is missing or is not an integral number")
+	}
+
+	sid := idToken.GetStringClaim("sid")
+	if len(sid) == 0 {
+		return reject("sid", "reason", "sid is missing")
+	}
+
+	sessionIdentifier := ""
+	if v := r.Context().Value(constants.ContextKeySessionIdentifier); v != nil {
+		sessionIdentifier, _ = v.(string)
+	}
+	if len(sessionIdentifier) == 0 {
+		// An RP may end a session with a hint alone and no cookie in play, which is what makes
+		// RP-initiated logout work from a back-channel-less RP, so the hint's own sid names the
+		// session. MiddlewareSessionIdentifier fills the context only when the cookie resolves to a
+		// live row, so "no identifier" covers a cookie whose session has already gone too.
+		sessionIdentifier = sid
+	} else if sid != sessionIdentifier {
+		// Not an error and not a 500, which is what it used to be. The spec's answer to a hint that
+		// does not belong to the current session is to ask the End-User, and a user whose session was
+		// reaped or replaced between signing in and logging out reaches this with nobody at fault.
+		return reject("sid", "reason", "sid names a different session than the browser's")
+	}
+
+	if time.Unix(exp, 0).Before(now) {
+		userSession, err := database.GetUserSessionBySessionIdentifier(nil, sessionIdentifier)
+		if err != nil {
+			// Propagated rather than read as "no such session". A database failure and a row that is
+			// not there have different answers, and conflating them would decide whether an expired
+			// hint is honoured on the database's health. The caller surfaces this as a 500, and the
+			// teardown reads the same row through the same call, so it would have failed anyway.
+			return hintClassification{}, err
+		}
+		if userSession == nil {
+			return reject("expiry tolerance", "reason", "exp has passed and sid names no live session")
+		}
+		// "Recent session" has exactly one meaning in this codebase: the row is still there.
+		slog.Info("logout: accepting an expired id_token_hint because its session is still live",
+			"aud", clientIdentifier)
+	}
+
+	return hintClassification{
+		state:             hintConfirmed,
+		client:            client,
+		sessionIdentifier: sessionIdentifier,
+	}, nil
 }
 
 func validateClientAndRedirectURI(idToken *oauth.JwtToken, postLogoutRedirectURI string, database data.Database, clientId string) (*models.Client, *i18n.LocalizedError) {

--- a/src/authserver/internal/handlers/handler_account_logout.go
+++ b/src/authserver/internal/handlers/handler_account_logout.go
@@ -15,8 +15,6 @@ import (
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/i18n"
 	"github.com/leodip/goiabada/core/models"
-	"github.com/leodip/goiabada/core/oauth"
-	oauthdb "github.com/leodip/goiabada/core/oauthdb"
 	"github.com/pkg/errors"
 )
 
@@ -30,20 +28,8 @@ func HandleAccountLogoutGet(
 ) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		r = refineLogoutLocale(r)
-
-		idTokenHint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint")
-
-		if len(idTokenHint) == 0 {
-			// OpenID Connect RP-Initiated Logout 1.0 section 2 makes this a MUST: "the OP MUST ask
-			// the End-User this question if an id_token_hint was not provided". So the consent page
-			// is the response, and it deliberately precedes any teardown.
-			renderLogoutConsent(w, r, httpHelper)
-			return
-		}
-
-		doLogoutWithIdToken(w, r, httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+		doLogout(w, r, httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 	}
 }
 
@@ -73,14 +59,29 @@ func refineLogoutLocale(r *http.Request) *http.Request {
 // renderLogoutConsent renders the logout consent page, carrying forward the parameters the
 // confirming POST needs and NOT the id_token_hint. See logout_consent.html for why the hint is
 // dropped and why state is treated differently from the other three.
-func renderLogoutConsent(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper) {
+//
+// hint says how the request's id_token_hint was classified, and it decides one thing: whether
+// client_id survives the hop. It does when no hint was supplied, because client_id is then the only
+// thing that can authorize a post-logout redirect and doing so is its documented primary purpose. It
+// must NOT when a hint was supplied and rejected: the confirming POST is hintless by design, so a
+// surviving client_id would authorize the redirect that the rejected hint was specifically denied,
+// and the detected error would become a redirect after all. RP-Initiated Logout 1.0 section 4 forbids
+// that twice, once as "any operations requiring the information that failed to correctly validate
+// MUST be aborted", and once as "the OP MUST not perform post-logout redirection to an RP" upon
+// detecting errors (#109).
+func renderLogoutConsent(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper, hint hintState) {
 	state, statePresent := httpHelper.LookupFromUrlQueryOrFormPost(r, "state")
+
+	clientId := ""
+	if hint == hintAbsent {
+		clientId = httpHelper.GetFromUrlQueryOrFormPost(r, "client_id")
+	}
 
 	bind := map[string]interface{}{
 		"csrfField":             csrf.TemplateField(r),
 		"formAction":            logoutFormPath,
 		"postLogoutRedirectUri": httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri"),
-		"clientId":              httpHelper.GetFromUrlQueryOrFormPost(r, "client_id"),
+		"clientId":              clientId,
 		"state":                 state,
 		"statePresent":          statePresent,
 		"uiLocales":             httpHelper.GetFromUrlQueryOrFormPost(r, "ui_locales"),
@@ -111,20 +112,6 @@ func renderLoggedOut(w http.ResponseWriter, r *http.Request, httpHelper HttpHelp
 	}
 }
 
-// renderAuthError renders the auth_error.html page with a localized title
-// and message. i18n surface: A — RP-initiated logout error page.
-func renderAuthError(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper, locErr *i18n.LocalizedError) {
-	ctx := r.Context()
-	bind := map[string]interface{}{
-		"title": i18n.T(ctx, i18n.ErrCodeLogoutErrorTitle),
-		"error": locErr.Localize(ctx),
-	}
-	err := httpHelper.RenderTemplate(w, r, "/layouts/no_menu_layout.html", "/auth_error.html", bind)
-	if err != nil {
-		httpHelper.InternalServerError(w, r, err)
-	}
-}
-
 // isEncryptedIDTokenHint reports whether the hint is a compact JWE (5
 // dot-separated segments) rather than a compact JWS (3 segments). An encrypted
 // hint must be decrypted with the client's key before validation; a plain
@@ -139,23 +126,31 @@ func isEncryptedIDTokenHint(hint string) bool {
 // documented in integration/endpoints.mdx and implemented in
 // encryption.DecryptIDTokenHintJWE. client_id selects which client's secret to
 // use, as required by RP-Initiated Logout for symmetrically-encrypted hints.
-func decryptIDTokenHint(idTokenHint, clientID string, database data.Database) (string, *i18n.LocalizedError) {
+//
+// The returned error is for the server log and never for the End-User. Every failure here means the
+// hint cannot be confirmed, and the spec's answer to a hint the OP cannot confirm is to ask the
+// End-User rather than to show them a diagnostic about a request their relying party built (#109).
+func decryptIDTokenHint(idTokenHint, clientID string, database data.Database) (string, error) {
 	client, err := database.GetClientByClientIdentifier(nil, clientID)
-	if err != nil || client == nil {
+	if err != nil {
 		slog.Error("logout: client lookup failed", "clientId", clientID, "err", err)
-		return "", i18n.NewLocalizedError(i18n.ErrCodeLogoutInvalidClient, nil)
+		return "", errors.Wrap(err, "unable to look up the client named by client_id")
+	}
+	if client == nil {
+		slog.Error("logout: client_id names no client", "clientId", clientID)
+		return "", errors.New("client_id names no client")
 	}
 
 	clientSecret, err := encryption.DecryptData(client.ClientSecretEncrypted)
 	if err != nil {
 		slog.Error("logout: client secret decrypt failed", "err", err)
-		return "", i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintDecryptFailed, nil)
+		return "", errors.Wrap(err, "unable to decrypt the client secret")
 	}
 
 	decryptedToken, err := encryption.DecryptIDTokenHintJWE(idTokenHint, clientSecret)
 	if err != nil {
 		slog.Error("logout: id_token_hint decrypt failed", "err", err)
-		return "", i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintDecryptFailed, nil)
+		return "", errors.Wrap(err, "unable to decrypt the id_token_hint")
 	}
 
 	return decryptedToken, nil
@@ -272,8 +267,8 @@ func classifyIdTokenHint(
 		if len(clientId) == 0 {
 			return reject("JWE key selection", "reason", "an encrypted id_token_hint needs client_id to select the key")
 		}
-		decrypted, locErr := decryptIDTokenHint(hint, clientId, database)
-		if locErr != nil {
+		decrypted, err := decryptIDTokenHint(hint, clientId, database)
+		if err != nil {
 			// decryptIDTokenHint has already logged which half failed.
 			return reject("JWE decryption")
 		}
@@ -425,54 +420,36 @@ func classifyIdTokenHint(
 	}, nil
 }
 
-func validateClientAndRedirectURI(idToken *oauth.JwtToken, postLogoutRedirectURI string, database data.Database, clientId string) (*models.Client, *i18n.LocalizedError) {
-	clientIdentifier := idToken.GetStringClaim("aud")
-	if len(clientIdentifier) == 0 {
-		return nil, i18n.NewLocalizedError(i18n.ErrCodeLogoutAudClaimMissing, nil)
-	}
-
-	client, err := database.GetClientByClientIdentifier(nil, clientIdentifier)
-	if err != nil || client == nil {
-		slog.Error("logout: client lookup failed", "clientIdentifier", clientIdentifier, "err", err)
-		return nil, i18n.NewLocalizedError(i18n.ErrCodeLogoutInvalidClient, nil)
-	}
-
-	if len(clientId) > 0 && clientId != clientIdentifier {
-		return nil, i18n.NewLocalizedError(i18n.ErrCodeLogoutClientIdMismatch, nil)
-	}
-
-	err = database.ClientLoadRedirectURIs(nil, client)
-	if err != nil {
-		slog.Error("logout: load redirect URIs failed", "clientIdentifier", clientIdentifier, "err", err)
-		return nil, i18n.NewLocalizedError(i18n.ErrCodeLogoutInvalidPostLogoutRedirect, nil)
-	}
-
-	for _, uri := range client.RedirectURIs {
-		if uri.URI == postLogoutRedirectURI {
-			return client, nil
-		}
-	}
-
-	return nil, i18n.NewLocalizedError(i18n.ErrCodeLogoutInvalidPostLogoutRedirect, nil)
-}
-
+// handleExistingSessionOnLogout performs the per-client teardown a CONFIRMED id_token_hint earns:
+// delete this client's row on the session, and the session row itself when that client was the last
+// one on it.
+//
+// Per-client rather than whole-session, unchanged by this rewrite, because #129 decided that logging
+// one client out must not stop the session-bound tokens of the other clients sharing that session.
+// Two of its integration tests exist so that widening this has to be deliberate (#109 decision 3).
+//
+// The sid guard this used to open with is gone. Whether the hint names the browser's session is part
+// of whether the hint can be confirmed at all, and classifyIdTokenHint decides that before anything
+// reaches here. It used to be decided here, by returning an error the caller turned into a 500, which
+// is what a user whose session had merely been reaped or replaced saw (#109 decision 11).
+//
+// A lookup or delete failure is returned so the caller can surface a 500. A session row that is not
+// there is nothing to tear down rather than a failure, and those two used to be one branch returning
+// a variable that was sometimes nil to mean both (#109 item 4).
 func handleExistingSessionOnLogout(
 	r *http.Request,
 	sessionIdentifier string,
-	idToken *oauth.JwtToken,
 	client *models.Client,
 	database data.Database,
 	auditLogger AuditLogger,
 	authHelper AuthHelper,
 ) error {
-	sid := idToken.GetStringClaim("sid")
-	if len(sid) == 0 || sid != sessionIdentifier {
-		return errors.New("Invalid session identifier in id_token_hint")
-	}
-
 	userSession, err := database.GetUserSessionBySessionIdentifier(nil, sessionIdentifier)
-	if err != nil || userSession == nil {
+	if err != nil {
 		return err
+	}
+	if userSession == nil {
+		return nil
 	}
 
 	err = database.UserSessionLoadClients(nil, userSession)
@@ -523,86 +500,181 @@ func HandleAccountLogoutPost(
 	httpSession sessions.Store,
 	authHelper AuthHelper,
 	database data.Database,
+	tokenParser TokenParser,
 	auditLogger AuditLogger,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		r = refineLogoutLocale(r)
-
-		// If id_token_hint is present in the POST body, handle same as GET flow
-		if hint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint"); len(hint) > 0 {
-			// Use a fresh token parser based on database
-			tp := oauthdb.NewTokenParser(database)
-			doLogoutWithIdToken(w, r, httpHelper, httpSession, authHelper, database, tp, auditLogger)
-			return
-		}
-
-		doLogoutWithoutIdToken(w, r, httpHelper, httpSession, authHelper, database, auditLogger)
+		doLogout(w, r, httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 	}
 }
 
-// doLogoutWithoutIdToken logs the End-User out on a request that named no id_token_hint. Reaching
-// here on a POST means the confirming submission of the consent page, since that page is what a
-// hintless GET renders and the CSRF token it carries is what proves the request came from it.
+// doLogout is the whole endpoint, entered identically by GET and by POST. Four steps, and the design
+// is in keeping them independent:
 //
-// The three steps run in this order and, crucially, the second reads nothing the first produced.
-// That independence is the whole fix for #109's first item: every error path in this endpoint used
-// to return before both the teardown and the cookie wipe, so a request the OP considered malformed
-// rendered a page saying so and left the user signed in. Whether a redirect can be honoured is now
-// only ever a question about the response, never about whether the logout happens.
-func doLogoutWithoutIdToken(
+//  1. Classify the id_token_hint into confirmed, absent or rejected.
+//  2. Decide whether the End-User has to be asked.
+//  3. Resolve the redirect target, which is only ever a question about the RESPONSE.
+//  4. Tear down and respond, reading nothing step 3 produced.
+//
+// Step 4 not reading step 3 is the fix for #109's first item and its six siblings at once. Every
+// error path in this endpoint used to return before both the database teardown and the cookie wipe,
+// so a request the OP considered malformed rendered a page saying so and left the user signed in.
+// Hint validity now decides only whether the End-User is asked, redirect-target validity decides only
+// whether a redirect happens, and neither decides whether the logout happens.
+func doLogout(
 	w http.ResponseWriter,
 	r *http.Request,
 	httpHelper HttpHelper,
 	httpSession sessions.Store,
 	authHelper AuthHelper,
 	database data.Database,
+	tokenParser TokenParser,
 	auditLogger AuditLogger,
 ) {
-	// 1. Resolve the redirect target. With no hint to read a signed aud from, the only thing that
-	// can authorize a target is client_id, which is the parameter's documented primary purpose:
-	// RP-Initiated Logout 1.0 section 2 says "The most common use case for this parameter is to
-	// specify the Client Identifier when post_logout_redirect_uri is used but id_token_hint is not."
-	// That is the "other means of confirming the legitimacy of the post-logout redirection target"
-	// section 3 requires before an OP may redirect.
+	// 1. Classify.
+	hint, err := classifyIdTokenHint(r, httpHelper, database, tokenParser)
+	if err != nil {
+		// The single failure classification propagates instead of rejecting: a database fault while
+		// deciding whether an expired hint's session is still alive. Everything else is a rejection,
+		// because a hint the OP cannot confirm is a reason to ask rather than an error to report.
+		httpHelper.InternalServerError(w, r, err)
+		return
+	}
+
+	// 2. Decide whether to ask. RP-Initiated Logout 1.0 section 2: "the OP MUST ask the End-User this
+	// question if an id_token_hint was not provided or if the supplied ID Token does not belong to the
+	// current OP session with the RP and/or currently logged in End-User".
+	switch {
+	case hint.state == hintConfirmed:
+		// The hint names a client and a session and validates, so there is nobody to ask.
+
+	case hint.state == hintAbsent && r.Method == http.MethodPost:
+		// The confirming submission of the consent page. A hintless POST is not CSRF-exempt, so it
+		// carried a token, so it came from a page this server rendered. That is what makes it consent
+		// rather than a cross-site request, and it is why the consent form drops the hint (#109
+		// decision 13).
+
+	case hint.state == hintRejected && r.Method == http.MethodPost:
+		redirectToHintlessLogout(w, r, httpHelper)
+		return
+
+	default:
+		// Absent on GET, and rejected on either method that is not POST. Ask.
+		renderLogoutConsent(w, r, httpHelper, hint.state)
+		return
+	}
+
+	// 3. Resolve the redirect target, independently of step 2 above and of step 4 below.
 	postLogoutRedirectURI := httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri")
 	location := ""
 	if len(postLogoutRedirectURI) > 0 {
-		clientId := httpHelper.GetFromUrlQueryOrFormPost(r, "client_id")
-		client := clientForPostLogoutRedirect(clientId, database)
+		// A confirmed hint carries its own client, resolved from the aud it is signed over. Only step
+		// 2's second row reaches here with no hint, and there the sole thing that can authorize a
+		// target is client_id, which is that parameter's documented primary purpose: RP-Initiated
+		// Logout 1.0 section 2, "The most common use case for this parameter is to specify the Client
+		// Identifier when post_logout_redirect_uri is used but id_token_hint is not". That is the
+		// "other means of confirming the legitimacy of the post-logout redirection target" section 3
+		// requires before an OP may redirect.
+		//
+		// A rejected hint never arrives here at all, because step 2 always asks first, and the consent
+		// page it renders drops client_id. That is how a detected error is kept from becoming a
+		// redirect (#109 decision 15).
+		client := hint.client
+		if hint.state == hintAbsent {
+			client = clientForPostLogoutRedirect(httpHelper.GetFromUrlQueryOrFormPost(r, "client_id"), database)
+		}
 		location = postLogoutRedirectLocation(r, httpHelper, database, client, postLogoutRedirectURI)
 	}
 
-	// 2. Tear down, which the step above cannot prevent.
-	sessionIdentifier := ""
-	if r.Context().Value(constants.ContextKeySessionIdentifier) != nil {
-		sessionIdentifier = r.Context().Value(constants.ContextKeySessionIdentifier).(string)
-	}
-
-	userId := int64(0)
-	if len(sessionIdentifier) > 0 {
-		var err error
-		userId, err = deleteWholeUserSession(r, sessionIdentifier, database, auditLogger, authHelper)
-		if err != nil {
-			// A failed teardown is the one thing here that does deserve a 500: the End-User is
-			// still signed in and saying otherwise would be a lie. Contrast the redirect
-			// resolution above, whose failures deliberately degrade to "no redirect".
+	// 4. Tear down, which the step above cannot prevent.
+	if hint.state == hintConfirmed {
+		// Scoped to the client the hint's SIGNED aud names. client_id is never allowed to scope a
+		// teardown, because it is unauthenticated and a caller could name any client; it is trusted
+		// only for deciding whether a supplied URI is registered to the client it names, which is
+		// self-limiting (#109).
+		if err := handleExistingSessionOnLogout(r, hint.sessionIdentifier, hint.client, database, auditLogger, authHelper); err != nil {
+			// A failed teardown is the one thing here that does deserve a 500: the End-User is still
+			// signed in and saying otherwise would be a lie. Contrast the redirect resolution above,
+			// whose failures deliberately degrade to "no redirect".
 			httpHelper.InternalServerError(w, r, err)
 			return
 		}
+		// AuditLogout is emitted inside, and only when the session row itself goes, which is what this
+		// path did before the rewrite and what decision 3 keeps.
+	} else {
+		// No client to scope to, so the whole session goes (#109 decision 2).
+		sessionIdentifier := ""
+		if v := r.Context().Value(constants.ContextKeySessionIdentifier); v != nil {
+			sessionIdentifier, _ = v.(string)
+		}
+
+		userId := int64(0)
+		if len(sessionIdentifier) > 0 {
+			var err error
+			userId, err = deleteWholeUserSession(r, sessionIdentifier, database, auditLogger, authHelper)
+			if err != nil {
+				httpHelper.InternalServerError(w, r, err)
+				return
+			}
+		}
+
+		// Unconditional, as before, so a logout with no usable session still records the attempt.
+		// There being no session to end is not a failure: it may have been reaped or ended from
+		// another device, and the End-User asking to leave has got what they asked for either way.
+		auditLogger.Log(constants.AuditLogout, map[string]interface{}{
+			"userId":            userId,
+			"sessionIdentifier": sessionIdentifier,
+			"loggedInUser":      authHelper.GetLoggedInSubject(r),
+		})
 	}
 
-	// Unconditional, as before, so a logout with no usable session still records the attempt. There
-	// being no session to end is not a failure: the session may have been reaped or ended from
-	// another device, and the End-User asking to leave has got what they asked for either way.
-	auditLogger.Log(constants.AuditLogout, map[string]interface{}{
-		"userId":            userId,
-		"sessionIdentifier": sessionIdentifier,
-		"loggedInUser":      authHelper.GetLoggedInSubject(r),
-	})
-
-	// 3. Respond.
+	// 5. Respond.
 	finishLogout(w, r, httpHelper, httpSession, location, len(postLogoutRedirectURI) > 0)
+}
+
+// redirectToHintlessLogout answers a POST whose id_token_hint could not be confirmed with a 303 back
+// to the GET binding, carrying what the consent page still needs and dropping the two parameters it
+// must not have.
+//
+// Why a redirect rather than simply rendering the consent page here. The CSRF exemption the POST
+// binding needs keys on the hint being PRESENT, because middleware cannot judge whether a hint is
+// genuine. gorilla/csrf returns from its handler on that skip flag before it saves the CSRF cookie
+// and before it attaches the token, so a consent page rendered on such a request carries an empty
+// csrf.TemplateField, and its own confirming POST is hintless, therefore not exempt, therefore
+// refused. That leaves the End-User on a page they cannot submit while still signed in, which is the
+// class of defect this endpoint was rewritten to remove. The GET binding is never exempt, so the page
+// it renders has a real token and a real cookie (#109).
+//
+// id_token_hint is dropped because sending it back would land on this branch again, forever.
+// client_id is dropped because the follow-up GET is then the hint-absent shape, where client_id is
+// what authorizes a post-logout redirect: keeping it would hand the request the redirect authority a
+// rejected hint is specifically denied. With no client_id nothing validates the target, so the
+// End-User is signed out and lands on the signed-out page with the "we could not return you" note,
+// which is the intended outcome for a hint that failed to validate (#109 decision 15).
+func redirectToHintlessLogout(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper) {
+	query := url.Values{}
+	if postLogoutRedirectURI := httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri"); len(postLogoutRedirectURI) > 0 {
+		query.Set("post_logout_redirect_uri", postLogoutRedirectURI)
+	}
+	// Presence-aware, so a state supplied empty survives as "state=" and an absent one stays absent,
+	// which is the contract the consent form's hidden field keeps too (#109 decision 16).
+	if state, statePresent := httpHelper.LookupFromUrlQueryOrFormPost(r, "state"); statePresent {
+		query.Set("state", state)
+	}
+	if uiLocales := httpHelper.GetFromUrlQueryOrFormPost(r, "ui_locales"); len(uiLocales) > 0 {
+		query.Set("ui_locales", uiLocales)
+	}
+
+	location := logoutFormPath
+	if encoded := query.Encode(); len(encoded) > 0 {
+		location += "?" + encoded
+	}
+
+	// 303 rather than 302, because the browser must re-request by GET and that is what the status
+	// means: RFC 7231 section 6.4.4, "the user agent ... performing a retrieval request on the
+	// alternate URI ... using the GET method".
+	http.Redirect(w, r, location, http.StatusSeeOther)
 }
 
 // deleteWholeUserSession ends the whole OP session named by the browser's cookie and returns the
@@ -775,107 +847,6 @@ func finishLogout(
 	}
 
 	renderLoggedOut(w, r, httpHelper, targetSupplied)
-}
-
-// doLogoutWithIdToken contains the shared logic used by both GET and POST flows when an id_token_hint is provided.
-func doLogoutWithIdToken(
-	w http.ResponseWriter,
-	r *http.Request,
-	httpHelper HttpHelper,
-	httpSession sessions.Store,
-	authHelper AuthHelper,
-	database data.Database,
-	tokenParser TokenParser,
-	auditLogger AuditLogger,
-) {
-	settings := r.Context().Value(constants.ContextKeySettings).(*models.Settings)
-
-	idTokenHint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint")
-	postLogoutRedirectURI := httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri")
-	if len(postLogoutRedirectURI) == 0 {
-		renderAuthError(w, r, httpHelper, i18n.NewLocalizedError(i18n.ErrCodeLogoutPostLogoutRedirectRequired, nil))
-		return
-	}
-
-	clientId := httpHelper.GetFromUrlQueryOrFormPost(r, "client_id")
-	// A JWE-encrypted id_token_hint must be decrypted before validation. It is
-	// keyed off client_id (RP-Initiated Logout): without it we cannot know whose
-	// secret derives the key. A plain signed hint is validated as-is, whether or
-	// not client_id is present.
-	if isEncryptedIDTokenHint(idTokenHint) {
-		if len(clientId) == 0 {
-			slog.Error("logout: encrypted id_token_hint requires client_id")
-			renderAuthError(w, r, httpHelper, i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintDecryptFailed, nil))
-			return
-		}
-		var locErr *i18n.LocalizedError
-		idTokenHint, locErr = decryptIDTokenHint(idTokenHint, clientId, database)
-		if locErr != nil {
-			renderAuthError(w, r, httpHelper, locErr)
-			return
-		}
-	}
-
-	idToken, err := tokenParser.DecodeAndValidateTokenString(idTokenHint, nil, true)
-	if err != nil {
-		slog.Error("logout: id_token_hint validation failed", "err", err)
-		renderAuthError(w, r, httpHelper, i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintInvalid, nil))
-		return
-	}
-
-	issuer := idToken.GetStringClaim("iss")
-	if len(issuer) == 0 {
-		renderAuthError(w, r, httpHelper, i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintIssMissing, nil))
-		return
-	}
-	if issuer != settings.Issuer {
-		renderAuthError(w, r, httpHelper, i18n.NewLocalizedError(i18n.ErrCodeLogoutIdTokenHintIssMismatch, nil))
-		return
-	}
-
-	client, locErr := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-	if locErr != nil {
-		renderAuthError(w, r, httpHelper, locErr)
-		return
-	}
-
-	sessionIdentifier := ""
-	if r.Context().Value(constants.ContextKeySessionIdentifier) != nil {
-		sessionIdentifier = r.Context().Value(constants.ContextKeySessionIdentifier).(string)
-	}
-	// Fallback: if no session cookie/context, use sid from id_token_hint
-	if len(sessionIdentifier) == 0 {
-		if sidClaim := idToken.GetStringClaim("sid"); len(sidClaim) > 0 {
-			sessionIdentifier = sidClaim
-		}
-	}
-
-	if len(sessionIdentifier) > 0 {
-		err = handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
-		if err != nil {
-			httpHelper.InternalServerError(w, r, err)
-			return
-		}
-	}
-
-	sess, err := httpSession.Get(r, constants.AuthServerSessionName)
-	if err != nil {
-		httpHelper.InternalServerError(w, r, err)
-		return
-	}
-	sess.Values = make(map[interface{}]interface{})
-	if err = httpSession.Save(r, w, sess); err != nil {
-		httpHelper.InternalServerError(w, r, err)
-		return
-	}
-
-	state := httpHelper.GetFromUrlQueryOrFormPost(r, "state")
-	sid := sessionIdentifier
-	logoutUri := postLogoutRedirectURI + "?sid=" + sid
-	if len(state) > 0 {
-		logoutUri += "&state=" + state
-	}
-	http.Redirect(w, r, logoutUri, http.StatusFound)
 }
 
 // buildPostLogoutRedirect returns the Location value for a post-logout redirect: the

--- a/src/authserver/internal/handlers/handler_account_logout.go
+++ b/src/authserver/internal/handlers/handler_account_logout.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
-	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/encryption"
@@ -30,23 +29,83 @@ func HandleAccountLogoutGet(
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		r = refineLogoutLocale(r)
+
 		idTokenHint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint")
 
 		if len(idTokenHint) == 0 {
-
-			// if no id_token_hint is provided, render the logout consent page
-			bind := map[string]interface{}{
-				"csrfField": csrf.TemplateField(r),
-			}
-
-			err := httpHelper.RenderTemplate(w, r, "/layouts/auth_layout.html", "/logout_consent.html", bind)
-			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
-			}
+			// OpenID Connect RP-Initiated Logout 1.0 section 2 makes this a MUST: "the OP MUST ask
+			// the End-User this question if an id_token_hint was not provided". So the consent page
+			// is the response, and it deliberately precedes any teardown.
+			renderLogoutConsent(w, r, httpHelper)
 			return
 		}
 
 		doLogoutWithIdToken(w, r, httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+	}
+}
+
+// logoutFormPath is where the logout consent form posts. It duplicates the route registered in
+// internal/server/routes.go on purpose: the form needs the path WITHOUT the query string that
+// served it, so it cannot use action="" (see the comment in logout_consent.html), and taking it
+// from r.URL.Path would silently start posting somewhere else the day anything rewrites the path.
+const logoutFormPath = "/auth/logout"
+
+// refineLogoutLocale honours a ui_locales the RP sent, which the global locale middleware cannot
+// see for itself. resolveLocale in core/i18n reads r.URL.Query() only, above a comment explaining
+// that it must not call ParseForm because that would consume the request body, so it works for a
+// GET and for nothing else. r.FormValue reads the query and the body, so this one call covers all
+// three shapes /auth/logout has: a GET carrying ?ui_locales, the consent form posting it back as a
+// hidden field, and an RP posting it directly in a body.
+//
+// Without this, a consent page rendered in the locale the RP asked for would be followed by a
+// signed-out page in a different one, because the confirming POST carries the parameter in its body
+// (#109). Same pattern as HandleAuthorizeGet, and the return value must be assigned.
+func refineLogoutLocale(r *http.Request) *http.Request {
+	if uiLocales := i18n.SanitizeUILocales(r.FormValue("ui_locales")); len(uiLocales) > 0 {
+		return i18n.RefineLocalizerWithUILocales(r, uiLocales)
+	}
+	return r
+}
+
+// renderLogoutConsent renders the logout consent page, carrying forward the parameters the
+// confirming POST needs and NOT the id_token_hint. See logout_consent.html for why the hint is
+// dropped and why state is treated differently from the other three.
+func renderLogoutConsent(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper) {
+	state, statePresent := httpHelper.LookupFromUrlQueryOrFormPost(r, "state")
+
+	bind := map[string]interface{}{
+		"csrfField":             csrf.TemplateField(r),
+		"formAction":            logoutFormPath,
+		"postLogoutRedirectUri": httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri"),
+		"clientId":              httpHelper.GetFromUrlQueryOrFormPost(r, "client_id"),
+		"state":                 state,
+		"statePresent":          statePresent,
+		"uiLocales":             httpHelper.GetFromUrlQueryOrFormPost(r, "ui_locales"),
+	}
+
+	err := httpHelper.RenderTemplate(w, r, "/layouts/auth_layout.html", "/logout_consent.html", bind)
+	if err != nil {
+		httpHelper.InternalServerError(w, r, err)
+	}
+}
+
+// renderLoggedOut renders the terminal page for a logout that completed without redirecting the
+// End-User anywhere. Every shape that tears down but has no redirect target ends here: a hinted
+// request that sent no post_logout_redirect_uri, a hintless confirmation, and a target the spec
+// forbids redirecting to.
+//
+// redirectDeclined adds one sentence, and only when a target was supplied and refused. It names no
+// failed check, so it tells the End-User why they are looking at Goiabada instead of their
+// application without disclosing which URIs are registered (#109).
+func renderLoggedOut(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper, redirectDeclined bool) {
+	bind := map[string]interface{}{
+		"redirectDeclined": redirectDeclined,
+	}
+
+	err := httpHelper.RenderTemplate(w, r, "/layouts/auth_layout.html", "/logged_out.html", bind)
+	if err != nil {
+		httpHelper.InternalServerError(w, r, err)
 	}
 }
 
@@ -202,6 +261,8 @@ func HandleAccountLogoutPost(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		r = refineLogoutLocale(r)
+
 		// If id_token_hint is present in the POST body, handle same as GET flow
 		if hint := httpHelper.GetFromUrlQueryOrFormPost(r, "id_token_hint"); len(hint) > 0 {
 			// Use a fresh token parser based on database
@@ -210,47 +271,244 @@ func HandleAccountLogoutPost(
 			return
 		}
 
-		sess, err := httpSession.Get(r, constants.AuthServerSessionName)
-		if err != nil {
-			httpHelper.InternalServerError(w, r, err)
-			return
-		}
-
-		sessionIdentifier := ""
-		if r.Context().Value(constants.ContextKeySessionIdentifier) != nil {
-			sessionIdentifier = r.Context().Value(constants.ContextKeySessionIdentifier).(string)
-		}
-
-		userId := int64(0)
-
-		if len(sessionIdentifier) > 0 {
-			userSession, err := database.GetUserSessionBySessionIdentifier(nil, sessionIdentifier)
-			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
-				return
-			}
-
-			if userSession != nil {
-				userId = userSession.UserId
-			}
-		}
-
-		// clear the session state
-		sess.Values = make(map[interface{}]interface{})
-		err = httpSession.Save(r, w, sess)
-		if err != nil {
-			httpHelper.InternalServerError(w, r, err)
-			return
-		}
-
-		auditLogger.Log(constants.AuditLogout, map[string]interface{}{
-			"userId":            userId,
-			"sessionIdentifier": sessionIdentifier,
-			"loggedInUser":      authHelper.GetLoggedInSubject(r),
-		})
-
-		http.Redirect(w, r, config.GetAuthServer().BaseURL, http.StatusFound)
+		doLogoutWithoutIdToken(w, r, httpHelper, httpSession, authHelper, database, auditLogger)
 	}
+}
+
+// doLogoutWithoutIdToken logs the End-User out on a request that named no id_token_hint. Reaching
+// here on a POST means the confirming submission of the consent page, since that page is what a
+// hintless GET renders and the CSRF token it carries is what proves the request came from it.
+//
+// The three steps run in this order and, crucially, the second reads nothing the first produced.
+// That independence is the whole fix for #109's first item: every error path in this endpoint used
+// to return before both the teardown and the cookie wipe, so a request the OP considered malformed
+// rendered a page saying so and left the user signed in. Whether a redirect can be honoured is now
+// only ever a question about the response, never about whether the logout happens.
+func doLogoutWithoutIdToken(
+	w http.ResponseWriter,
+	r *http.Request,
+	httpHelper HttpHelper,
+	httpSession sessions.Store,
+	authHelper AuthHelper,
+	database data.Database,
+	auditLogger AuditLogger,
+) {
+	// 1. Resolve the redirect target. With no hint to read a signed aud from, the only thing that
+	// can authorize a target is client_id, which is the parameter's documented primary purpose:
+	// RP-Initiated Logout 1.0 section 2 says "The most common use case for this parameter is to
+	// specify the Client Identifier when post_logout_redirect_uri is used but id_token_hint is not."
+	// That is the "other means of confirming the legitimacy of the post-logout redirection target"
+	// section 3 requires before an OP may redirect.
+	postLogoutRedirectURI := httpHelper.GetFromUrlQueryOrFormPost(r, "post_logout_redirect_uri")
+	location := ""
+	if len(postLogoutRedirectURI) > 0 {
+		clientId := httpHelper.GetFromUrlQueryOrFormPost(r, "client_id")
+		client := clientForPostLogoutRedirect(clientId, database)
+		location = postLogoutRedirectLocation(r, httpHelper, database, client, postLogoutRedirectURI)
+	}
+
+	// 2. Tear down, which the step above cannot prevent.
+	sessionIdentifier := ""
+	if r.Context().Value(constants.ContextKeySessionIdentifier) != nil {
+		sessionIdentifier = r.Context().Value(constants.ContextKeySessionIdentifier).(string)
+	}
+
+	userId := int64(0)
+	if len(sessionIdentifier) > 0 {
+		var err error
+		userId, err = deleteWholeUserSession(r, sessionIdentifier, database, auditLogger, authHelper)
+		if err != nil {
+			// A failed teardown is the one thing here that does deserve a 500: the End-User is
+			// still signed in and saying otherwise would be a lie. Contrast the redirect
+			// resolution above, whose failures deliberately degrade to "no redirect".
+			httpHelper.InternalServerError(w, r, err)
+			return
+		}
+	}
+
+	// Unconditional, as before, so a logout with no usable session still records the attempt. There
+	// being no session to end is not a failure: the session may have been reaped or ended from
+	// another device, and the End-User asking to leave has got what they asked for either way.
+	auditLogger.Log(constants.AuditLogout, map[string]interface{}{
+		"userId":            userId,
+		"sessionIdentifier": sessionIdentifier,
+		"loggedInUser":      authHelper.GetLoggedInSubject(r),
+	})
+
+	// 3. Respond.
+	finishLogout(w, r, httpHelper, httpSession, location, len(postLogoutRedirectURI) > 0)
+}
+
+// deleteWholeUserSession ends the whole OP session named by the browser's cookie and returns the
+// user it belonged to, or 0 when there was no such row.
+//
+// Whole-session, not per-client, because a request that named no client has nothing to scope a
+// per-client teardown to. Deleting the row is what stops the session-bound refresh tokens
+// immediately, since RequireValidSession resolves it; offline grants survive, which is OIDC Core
+// section 11's reading and the one #129 adopted for the hinted path. The child rows in
+// user_session_clients go with the parent on every engine, on the fk_user_sessions_clients cascade
+// that TerminateUserSessionTx already relies on.
+//
+// A lookup or delete failure is returned so the caller can surface a 500; a row that is simply not
+// there is not an error, it is nothing to tear down. Those two used to be one branch returning a
+// variable that was sometimes nil to mean both (#109 item 4).
+func deleteWholeUserSession(
+	r *http.Request,
+	sessionIdentifier string,
+	database data.Database,
+	auditLogger AuditLogger,
+	authHelper AuthHelper,
+) (int64, error) {
+	userSession, err := database.GetUserSessionBySessionIdentifier(nil, sessionIdentifier)
+	if err != nil {
+		return 0, err
+	}
+	if userSession == nil {
+		return 0, nil
+	}
+
+	if err := database.DeleteUserSession(nil, userSession.Id); err != nil {
+		return 0, err
+	}
+
+	auditLogger.Log(constants.AuditDeletedUserSession, map[string]interface{}{
+		"userSessionId": userSession.Id,
+		"loggedInUser":  authHelper.GetLoggedInSubject(r),
+	})
+
+	return userSession.UserId, nil
+}
+
+// clientForPostLogoutRedirect resolves the client whose registered URIs may authorize a post-logout
+// redirect for a request that carried no confirmable id_token_hint. Returns nil for a client_id that
+// is absent, unknown or unreadable, and nil means no redirect.
+//
+// client_id is unauthenticated, so a caller can name any client. It is trusted for exactly one
+// thing, deciding whether a supplied URI is registered to the client it names, which is
+// self-limiting because the URI has to be in that client's set already. It is never allowed to
+// scope a teardown: only an id_token_hint, whose aud is signed, does that.
+//
+// A database failure here returns nil rather than propagating, which is deliberate. This runs before
+// the teardown, so turning it into a 500 would put the End-User back on a terminal page while still
+// signed in, which is the defect #109 exists to remove. Losing a redirect is the safe direction; the
+// reason is logged.
+func clientForPostLogoutRedirect(clientId string, database data.Database) *models.Client {
+	if len(clientId) == 0 {
+		// RP-Initiated Logout 1.0 section 3: "if it is not supplied with post_logout_redirect_uri,
+		// the OP MUST NOT perform post-logout redirection unless the OP has other means of
+		// confirming the legitimacy of the post-logout redirection target". With neither a hint nor
+		// a client_id there are no such means.
+		slog.Warn("logout: post_logout_redirect_uri supplied with no id_token_hint and no client_id, not redirecting")
+		return nil
+	}
+
+	client, err := database.GetClientByClientIdentifier(nil, clientId)
+	if err != nil {
+		slog.Error("logout: client lookup failed, not redirecting", "clientId", clientId, "err", err)
+		return nil
+	}
+	if client == nil {
+		slog.Warn("logout: client_id names no client, not redirecting", "clientId", clientId)
+		return nil
+	}
+
+	return client
+}
+
+// postLogoutRedirectLocation returns the Location value for the post-logout redirect, or "" when the
+// request has not earned one. A nil client always returns "", which is how a rejected id_token_hint
+// is denied a redirect however valid the client_id beside it looks.
+//
+// The match is exact, as OpenID Connect RP-Initiated Logout 1.0 section 2 requires ("The OP also
+// MUST NOT perform post-logout redirection if the post_logout_redirect_uri value supplied does not
+// exactly match one of the previously registered post_logout_redirect_uris values") and as RFC 9700
+// section 2.1 requires of redirect URIs generally.
+//
+// Goiabada has no separate post_logout_redirect_uris client metadata, so the set matched against is
+// the client's OAuth redirect URIs. The spec permits that: the value "MUST have been previously
+// registered with the OP, either using the post_logout_redirect_uris Registration parameter or via
+// other mechanisms". Registering the two separately is tracked as its own change.
+func postLogoutRedirectLocation(
+	r *http.Request,
+	httpHelper HttpHelper,
+	database data.Database,
+	client *models.Client,
+	postLogoutRedirectURI string,
+) string {
+	if client == nil {
+		return ""
+	}
+
+	if err := database.ClientLoadRedirectURIs(nil, client); err != nil {
+		slog.Error("logout: load redirect URIs failed, not redirecting",
+			"clientIdentifier", client.ClientIdentifier, "err", err)
+		return ""
+	}
+
+	registered := false
+	for _, uri := range client.RedirectURIs {
+		if uri.URI == postLogoutRedirectURI {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		slog.Warn("logout: post_logout_redirect_uri is not registered for this client, not redirecting",
+			"clientIdentifier", client.ClientIdentifier)
+		return ""
+	}
+
+	// Presence-aware, because "state=" and no state at all are different requests and the RP can
+	// tell the difference in what comes back.
+	state, statePresent := httpHelper.LookupFromUrlQueryOrFormPost(r, "state")
+	location, err := buildPostLogoutRedirect(postLogoutRedirectURI, state, statePresent)
+	if err != nil {
+		slog.Error("logout: could not build the post-logout redirect, not redirecting",
+			"clientIdentifier", client.ClientIdentifier, "err", err)
+		return ""
+	}
+
+	return location
+}
+
+// finishLogout clears the OP session cookie and writes the terminal response.
+//
+// The cookie wipe is unconditional and covers the whole session even when the database teardown was
+// scoped to one client. That asymmetry is deliberate and worth stating, because it looks like an
+// oversight: the RP asked the OP to log the End-User out, and the cookie IS the OP session, so
+// leaving the session identifier in it would keep the user signed in at the OP right after they
+// asked to be signed out. The per-client database teardown stays per-client because #129 decided
+// grants survive logout. The residue is that while other clients remain on the session, the row
+// outlives the browser's ability to reach it until the idle reaper takes it; cutting those clients'
+// tokens off properly needs client-scoped revocation, which is #135's job.
+//
+// redirectDeclined is passed through rather than derived from location being empty, so the signed-out
+// page can tell "no target was asked for" from "a target was asked for and refused".
+func finishLogout(
+	w http.ResponseWriter,
+	r *http.Request,
+	httpHelper HttpHelper,
+	httpSession sessions.Store,
+	location string,
+	targetSupplied bool,
+) {
+	sess, err := httpSession.Get(r, constants.AuthServerSessionName)
+	if err != nil {
+		httpHelper.InternalServerError(w, r, err)
+		return
+	}
+	sess.Values = make(map[interface{}]interface{})
+	if err := httpSession.Save(r, w, sess); err != nil {
+		httpHelper.InternalServerError(w, r, err)
+		return
+	}
+
+	if len(location) > 0 {
+		http.Redirect(w, r, location, http.StatusFound)
+		return
+	}
+
+	renderLoggedOut(w, r, httpHelper, targetSupplied)
 }
 
 // doLogoutWithIdToken contains the shared logic used by both GET and POST flows when an id_token_hint is provided.

--- a/src/authserver/internal/handlers/handler_account_logout_test.go
+++ b/src/authserver/internal/handlers/handler_account_logout_test.go
@@ -19,7 +19,6 @@ import (
 	mocks_sessionstore "github.com/leodip/goiabada/core/sessionstore/mocks"
 
 	"github.com/gorilla/sessions"
-	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/i18n"
@@ -73,7 +72,7 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
 		req = req.WithContext(ctx)
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", req, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return("")
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "client_id").Return("")
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "ui_locales").Return("")
@@ -106,7 +105,7 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", req, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return("https://example.com/out")
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "client_id").Return("test_client")
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "ui_locales").Return("pt-BR")
@@ -157,6 +156,7 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 				req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
 
 				httpHelper.On("GetFromUrlQueryOrFormPost", req, mock.Anything).Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", req, "id_token_hint").Return("", false)
 				httpHelper.On("LookupFromUrlQueryOrFormPost", req, "state").Return(tc.value, tc.present)
 
 				var bound map[string]interface{}
@@ -191,6 +191,7 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
 
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, mock.Anything).Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("", false)
 		httpHelper.On("RenderTemplate", rr, mock.MatchedBy(func(rendered *http.Request) bool {
 			return i18n.T(rendered.Context(), "logout_consent.title") == "Sair"
@@ -201,7 +202,11 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		httpHelper.AssertExpectations(t)
 	})
 
-	t.Run("No postLogoutRedirectURI given", func(t *testing.T) {
+	// Item 1, the defect this issue is named for, at the seam where it is visible.
+	// post_logout_redirect_uri is OPTIONAL, and the check that treated it as required returned before
+	// both the database teardown and the cookie wipe, so the most ordinary conforming request in the
+	// specification rendered an error page and left the End-User signed in.
+	t.Run("A confirmed hint with no post_logout_redirect_uri still logs the user out", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
@@ -211,75 +216,36 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 
 		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint=sometoken", nil)
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
 		rr := httptest.NewRecorder()
 
-		settings := &models.Settings{}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
+		client := stubConfirmedHint(httpHelper, database, tokenParser, hintedClaims())
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return("sometoken")
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return("")
-		httpHelper.On("RenderTemplate", rr, req, "/layouts/no_menu_layout.html", "/auth_error.html", mock.MatchedBy(func(data map[string]interface{}) bool {
-			title, hasTitle := data["title"].(string)
-			error, hasError := data["error"].(string)
-			return hasTitle && title == "Logout error" &&
-				hasError && error == "The post_logout_redirect_uri parameter is required. This parameter must match one of the redirect URIs that was registered for this client."
-		})).Return(nil)
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+			mock.MatchedBy(func(data map[string]interface{}) bool {
+				return data["redirectDeclined"] == false
+			})).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-	})
-
-	t.Run("Fails to parse encrypted idTokenHint as JWE", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
-		assert.Nil(t, err)
-
-		// A 5-segment token is detected as a JWE, but this one is malformed, so
-		// JWE parsing fails and the handler reports a decrypt failure.
-		idTokenHint := "not.a.valid.jwe.token"
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHint)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		settings := &models.Settings{}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHint)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(&models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-		}, nil)
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html", mock.MatchedBy(func(data map[string]interface{}) bool {
-			errorMsg, ok := data["error"].(string)
-			return ok && strings.Contains(errorMsg, "Failed to decrypt the id_token_hint.")
-		})).Return(nil)
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, rr.Header().Get("Location"))
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+		httpHelper.AssertNotCalled(t, "InternalServerError", mock.Anything, mock.Anything, mock.Anything)
 		httpHelper.AssertExpectations(t)
 		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		httpSession.AssertExpectations(t)
 	})
 
-	t.Run("Fails to decrypt idTokenHint", func(t *testing.T) {
+	// The ordinary success, and the two parameters it turns on: state reaches the RP byte-identical
+	// through url.Values rather than concatenation, and sid does not reach it at all. RP-Initiated
+	// Logout 1.0 defines exactly one parameter on the way back, and sid belongs to Front-Channel
+	// Logout, a different endpoint travelling the other way (decisions 5 and 16).
+	t.Run("A confirmed hint tears down per client and redirects", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
@@ -289,510 +255,228 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 
 		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
-		assert.Nil(t, err)
-
-		// A structurally valid JWE, but encrypted with a different secret than the
-		// client's, so authenticated decryption fails.
-		idTokenHint := encryptIDTokenHintForTest(t, "some_id_token", "a-different-client-secret")
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHint)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
 		rr := httptest.NewRecorder()
 
-		settings := &models.Settings{}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHint)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html",
-			mock.MatchedBy(func(bind map[string]interface{}) bool {
-				errorMsg, ok := bind["error"].(string)
-				return ok && strings.Contains(errorMsg, "Failed to decrypt the id_token_hint")
-			})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("Token parser fails to validate id token", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		settings := &models.Settings{}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).
-			Return(nil, errors.New("some error")).Once()
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html",
-			mock.MatchedBy(func(bind map[string]interface{}) bool {
-				errorMsg, ok := bind["error"].(string)
-				return ok && strings.Contains(errorMsg, "The id_token_hint parameter is invalid.")
-			})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		database.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-	})
-
-	t.Run("Issuer does not match", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{
-			Issuer: config.GetAuthServer().BaseURL,
-		}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-			ClientIdentifier:      "someclientid",
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": "http://wrong-issuer.com",
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html",
-			mock.MatchedBy(func(bind map[string]interface{}) bool {
-				errorMsg, ok := bind["error"].(string)
-				return ok && strings.Contains(errorMsg, "The id_token_hint parameter is invalid: the iss claim does not match the issuer of this server.")
-			})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("Aud claim does not match any client", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{
-			Issuer: config.GetAuthServer().BaseURL,
-		}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-			ClientIdentifier:      "someclientid",
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": config.GetAuthServer().BaseURL,
-				"aud": "non_existent_client_id",
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-		database.On("GetClientByClientIdentifier", mock.Anything, "non_existent_client_id").Return(nil, nil)
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html",
-			mock.MatchedBy(func(bind map[string]interface{}) bool {
-				errorMsg, ok := bind["error"].(string)
-				return ok && strings.Contains(errorMsg, "Invalid client.")
-			})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("Post logout redirect URI not authorized", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		unauthorizedRedirectURI := "http://unauthorized-redirect.com"
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri="+url.QueryEscape(unauthorizedRedirectURI)+"&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{
-			Issuer: config.GetAuthServer().BaseURL,
-		}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-			ClientIdentifier:      "someclientid",
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return(unauthorizedRedirectURI)
-		httpHelper.On("GetFromUrlQueryOrFormPost", req, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": config.GetAuthServer().BaseURL,
-				"aud": "someclientid",
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			client := args.Get(1).(*models.Client)
-			client.RedirectURIs = []models.RedirectURI{
-				{URI: "http://authorized-redirect.com"},
-			}
-		}).Return(nil)
-
-		httpHelper.On("RenderTemplate", mock.Anything, mock.Anything, "/layouts/no_menu_layout.html", "/auth_error.html",
-			mock.MatchedBy(func(bind map[string]interface{}) bool {
-				errorMsg, ok := bind["error"].(string)
-				return ok && strings.Contains(errorMsg, "Invalid post_logout_redirect_uri")
-			})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("SessionIdentifier exists but sid claim is missing from ID token", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{
-			Issuer: config.GetAuthServer().BaseURL,
-		}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, "existing-session-id")
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			ClientSecretEncrypted: clientSecretEncrypted,
-			ClientIdentifier:      "someclientid",
-		}
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": config.GetAuthServer().BaseURL,
-				"aud": "someclientid",
-				// Note: 'sid' claim is intentionally missing
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			client := args.Get(1).(*models.Client)
-			client.RedirectURIs = []models.RedirectURI{
-				{URI: "http://example.com"},
-			}
-		}).Return(nil)
-
-		httpHelper.On("InternalServerError", mock.Anything, mock.Anything, mock.MatchedBy(func(err error) bool {
-			return err != nil && err.Error() == "Invalid session identifier in id_token_hint"
-		})).Return(nil).Once()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("Sid claim does not match", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{Issuer: config.GetAuthServer().BaseURL}
-		ctx := context.WithValue(req.Context(), constants.ContextKeySettings, settings)
-		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, "existing-session-id")
-		req = req.WithContext(ctx)
-
-		client := &models.Client{ClientSecretEncrypted: clientSecretEncrypted, ClientIdentifier: "someclientid"}
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": config.GetAuthServer().BaseURL,
-				"aud": "someclientid",
-				"sid": "some-other-session-id",
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			client := args.Get(1).(*models.Client)
-			client.RedirectURIs = []models.RedirectURI{{URI: "http://example.com"}}
-		}).Return(nil)
-
-		httpHelper.On("InternalServerError", mock.Anything, mock.Anything, mock.MatchedBy(func(err error) bool {
-			return err != nil && err.Error() == "Invalid session identifier in id_token_hint"
-		})).Return(nil).Once()
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
-		database.AssertExpectations(t)
-	})
-
-	t.Run("Successful logout with DeleteUserSession call", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		tokenParser := mocks_oauth.NewTokenParser(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
-
-		clientSecret := "some_client_secret"
-		clientSecretEncrypted, _ := encryption.EncryptData(clientSecret)
-
-		idTokenHint := "some_id_token"
-		idTokenHintEncryptedBase64 := encryptIDTokenHintForTest(t, idTokenHint, clientSecret)
-
-		sessionIdentifier := "existing-session-id"
-		req, _ := http.NewRequest("GET", "/logout?id_token_hint="+url.QueryEscape(idTokenHintEncryptedBase64)+"&post_logout_redirect_uri=http://example.com&client_id=someclientid&state=abc123", nil)
-		rr := httptest.NewRecorder()
-
-		config.GetAuthServer().BaseURL = "http://correct-issuer.com"
-		settings := &models.Settings{
-			Issuer: config.GetAuthServer().BaseURL,
-		}
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
-		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)
-		req = req.WithContext(ctx)
-
-		client := &models.Client{
-			Id:                    1,
-			ClientSecretEncrypted: clientSecretEncrypted,
-			ClientIdentifier:      "someclientid",
-		}
-		database.On("GetClientByClientIdentifier", mock.Anything, "someclientid").Return(client, nil)
-
-		mockIdToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"iss": config.GetAuthServer().BaseURL,
-				"aud": "someclientid",
-				"sid": sessionIdentifier,
-			},
-		}
-
-		tokenParser.On("DecodeAndValidateTokenString", idTokenHint, (*rsa.PublicKey)(nil), true).Return(mockIdToken, nil)
-
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			client := args.Get(1).(*models.Client)
-			client.RedirectURIs = []models.RedirectURI{
-				{URI: "http://example.com"},
-			}
-		}).Return(nil)
-
-		userSession := &models.UserSession{
-			Id:     1,
-			UserId: 123,
-			Clients: []models.UserSessionClient{
-				{
-					Id:       1,
-					ClientId: 1,
-					Client:   *client,
-				},
-			},
-		}
-		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
-		database.On("UserSessionLoadClients", mock.Anything, userSession).Return(nil)
-		database.On("UserSessionClientsLoadClients", mock.Anything, userSession.Clients).Return(nil)
-		database.On("DeleteUserSessionClient", mock.Anything, int64(1)).Return(nil)
-		database.On("DeleteUserSession", mock.Anything, int64(1)).Return(nil)
-
-		auditLogger.On("Log", constants.AuditDeletedUserSessionClient, mock.Anything).Return()
-		auditLogger.On("Log", constants.AuditLogout, mock.Anything).Return()
-
-		mockSession := &sessions.Session{
-			Values: make(map[interface{}]interface{}),
-		}
-		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(mockSession, nil)
-		httpSession.On("Save", mock.Anything, mock.Anything, mockSession).Return(nil)
-
-		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
-
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(idTokenHintEncryptedBase64)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("http://example.com")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("someclientid")
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "state").Return("abc-123")
+		client := stubConfirmedHint(httpHelper, database, tokenParser, hintedClaims())
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(hintedRegisteredURI)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("aB+cd/efgh==#&x=1", true)
+		stubRegisteredURI(database, client, hintedRegisteredURI)
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
+
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
 
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusFound, rr.Code)
-		assert.Contains(t, rr.Header().Get("Location"), "http://example.com?sid="+sessionIdentifier+"&state=abc-123")
-
+		location, err := url.Parse(rr.Header().Get("Location"))
+		assert.NoError(t, err)
+		assert.Equal(t, hintedRegisteredURI, location.Scheme+"://"+location.Host+location.Path)
+		assert.Equal(t, []string{"aB+cd/efgh==#&x=1"}, location.Query()["state"],
+			"exactly one state, byte-identical to what the RP sent")
+		assert.Empty(t, location.Query().Get("sid"),
+			"sid is not a parameter RP-initiated logout defines, decision 5")
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
 		httpHelper.AssertExpectations(t)
-		tokenParser.AssertExpectations(t)
 		database.AssertExpectations(t)
-		auditLogger.AssertExpectations(t)
 		httpSession.AssertExpectations(t)
-		authHelper.AssertExpectations(t)
+	})
+
+	// The confirmed half of "whether a redirect can be honoured is a question about the response". The
+	// hintless half of this property has its own table above; this row is what says the hinted path
+	// answers it the same way rather than returning before the teardown as all seven of its error
+	// paths used to.
+	t.Run("A confirmed hint whose target is unregistered is declined, and the logout still happens", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
+		rr := httptest.NewRecorder()
+
+		client := stubConfirmedHint(httpHelper, database, tokenParser, hintedClaims())
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").
+			Return("https://example.com/somewhere-else")
+		stubRegisteredURI(database, client, hintedRegisteredURI)
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
+
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+			mock.MatchedBy(func(data map[string]interface{}) bool {
+				return data["redirectDeclined"] == true
+			})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, rr.Header().Get("Location"), "a declined target must never become a redirect")
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+		httpHelper.AssertNotCalled(t, "InternalServerError", mock.Anything, mock.Anything, mock.Anything)
+		database.AssertExpectations(t)
+		httpHelper.AssertExpectations(t)
+	})
+
+	// Divergence C, which is by design rather than a defect: an RP may end a session with a hint alone
+	// and no cookie in play, which is what makes RP-initiated logout work from a relying party that
+	// cannot reach the End-User's browser session. The hint's own sid then names the session, and the
+	// teardown is still scoped to the client the hint is signed over.
+	t.Run("A confirmed hint with no browser session tears down the session its sid names", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, "")
+		rr := httptest.NewRecorder()
+
+		client := stubConfirmedHint(httpHelper, database, tokenParser, hintedClaims())
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
+
+		expectCookieWipedBeforeSave(t, httpSession)
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+			mock.Anything).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		database.AssertExpectations(t)
+	})
+
+	// Decision 14, at the seam where the consequence is visible rather than the classification. The
+	// admin console mints a 60-second hint, so an operator who pauses on the way through arrives here
+	// with an expired one; the spec says to accept it while the session it names is still alive, and
+	// what that has to buy is the same per-client teardown and the same redirect a fresh hint gets.
+	t.Run("An expired hint whose session is still live is honoured in full", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
+		rr := httptest.NewRecorder()
+
+		claims := hintedClaims()
+		claims["exp"] = float64(time.Now().UTC().Add(-1 * time.Minute).Unix())
+
+		client := stubConfirmedHint(httpHelper, database, tokenParser, claims)
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(hintedRegisteredURI)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("abc", true)
+		stubRegisteredURI(database, client, hintedRegisteredURI)
+		// The tolerance lookup and the teardown read the same row through the same call, which is one
+		// of the reasons a database fault there propagates rather than being read as "no such session".
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
+
+		expectCookieWipedBeforeSave(t, httpSession)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, "abc", mustParseURL(t, rr.Header().Get("Location")).Query().Get("state"))
+		database.AssertExpectations(t)
+	})
+
+	// The one classification failure that is not a rejection. A database fault while deciding whether
+	// an expired hint's session is still alive has a different answer from a row that is not there:
+	// reading it as "no such session" would decide whether the hint is honoured on the database's
+	// health, and silently widen the teardown at the same time.
+	t.Run("A database fault while judging an expired hint is a 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
+		rr := httptest.NewRecorder()
+
+		claims := hintedClaims()
+		claims["exp"] = float64(time.Now().UTC().Add(-1 * time.Minute).Unix())
+
+		stubConfirmedHint(httpHelper, database, tokenParser, claims)
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, hintedSessionId).
+			Return(nil, errors.New("the database is on fire"))
+
+		httpHelper.On("InternalServerError", mock.Anything, mock.Anything,
+			mock.MatchedBy(func(err error) bool { return err.Error() == "the database is on fire" })).
+			Run(func(args mock.Arguments) {
+				args.Get(0).(http.ResponseWriter).WriteHeader(http.StatusInternalServerError)
+			}).Return()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		database.AssertNotCalled(t, "DeleteUserSessionClient", mock.Anything, mock.Anything)
+		database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+		httpHelper.AssertExpectations(t)
+	})
+
+	// Decision 15, and the case §5 warns can pass for the wrong reason. The client_id here names a
+	// DIFFERENT client from the aud the hint is signed over, which rejects the hint, and a rejected
+	// hint earns no redirect however good that client_id looks. The target supplied is one this
+	// server would accept from a hintless request, so the case fails for the reason it names rather
+	// than because the URI was unregistered.
+	//
+	// What makes the redirect impossible is that client_id does not survive the consent hop: the
+	// confirming POST is hintless by design, so a client_id carried forward would authorize the
+	// target and the detected error would become a redirect after all. The parameter is not even
+	// read, which is what the AssertNotCalled below pins.
+	t.Run("A rejected hint reaches the consent page without its client_id", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodGet, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
+		rr := httptest.NewRecorder()
+
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(hintedToken, true)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("another_client", true)
+		tokenParser.On("DecodeAndValidateTokenString", hintedToken, (*rsa.PublicKey)(nil), false).
+			Return(&oauth.JwtToken{TokenBase64: hintedToken, Claims: hintedClaims()}, nil)
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(hintedRegisteredURI)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("abc", true)
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "ui_locales").Return("")
+
+		var bound map[string]interface{}
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logout_consent.html",
+			mock.MatchedBy(func(data map[string]interface{}) bool {
+				bound = data
+				return true
+			})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "", bound["clientId"],
+			"a rejected hint's client_id must not survive the consent hop, or it authorizes the redirect decision 15 denies")
+		assert.Equal(t, hintedRegisteredURI, bound["postLogoutRedirectUri"],
+			"the target still travels, so the signed-out page can say a return was attempted and refused")
+		httpHelper.AssertNotCalled(t, "GetFromUrlQueryOrFormPost", mock.Anything, "client_id")
+		database.AssertNotCalled(t, "DeleteUserSessionClient", mock.Anything, mock.Anything)
+		database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+		httpHelper.AssertExpectations(t)
 	})
 }
 
@@ -843,8 +527,8 @@ func TestDecryptIDTokenHint(t *testing.T) {
 
 		_, err := decryptIDTokenHint("a.b.c.d.e", "invalid_client", database)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutInvalidClient, err.Code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client_id names no client")
 	})
 
 	t.Run("Not a valid JWE", func(t *testing.T) {
@@ -857,8 +541,8 @@ func TestDecryptIDTokenHint(t *testing.T) {
 
 		_, err := decryptIDTokenHint("not.a.valid.jwe.token", "test_client", database)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutIdTokenHintDecryptFailed, err.Code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to decrypt the id_token_hint")
 	})
 
 	t.Run("Decryption failure (wrong key)", func(t *testing.T) {
@@ -874,172 +558,61 @@ func TestDecryptIDTokenHint(t *testing.T) {
 
 		_, err := decryptIDTokenHint(jwe, "test_client", database)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutIdTokenHintDecryptFailed, err.Code)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to decrypt the id_token_hint")
 	})
 }
 
-func TestValidateClientAndRedirectURI(t *testing.T) {
-	t.Run("Valid client and redirect URI", func(t *testing.T) {
-		database := mocks_data.NewDatabase(t)
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"aud": "test_client",
-			},
-		}
-		postLogoutRedirectURI := "https://example.com/logout"
-		clientId := "test_client"
-
-		client := &models.Client{
-			ClientIdentifier: "test_client",
-			RedirectURIs: []models.RedirectURI{
-				{URI: "https://example.com/logout"},
-			},
-		}
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			// RedirectURIs are already set, so we don't need to do anything here
-		}).Return(nil)
-
-		result, err := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-
-		assert.Nil(t, err)
-		assert.Equal(t, client, result)
-	})
-
-	t.Run("Missing aud claim", func(t *testing.T) {
-		database := mocks_data.NewDatabase(t)
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{},
-		}
-		postLogoutRedirectURI := "https://example.com/logout"
-		clientId := "test_client"
-
-		_, err := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutAudClaimMissing, err.Code)
-	})
-
-	t.Run("Invalid client", func(t *testing.T) {
-		database := mocks_data.NewDatabase(t)
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"aud": "invalid_client",
-			},
-		}
-		postLogoutRedirectURI := "https://example.com/logout"
-		clientId := "invalid_client"
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "invalid_client").Return(nil, nil)
-
-		_, err := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutInvalidClient, err.Code)
-	})
-
-	t.Run("Mismatched client_id", func(t *testing.T) {
-		database := mocks_data.NewDatabase(t)
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"aud": "test_client",
-			},
-		}
-		postLogoutRedirectURI := "https://example.com/logout"
-		clientId := "different_client"
-
-		// Set up mock for GetClientByClientIdentifier
-		client := &models.Client{
-			ClientIdentifier: "test_client",
-		}
-		database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
-
-		_, err := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutClientIdMismatch, err.Code)
-	})
-
-	t.Run("Invalid redirect URI", func(t *testing.T) {
-		database := mocks_data.NewDatabase(t)
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"aud": "test_client",
-			},
-		}
-		postLogoutRedirectURI := "https://example.com/invalid"
-		clientId := "test_client"
-
-		client := &models.Client{
-			ClientIdentifier: "test_client",
-			RedirectURIs: []models.RedirectURI{
-				{URI: "https://example.com/logout"},
-			},
-		}
-
-		database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
-		database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
-			// RedirectURIs are already set, so we don't need to do anything here
-		}).Return(nil)
-
-		_, err := validateClientAndRedirectURI(idToken, postLogoutRedirectURI, database, clientId)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, i18n.ErrCodeLogoutInvalidPostLogoutRedirect, err.Code)
-	})
-}
-
+// TestHandleExistingSessionOnLogout covers the per-client teardown a confirmed id_token_hint earns.
+//
+// The sid guard this function used to open with is gone, and so is the subtest that pinned it:
+// whether the hint names the browser's session is part of whether the hint can be confirmed at all,
+// and classifyIdTokenHint owns that with an exhaustive table. Deciding it here meant returning an
+// error the caller turned into a 500, which is what a user whose session had merely been reaped or
+// replaced saw (#109 decision 11).
 func TestHandleExistingSessionOnLogout(t *testing.T) {
-	t.Run("Invalid session identifier", func(t *testing.T) {
+
+	// Item 4. A database error and a session that is simply not there used to be one branch returning
+	// a variable that was sometimes nil to mean both, so a failing lookup completed the logout as
+	// though there had been nothing to tear down. They have different answers and both are pinned.
+	t.Run("The session lookup fails", func(t *testing.T) {
 		r := &http.Request{}
-		sessionIdentifier := "test-session"
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"sid": "different-session",
-			},
-		}
-		client := &models.Client{}
 		database := mocks_data.NewDatabase(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 
-		err := handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").
+			Return(nil, errors.New("lookup exploded"))
+
+		err := handleExistingSessionOnLogout(r, "test-session", &models.Client{}, database, auditLogger, authHelper)
 
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Invalid session identifier in id_token_hint")
+		assert.Contains(t, err.Error(), "lookup exploded")
+		database.AssertExpectations(t)
+		auditLogger.AssertNotCalled(t, "Log")
 	})
 
 	t.Run("Session not found", func(t *testing.T) {
 		r := &http.Request{}
-		sessionIdentifier := "test-session"
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"sid": "test-session",
-			},
-		}
-		client := &models.Client{}
 		database := mocks_data.NewDatabase(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 
-		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(nil, nil)
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(nil, nil)
 
-		err := handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
+		err := handleExistingSessionOnLogout(r, "test-session", &models.Client{}, database, auditLogger, authHelper)
 
-		assert.NoError(t, err) // The function should not return an error if the session is not found
+		assert.NoError(t, err, "a session that is not there is nothing to tear down, not a failure")
 		database.AssertExpectations(t)
+		auditLogger.AssertNotCalled(t, "Log")
 	})
 
+	// Decision 3's first half: another client on the session means the row survives, so that client's
+	// session-bound tokens keep working. #129 wrote two integration tests so this cannot change by
+	// accident, and this is the unit-tier statement of the same rule.
 	t.Run("Delete user session client", func(t *testing.T) {
 		r := &http.Request{}
 		sessionIdentifier := "test-session"
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"sid": "test-session",
-			},
-		}
 		client := &models.Client{
 			ClientIdentifier: "test-client",
 		}
@@ -1076,7 +649,7 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 
 		auditLogger.On("Log", constants.AuditDeletedUserSessionClient, mock.Anything).Return()
 
-		err := handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
+		err := handleExistingSessionOnLogout(r, sessionIdentifier, client, database, auditLogger, authHelper)
 
 		assert.NoError(t, err)
 		database.AssertExpectations(t)
@@ -1087,11 +660,6 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 	t.Run("Delete entire user session", func(t *testing.T) {
 		r := &http.Request{}
 		sessionIdentifier := "test-session"
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"sid": "test-session",
-			},
-		}
 		client := &models.Client{
 			ClientIdentifier: "test-client",
 		}
@@ -1123,7 +691,7 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 		auditLogger.On("Log", constants.AuditDeletedUserSessionClient, mock.Anything).Return()
 		auditLogger.On("Log", constants.AuditLogout, mock.Anything).Return()
 
-		err := handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
+		err := handleExistingSessionOnLogout(r, sessionIdentifier, client, database, auditLogger, authHelper)
 
 		assert.NoError(t, err)
 		database.AssertExpectations(t)
@@ -1134,11 +702,6 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 	t.Run("Client not found in user session", func(t *testing.T) {
 		r := &http.Request{}
 		sessionIdentifier := "test-session"
-		idToken := &oauth.JwtToken{
-			Claims: map[string]interface{}{
-				"sid": "test-session",
-			},
-		}
 		client := &models.Client{
 			ClientIdentifier: "test-client",
 		}
@@ -1163,13 +726,135 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 		database.On("UserSessionLoadClients", mock.Anything, userSession).Return(nil)
 		database.On("UserSessionClientsLoadClients", mock.Anything, userSession.Clients).Return(nil)
 
-		err := handleExistingSessionOnLogout(r, sessionIdentifier, idToken, client, database, auditLogger, authHelper)
+		err := handleExistingSessionOnLogout(r, sessionIdentifier, client, database, auditLogger, authHelper)
 
 		assert.NoError(t, err) // The function should not return an error if the client is not found in the session
 		database.AssertExpectations(t)
 		auditLogger.AssertNotCalled(t, "Log")
 		authHelper.AssertNotCalled(t, "GetLoggedInSubject")
 	})
+}
+
+// The fixtures the hinted pipeline's cases share. A confirmed hint is one classifyIdTokenHint
+// accepts, and seam 2 owns the exhaustive table of what makes it accept or refuse one, so the cases
+// here need exactly one confirmed hint and one rejected one and say which they are using.
+const (
+	hintedIssuer        = "https://hinted-issuer.example"
+	hintedClientId      = "hinted_client"
+	hintedSessionId     = "hinted-session"
+	hintedToken         = "a.signed.hint"
+	hintedRegisteredURI = "https://example.com/out"
+)
+
+// hintedClaims is the claim set of a hint that validates. Every numeric claim is a float64 because
+// claims arrive through encoding/json inside jwt.MapClaims, and GetIntClaim refuses anything else, so
+// writing them as int would make the fixture unlike any real token.
+func hintedClaims() map[string]interface{} {
+	now := time.Now().UTC()
+	return map[string]interface{}{
+		"iss": hintedIssuer,
+		"sub": "the-user",
+		"iat": float64(now.Add(-2 * time.Minute).Unix()),
+		"exp": float64(now.Add(2 * time.Minute).Unix()),
+		"aud": hintedClientId,
+		"sid": hintedSessionId,
+	}
+}
+
+// hintedRequest builds a request for the hinted pipeline. The parameters are read through the mocked
+// HttpHelper rather than off the request, so the query and body here matter for one thing only:
+// ui_locales, which refineLogoutLocale reads with r.FormValue.
+//
+// sessionIdentifier empty means the session-identifier middleware attached nothing, which it does
+// whenever the cookie names no live row.
+func hintedRequest(t *testing.T, method string, form url.Values, sessionIdentifier string) *http.Request {
+	t.Helper()
+
+	var req *http.Request
+	var err error
+	if method == http.MethodPost {
+		req, err = http.NewRequest(method, "/auth/logout", strings.NewReader(form.Encode()))
+		assert.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		req, err = http.NewRequest(method, "/auth/logout?"+form.Encode(), nil)
+		assert.NoError(t, err)
+	}
+
+	ctx := context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{Issuer: hintedIssuer})
+	if len(sessionIdentifier) > 0 {
+		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)
+	}
+	return req.WithContext(ctx)
+}
+
+// stubConfirmedHint wires everything classifyIdTokenHint reads for a hint that validates, and returns
+// the client its aud names. That client pointer is the one the teardown then compares against the
+// session's clients, so the cases must not build a second one.
+//
+// The literal false on the parse is decision 14's whole mechanism: claims validation is off, and the
+// classifier checks exp by hand so it can tolerate a past one while the session lives.
+func stubConfirmedHint(
+	httpHelper *mocks_handlerhelpers.HttpHelper,
+	database *mocks_data.Database,
+	tokenParser *mocks_oauth.TokenParser,
+	claims map[string]interface{},
+) *models.Client {
+	client := &models.Client{Id: 11, ClientIdentifier: hintedClientId}
+
+	httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(hintedToken, true)
+	httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("", false)
+	tokenParser.On("DecodeAndValidateTokenString", hintedToken, (*rsa.PublicKey)(nil), false).
+		Return(&oauth.JwtToken{TokenBase64: hintedToken, Claims: claims}, nil)
+	database.On("GetClientByClientIdentifier", mock.Anything, hintedClientId).Return(client, nil)
+
+	return client
+}
+
+// stubRegisteredURI gives the client one registered redirect URI, which is the set a post-logout
+// target is matched against exactly.
+func stubRegisteredURI(database *mocks_data.Database, client *models.Client, uri string) {
+	database.On("ClientLoadRedirectURIs", mock.Anything, client).Run(func(args mock.Arguments) {
+		args.Get(1).(*models.Client).RedirectURIs = []models.RedirectURI{{URI: uri}}
+	}).Return(nil)
+}
+
+// stubPerClientTeardown wires the reads and writes the per-client teardown performs on a session whose
+// only client is the one logging out, which is the shape that also deletes the session row.
+//
+// Per-client is what the assertions in the cases are really about: the hint's SIGNED aud scopes the
+// teardown, and an unauthenticated client_id never does.
+func stubPerClientTeardown(
+	database *mocks_data.Database,
+	auditLogger *mocks_audit.AuditLogger,
+	authHelper *mocks_handlerhelpers.AuthHelper,
+	client *models.Client,
+	sessionIdentifier string,
+) {
+	userSession := &models.UserSession{
+		Id:      42,
+		UserId:  123,
+		Clients: []models.UserSessionClient{{Id: 7, ClientId: client.Id, Client: *client}},
+	}
+
+	database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+	database.On("UserSessionLoadClients", mock.Anything, userSession).Return(nil)
+	database.On("UserSessionClientsLoadClients", mock.Anything, userSession.Clients).Return(nil)
+	database.On("DeleteUserSessionClient", mock.Anything, int64(7)).Return(nil)
+	database.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil)
+
+	authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+	auditLogger.On("Log", constants.AuditDeletedUserSessionClient, mock.Anything).Return()
+	auditLogger.On("Log", constants.AuditLogout, mock.Anything).Return()
+}
+
+// mustParseURL fails the test rather than returning a zero URL, so an assertion on a malformed
+// Location says so instead of silently comparing empty strings.
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	assert.NoError(t, err)
+	return parsed
 }
 
 // logoutPostRequest builds a hintless POST the way the consent form submits one: a real
@@ -1231,14 +916,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 		req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
 		userSession := &models.UserSession{Id: 42, UserId: 123}
@@ -1281,14 +967,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 		req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("https://example.com/out?state=registered&lang=en")
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("test_client")
 		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("aB+cd/efgh==#&x=1", true)
@@ -1518,9 +1205,10 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 				httpSession := mocks_sessionstore.NewStore(t)
 				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 				database := mocks_data.NewDatabase(t)
+				tokenParser := mocks_oauth.NewTokenParser(t)
 				auditLogger := mocks_audit.NewAuditLogger(t)
 
-				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 				req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
 				rr := httptest.NewRecorder()
@@ -1530,7 +1218,7 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 					redirectURI = "https://example.com/out"
 				}
 
-				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(redirectURI)
 				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return(tc.clientId)
 				tc.stubDB(database)
@@ -1601,14 +1289,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 				httpSession := mocks_sessionstore.NewStore(t)
 				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 				database := mocks_data.NewDatabase(t)
+				tokenParser := mocks_oauth.NewTokenParser(t)
 				auditLogger := mocks_audit.NewAuditLogger(t)
 
-				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 				req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
 				rr := httptest.NewRecorder()
 
-				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 				tc.stubDB(database)
 
@@ -1656,9 +1345,10 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 				httpSession := mocks_sessionstore.NewStore(t)
 				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 				database := mocks_data.NewDatabase(t)
+				tokenParser := mocks_oauth.NewTokenParser(t)
 				auditLogger := mocks_audit.NewAuditLogger(t)
 
-				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 				req := logoutPostRequest(t, url.Values{})
 				if tc.sessionIdentifier != "" {
@@ -1666,7 +1356,7 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 				}
 				rr := httptest.NewRecorder()
 
-				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 				tc.stubDB(database)
 
@@ -1699,14 +1389,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 		req := logoutPostRequest(t, url.Values{"ui_locales": {"pt-BR"}})
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
 		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
@@ -1725,40 +1416,148 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 	})
 
 	// The other half of decision 17 on this method, and the half the case above cannot reach. A POST
-	// carrying a hint returns before doLogoutWithoutIdToken is ever called, so the refinement has to
-	// happen above that branch rather than inside the hintless one. Move it down and the case above
-	// still passes while every hinted POST that renders anything renders it in the fallback language,
-	// which an RP posting ui_locales in its body has no way to correct.
-	//
-	// Which page comes back is deliberately not asserted: the hinted branch is stage 4's to rewrite,
-	// and the property here is that whatever this handler renders is localized from the body. Today
-	// the shortest hinted render is the missing-target error page.
+	// carrying a hint never enters the hintless branch, so the refinement has to happen above the
+	// pipeline rather than inside it. Move it down and the case above still passes while every hinted
+	// POST that renders anything renders it in the fallback language, which an RP posting ui_locales in
+	// its body has no way to correct.
 	t.Run("ui_locales in the body only reaches a hinted POST's render", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
-		req := logoutPostRequest(t, url.Values{
-			"id_token_hint": {"a.b.c"},
+		req := hintedRequest(t, http.MethodPost, url.Values{
+			"id_token_hint": {hintedToken},
 			"ui_locales":    {"pt-BR"},
-		})
+		}, hintedSessionId)
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("a.b.c")
+		client := stubConfirmedHint(httpHelper, database, tokenParser, hintedClaims())
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+		stubPerClientTeardown(database, auditLogger, authHelper, client, hintedSessionId)
 
+		expectCookieWipedBeforeSave(t, httpSession)
 		httpHelper.On("RenderTemplate", rr, mock.MatchedBy(func(rendered *http.Request) bool {
-			return i18n.T(rendered.Context(), "logout_consent.title") == "Sair"
-		}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			return i18n.T(rendered.Context(), "logged_out.title") == "Sessão encerrada"
+		}), "/layouts/auth_layout.html", "/logged_out.html", mock.Anything).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
 		httpHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+	})
+
+	// Decision 18. The CSRF exemption the POST binding needs keys on the hint being PRESENT, because
+	// middleware cannot judge whether one is genuine, and gorilla/csrf returns on that skip flag before
+	// it saves the cookie and attaches the token. So a consent page rendered on this request would
+	// carry no token and its own hintless confirming POST would be refused, leaving the End-User on a
+	// page they cannot submit while still signed in. The 303 sends them to the GET binding, which is
+	// never exempt and therefore renders a page that works.
+	//
+	// The two parameters dropped are the point of the case. id_token_hint, because carrying it back
+	// would land here again forever; client_id, because the follow-up GET is the hint-absent shape,
+	// where client_id authorizes the redirect a rejected hint is specifically denied (decision 15).
+	t.Run("A POST whose hint is rejected is sent to the GET binding", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req := hintedRequest(t, http.MethodPost, url.Values{
+			"id_token_hint": {hintedToken},
+			"ui_locales":    {"pt-BR"},
+		}, hintedSessionId)
+		rr := httptest.NewRecorder()
+
+		// Rejected at the client_id gate, which refuses before any lookup: the parameter names a
+		// different client from the aud the hint is signed over.
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(hintedToken, true)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("another_client", true)
+		tokenParser.On("DecodeAndValidateTokenString", hintedToken, (*rsa.PublicKey)(nil), false).
+			Return(&oauth.JwtToken{TokenBase64: hintedToken, Claims: hintedClaims()}, nil)
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(hintedRegisteredURI)
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("aB+cd/efgh==#&x=1", true)
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "ui_locales").Return("pt-BR")
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusSeeOther, rr.Code,
+			"303, because the browser has to re-request by GET for the consent page to carry a token")
+		location := mustParseURL(t, rr.Header().Get("Location"))
+		assert.Equal(t, "/auth/logout", location.Path)
+		assert.Equal(t, hintedRegisteredURI, location.Query().Get("post_logout_redirect_uri"))
+		assert.Equal(t, "aB+cd/efgh==#&x=1", location.Query().Get("state"),
+			"state survives the hop byte-identical, escaped rather than concatenated")
+		assert.Equal(t, "pt-BR", location.Query().Get("ui_locales"),
+			"the locale survives, or the consent page comes back in a different language from the one asked for")
+		_, hintCarried := location.Query()["id_token_hint"]
+		assert.False(t, hintCarried, "carrying the hint back would land on this branch again, forever")
+		_, clientIdCarried := location.Query()["client_id"]
+		assert.False(t, clientIdCarried,
+			"a rejected hint's client_id must not survive, or it authorizes the redirect decision 15 denies")
+
+		database.AssertNotCalled(t, "DeleteUserSessionClient", mock.Anything, mock.Anything)
 		database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+		httpSession.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+		httpHelper.AssertExpectations(t)
+	})
+
+	// The 303 keeps decision 16's contract too, which an unconditional query would quietly break: an
+	// RP that sent no state must not have one invented for it on the way to the consent page, and one
+	// that sent "state=" must still get "state=" back at the end. Neither row catches the mutation
+	// alone, since an unconditional parameter passes the empty row and no parameter at all passes the
+	// absent row.
+	t.Run("The 303 carries state only when the request did", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			value   string
+			present bool
+		}{
+			{"supplied empty", "", true},
+			{"absent", "", false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+				httpSession := mocks_sessionstore.NewStore(t)
+				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+				database := mocks_data.NewDatabase(t)
+				tokenParser := mocks_oauth.NewTokenParser(t)
+				auditLogger := mocks_audit.NewAuditLogger(t)
+
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+				req := hintedRequest(t, http.MethodPost, url.Values{"id_token_hint": {hintedToken}}, hintedSessionId)
+				rr := httptest.NewRecorder()
+
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return(hintedToken, true)
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("another_client", true)
+				tokenParser.On("DecodeAndValidateTokenString", hintedToken, (*rsa.PublicKey)(nil), false).
+					Return(&oauth.JwtToken{TokenBase64: hintedToken, Claims: hintedClaims()}, nil)
+
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return(tc.value, tc.present)
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "ui_locales").Return("")
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusSeeOther, rr.Code)
+				location := mustParseURL(t, rr.Header().Get("Location"))
+				values, present := location.Query()["state"]
+				assert.Equal(t, tc.present, present, "raw query: %q", location.RawQuery)
+				if tc.present {
+					assert.Equal(t, []string{tc.value}, values)
+				}
+			})
+		}
 	})
 
 	t.Run("Session store error", func(t *testing.T) {
@@ -1766,14 +1565,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 		req := logoutPostRequest(t, url.Values{})
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
 		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
@@ -1800,14 +1600,15 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
 		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
 		auditLogger := mocks_audit.NewAuditLogger(t)
 
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
 
 		req := logoutPostRequest(t, url.Values{})
 		rr := httptest.NewRecorder()
 
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("", false)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
 		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")

--- a/src/authserver/internal/handlers/handler_account_logout_test.go
+++ b/src/authserver/internal/handlers/handler_account_logout_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
@@ -2035,6 +2036,445 @@ func TestBuildPostLogoutRedirect(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestClassifyIdTokenHint is the exhaustive table for the hint classifier. Every negative row
+// differs from the confirmed row in exactly one field and names the gate that refuses it, which is
+// why the confirmed claims come from a constructor the rows mutate rather than from copy-paste: a
+// row that varied two fields could pass because of the field it was not testing.
+//
+// Nothing calls the classifier yet, so this is the only thing standing behind it until stage 4 wires
+// it into the pipeline (#109).
+func TestClassifyIdTokenHint(t *testing.T) {
+	const (
+		theIssuer    = "https://issuer.example"
+		theClientId  = "test_client"
+		theSessionId = "test-session"
+		theHint      = "a.signed.hint"
+		// The persisted row ID, distinct from the identifier, because the two are not
+		// interchangeable downstream: ClientLoadRedirectURIs queries by Client.Id, so a classifier
+		// that rebuilt the client from the identifier alone would carry Id 0 and every registered
+		// redirect URI would come back empty (#109).
+		theClientDbId int64 = 11
+	)
+
+	now := time.Now().UTC()
+
+	// Claims arrive through encoding/json inside jwt.MapClaims, so every numeric claim is a float64.
+	// Writing these as int would make GetIntClaim reject values a real token presents perfectly well,
+	// and the table would then pass for the wrong reason on every numeric gate.
+	confirmedClaims := func() map[string]interface{} {
+		return map[string]interface{}{
+			"iss": theIssuer,
+			"sub": "the-user",
+			"iat": float64(now.Add(-2 * time.Minute).Unix()),
+			"nbf": float64(now.Add(-2 * time.Minute).Unix()),
+			"exp": float64(now.Add(2 * time.Minute).Unix()),
+			"aud": theClientId,
+			"sid": theSessionId,
+		}
+	}
+
+	newClient := func() *models.Client {
+		return &models.Client{Id: theClientDbId, ClientIdentifier: theClientId}
+	}
+
+	// The confirmed row's database: the hint's aud resolves to a client and nothing else is asked.
+	// Maybe(), because the rows refused at an earlier gate never get here, and the state assertion is
+	// what catches a gate that stopped refusing.
+	resolvesClient := func(database *mocks_data.Database) {
+		database.On("GetClientByClientIdentifier", mock.Anything, theClientId).Return(newClient(), nil).Maybe()
+	}
+
+	// A live session for decision 14's tolerance lookup, which only an expired row reaches.
+	resolvesClientAndSession := func(userSession *models.UserSession, err error) func(*mocks_data.Database) {
+		return func(database *mocks_data.Database) {
+			resolvesClient(database)
+			database.On("GetUserSessionBySessionIdentifier", mock.Anything, theSessionId).Return(userSession, err)
+		}
+	}
+
+	strPtr := func(s string) *string { return &s }
+
+	for _, tc := range []struct {
+		name string
+		// gate names the check that is expected to refuse the row, so a failure says which one stopped
+		// working rather than only that the answer changed.
+		gate       string
+		mutate     func(claims map[string]interface{})
+		hintAbsent bool
+		hintValue  *string
+		innerToken *string
+		// clientId is the value the parameter arrived with; clientIdAbsent says it did not arrive at
+		// all. The two are separate fields because the classifier reads client_id for presence, so a
+		// row that could only say "" would be unable to tell the gate's two sides apart, which is
+		// exactly the hole this pair was added to close.
+		clientId       *string
+		clientIdAbsent bool
+		noSession      bool
+		parserErr      error
+		stubDB         func(*mocks_data.Database)
+		want           hintState
+		wantErr        bool
+		wantSid        string
+	}{
+		{
+			name: "the confirmed case",
+			want: hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			name: "no id_token_hint parameter at all", gate: "presence",
+			hintAbsent: true,
+			want:       hintAbsent,
+		},
+		{
+			// Rejected rather than absent, and the distinction is load-bearing: the CSRF middleware
+			// exempts a cross-site POST on hint PRESENCE and cannot judge validity, so reading
+			// "id_token_hint=" as no hint would send an exempted POST down the branch that tears the
+			// whole session down without consent.
+			name: "id_token_hint supplied with an empty value", gate: "presence",
+			hintValue: strPtr(""),
+			want:      hintRejected,
+		},
+		{
+			name: "an encrypted hint with no client_id", gate: "JWE key selection",
+			hintValue:      strPtr("a.b.c.d.e"),
+			clientIdAbsent: true,
+			want:           hintRejected,
+		},
+		{
+			// The other side of the key-selection gate, and the reason it reads the VALUE where the
+			// gate further down reads the presence: a client_id supplied empty names no client secret
+			// either, so it must stop here too rather than reaching the client_id gate.
+			name: "an encrypted hint with an empty client_id", gate: "JWE key selection",
+			hintValue: strPtr("a.b.c.d.e"),
+			clientId:  strPtr(""),
+			want:      hintRejected,
+		},
+		{
+			name: "an encrypted hint that will not decrypt", gate: "JWE decryption",
+			hintValue: strPtr("a.b.c.d.e"),
+			stubDB: func(database *mocks_data.Database) {
+				secret, err := encryption.EncryptData("some_client_secret")
+				assert.NoError(t, err)
+				database.On("GetClientByClientIdentifier", mock.Anything, theClientId).
+					Return(&models.Client{ClientIdentifier: theClientId, ClientSecretEncrypted: secret}, nil)
+			},
+			want: hintRejected,
+		},
+		{
+			// The positive half of the two rows above, and the only thing that pins the decrypted
+			// inner token being what gets parsed: the parser is stubbed on the inner value, so a
+			// classifier that parsed the JWE itself would find no expectation and fail.
+			name: "an encrypted hint that decrypts", gate: "JWE decryption",
+			hintValue:  strPtr(encryptIDTokenHintForTest(t, "inner.signed.token", "some_client_secret")),
+			innerToken: strPtr("inner.signed.token"),
+			stubDB: func(database *mocks_data.Database) {
+				secret, err := encryption.EncryptData("some_client_secret")
+				assert.NoError(t, err)
+				database.On("GetClientByClientIdentifier", mock.Anything, theClientId).
+					Return(&models.Client{Id: theClientDbId, ClientIdentifier: theClientId, ClientSecretEncrypted: secret}, nil)
+			},
+			want: hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			name: "the hint cannot be parsed", gate: "parse and signature",
+			parserErr: errors.New("token is malformed"),
+			want:      hintRejected,
+		},
+		{
+			name: "the hint is signed with the wrong key", gate: "parse and signature",
+			parserErr: errors.New("token signature is invalid"),
+			want:      hintRejected,
+		},
+		{
+			// An access token satisfies every other gate under a client/resource identifier
+			// collision, so this row is the one standing between a session-bound access token and a
+			// consent-free logout. Every other claim is identical to the confirmed row.
+			name: "typ says this is an access token", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["typ"] = "Bearer" },
+			want:   hintRejected,
+		},
+		{
+			name: "typ says this is an offline refresh token", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["typ"] = "Offline" },
+			want:   hintRejected,
+		},
+		{
+			name: "typ says this is a session refresh token", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["typ"] = "Refresh" },
+			want:   hintRejected,
+		},
+		{
+			// The gate is a denylist, because no ID Token this server issues carries typ at all.
+			// Turning it into a requirement that typ be "ID" would refuse every real hint, so this
+			// row fails the moment somebody inverts it.
+			name: "typ says this is an ID token", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["typ"] = "ID" },
+			want:   hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			name: "sub is missing", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { delete(claims, "sub") },
+			want:   hintRejected,
+		},
+		{
+			name: "sub is empty", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["sub"] = "" },
+			want:   hintRejected,
+		},
+		{
+			name: "iat is missing", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { delete(claims, "iat") },
+			want:   hintRejected,
+		},
+		{
+			name: "iat is not a number", gate: "ID-Token shape",
+			mutate: func(claims map[string]interface{}) { claims["iat"] = "yesterday" },
+			want:   hintRejected,
+		},
+		{
+			name: "iss is missing", gate: "iss",
+			mutate: func(claims map[string]interface{}) { delete(claims, "iss") },
+			want:   hintRejected,
+		},
+		{
+			name: "iss names another server", gate: "iss",
+			mutate: func(claims map[string]interface{}) { claims["iss"] = "https://elsewhere.example" },
+			want:   hintRejected,
+		},
+		{
+			name: "aud is missing", gate: "aud",
+			mutate: func(claims map[string]interface{}) { delete(claims, "aud") },
+			want:   hintRejected,
+		},
+		{
+			// An ID Token this server issues has exactly one audience, so an array is not a hint
+			// shape and GetStringClaim reads it as absent. Pinned because the array form is what a
+			// multi-audience access token carries.
+			name: "aud arrived as an array", gate: "aud",
+			mutate: func(claims map[string]interface{}) {
+				claims["aud"] = []interface{}{theClientId}
+			},
+			want: hintRejected,
+		},
+		{
+			// client_id moves with aud so that the row still reaches the gate it is about. Leaving
+			// client_id at the confirmed value would be refused one gate earlier, as a mismatch, and
+			// the row would pass without the lookup ever happening.
+			name: "aud names no client", gate: "aud",
+			mutate:   func(claims map[string]interface{}) { claims["aud"] = "ghost_client" },
+			clientId: strPtr("ghost_client"),
+			stubDB: func(database *mocks_data.Database) {
+				database.On("GetClientByClientIdentifier", mock.Anything, "ghost_client").Return(nil, nil)
+			},
+			want: hintRejected,
+		},
+		{
+			// Rejected rather than a 500, and the asymmetry with the expiry lookup below is
+			// deliberate: this one runs before any teardown, so surfacing it would put the End-User
+			// on a terminal page while still signed in.
+			name: "the client lookup fails", gate: "aud",
+			stubDB: func(database *mocks_data.Database) {
+				database.On("GetClientByClientIdentifier", mock.Anything, theClientId).
+					Return(nil, errors.New("the database is on fire"))
+			},
+			want: hintRejected,
+		},
+		{
+			name: "client_id does not match aud", gate: "client_id",
+			clientId: strPtr("another_client"),
+			want:     hintRejected,
+		},
+		{
+			// The gate only fires when both are present. RP-Initiated Logout makes client_id
+			// OPTIONAL, so its absence beside a valid hint is an ordinary conforming request. Absent
+			// here means the parameter did not arrive, which is why the row says so rather than
+			// passing an empty value: the row below is the empty one and they must not agree.
+			name: "client_id is absent beside a valid aud", gate: "client_id",
+			clientIdAbsent: true,
+			want:           hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			// Supplied empty is supplied. RP-Initiated Logout 1.0 section 2 makes the OP verify the
+			// Client Identifier "when both client_id and id_token_hint are present", and "" is not a
+			// Client Identifier valid at this server, so the hint is refused exactly as it is for a
+			// client_id naming somebody else. Reading this as absent would skip a MUST on a parameter
+			// the request carried, and it is the row that stops the two reads of client_id, this gate
+			// and the JWE key selection above, from being collapsed back into one.
+			name: "client_id supplied with an empty value", gate: "client_id",
+			clientId: strPtr(""),
+			want:     hintRejected,
+		},
+		{
+			name: "nbf is in the future", gate: "nbf",
+			mutate: func(claims map[string]interface{}) {
+				claims["nbf"] = float64(now.Add(10 * time.Minute).Unix())
+			},
+			want: hintRejected,
+		},
+		{
+			// Raw map presence rather than a zero-value test, so a present-but-malformed nbf is
+			// refused instead of read as absent and skipped.
+			name: "nbf is present and is not a number", gate: "nbf",
+			mutate: func(claims map[string]interface{}) { claims["nbf"] = "soon" },
+			want:   hintRejected,
+		},
+		{
+			name: "nbf is absent", gate: "nbf",
+			mutate: func(claims map[string]interface{}) { delete(claims, "nbf") },
+			want:   hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			// Decision 14 tolerates a past exp, never a missing one: a hint with no expiry is an
+			// indefinitely replayable forced-logout token.
+			name: "exp is missing", gate: "exp",
+			mutate: func(claims map[string]interface{}) { delete(claims, "exp") },
+			want:   hintRejected,
+		},
+		{
+			// The present-but-malformed half, which the missing row cannot reach. Claims validation is
+			// off at the parse, so this gate is the only thing standing between a garbage exp and the
+			// expiry-tolerance comparison below, and a build that read an unreadable exp as "not
+			// expired yet" would confirm a hint whose lifetime nothing had checked.
+			name: "exp is present and is not a number", gate: "exp",
+			mutate: func(claims map[string]interface{}) { claims["exp"] = "later" },
+			want:   hintRejected,
+		},
+		{
+			name: "sid is missing", gate: "sid",
+			mutate: func(claims map[string]interface{}) { delete(claims, "sid") },
+			want:   hintRejected,
+		},
+		{
+			name: "sid names a different session than the browser's", gate: "sid",
+			mutate: func(claims map[string]interface{}) { claims["sid"] = "another-session" },
+			want:   hintRejected,
+		},
+		{
+			// With no cookie the hint's own sid names the session, which is what makes RP-initiated
+			// logout work at all from an RP the browser is not currently at. The assertion that
+			// proves seeding happened is wantSid: without it the identifier would come back empty.
+			name: "no browser session, so sid seeds the identifier", gate: "sid",
+			noSession: true,
+			want:      hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			// The reachable half of decision 14: the admin console mints a 60-second hint, so a user
+			// who pauses on the way through arrives here.
+			name: "expired, and sid still names a live session", gate: "expiry tolerance",
+			mutate: func(claims map[string]interface{}) {
+				claims["exp"] = float64(now.Add(-1 * time.Minute).Unix())
+			},
+			stubDB: resolvesClientAndSession(&models.UserSession{Id: 7, UserId: 3}, nil),
+			want:   hintConfirmed, wantSid: theSessionId,
+		},
+		{
+			name: "expired, and sid names no live session", gate: "expiry tolerance",
+			mutate: func(claims map[string]interface{}) {
+				claims["exp"] = float64(now.Add(-1 * time.Minute).Unix())
+			},
+			stubDB: resolvesClientAndSession(nil, nil),
+			want:   hintRejected,
+		},
+		{
+			// The one failure that is not a rejection. A database error and a row that is not there
+			// have different answers, so reading this as "no such session" would decide the tolerance
+			// on the database's health (decision 8's rule for this handler).
+			name: "expired, and the session lookup fails", gate: "expiry tolerance",
+			mutate: func(claims map[string]interface{}) {
+				claims["exp"] = float64(now.Add(-1 * time.Minute).Unix())
+			},
+			stubDB:  resolvesClientAndSession(nil, errors.New("the database is on fire")),
+			want:    hintRejected,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+			database := mocks_data.NewDatabase(t)
+			tokenParser := mocks_oauth.NewTokenParser(t)
+
+			req, err := http.NewRequest("GET", "/auth/logout", nil)
+			assert.NoError(t, err)
+			ctx := context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{Issuer: theIssuer})
+			if !tc.noSession {
+				ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, theSessionId)
+			}
+			req = req.WithContext(ctx)
+
+			hint := theHint
+			if tc.hintValue != nil {
+				hint = *tc.hintValue
+			}
+			httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").
+				Return(hint, !tc.hintAbsent)
+
+			clientId := theClientId
+			if tc.clientId != nil {
+				clientId = *tc.clientId
+			}
+			if tc.clientIdAbsent {
+				clientId = ""
+			}
+			httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "client_id").
+				Return(clientId, !tc.clientIdAbsent).Maybe()
+
+			claims := confirmedClaims()
+			if tc.mutate != nil {
+				tc.mutate(claims)
+			}
+
+			// The literal false is decision 14's whole mechanism, so it is asserted rather than
+			// matched loosely: a classifier that passed true would find no expectation here and the
+			// row would fail outright.
+			parsed := hint
+			if tc.innerToken != nil {
+				parsed = *tc.innerToken
+			}
+			parserCall := tokenParser.On("DecodeAndValidateTokenString", parsed, (*rsa.PublicKey)(nil), false)
+			if tc.parserErr != nil {
+				parserCall.Return(nil, tc.parserErr).Maybe()
+			} else {
+				parserCall.Return(&oauth.JwtToken{TokenBase64: parsed, Claims: claims}, nil).Maybe()
+			}
+
+			stubDB := tc.stubDB
+			if stubDB == nil {
+				stubDB = resolvesClient
+			}
+			stubDB(database)
+
+			got, err := classifyIdTokenHint(req, httpHelper, database, tokenParser)
+
+			if tc.wantErr {
+				assert.Error(t, err, "a database failure in the expiry lookup must propagate")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.want, got.state, "gate: %s", tc.gate)
+
+			if tc.want == hintConfirmed {
+				assert.NotNil(t, got.client, "a confirmed hint must yield the client its aud named")
+				assert.Equal(t, theClientId, got.client.ClientIdentifier)
+				// The persisted row, not a model rebuilt from the identifier. Asserting the identifier
+				// alone leaves Id 0 indistinguishable from the real client, and Id is what the
+				// redirect path queries by.
+				assert.Equal(t, theClientDbId, got.client.Id,
+					"a confirmed hint must yield the persisted client, since its Id is what loads the registered redirect URIs")
+				assert.Equal(t, tc.wantSid, got.sessionIdentifier)
+			} else {
+				// RP-Initiated Logout 1.0 section 4: information that failed to validate MUST NOT be
+				// used. From a caller's side that looks like having nothing to use.
+				assert.Nil(t, got.client, "a hint that was not confirmed must yield no client")
+				assert.Empty(t, got.sessionIdentifier, "a hint that was not confirmed must yield no session")
+			}
+
+			httpHelper.AssertExpectations(t)
+			database.AssertExpectations(t)
+			tokenParser.AssertExpectations(t)
 		})
 	}
 }

--- a/src/authserver/internal/handlers/handler_account_logout_test.go
+++ b/src/authserver/internal/handlers/handler_account_logout_test.go
@@ -73,6 +73,10 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		req = req.WithContext(ctx)
 
 		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "client_id").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "ui_locales").Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", req, "state").Return("", false)
 		httpHelper.On("RenderTemplate", rr, req, "/layouts/auth_layout.html", "/logout_consent.html", mock.MatchedBy(func(data map[string]interface{}) bool {
 			_, hasCsrfField := data["csrfField"]
 			return hasCsrfField
@@ -81,6 +85,118 @@ func TestHandleAccountLogoutGet(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
+		httpHelper.AssertExpectations(t)
+	})
+
+	// The consent page must carry forward everything the confirming POST needs, and it must NOT
+	// carry the id_token_hint. Dropping the hint is what stops a cross-site POST with a bogus hint
+	// from being converted into a teardown once the POST binding is CSRF-exempt on hint presence:
+	// confirming this page is always a hintless POST, and a hintless POST had to pass CSRF (#109).
+	t.Run("Hintless GET carries the confirming POST's fields and never the hint", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req, _ := http.NewRequest("GET", "/auth/logout", nil)
+		rr := httptest.NewRecorder()
+		req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "post_logout_redirect_uri").Return("https://example.com/out")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "client_id").Return("test_client")
+		httpHelper.On("GetFromUrlQueryOrFormPost", req, "ui_locales").Return("pt-BR")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", req, "state").Return("abc", true)
+
+		var bound map[string]interface{}
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logout_consent.html",
+			mock.MatchedBy(func(data map[string]interface{}) bool {
+				bound = data
+				return true
+			})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, "/auth/logout", bound["formAction"])
+		assert.Equal(t, "https://example.com/out", bound["postLogoutRedirectUri"])
+		assert.Equal(t, "test_client", bound["clientId"])
+		assert.Equal(t, "abc", bound["state"])
+		assert.Equal(t, true, bound["statePresent"])
+		assert.Equal(t, "pt-BR", bound["uiLocales"])
+		assert.NotContains(t, bound, "idTokenHint")
+		httpHelper.AssertExpectations(t)
+	})
+
+	// state supplied empty and state absent are different requests, and the difference has to
+	// survive the consent hop: the hidden field is emitted on presence, so an RP that sent nothing
+	// does not get "state=" invented for it on the way back (#109 decision 16).
+	t.Run("Hintless GET distinguishes an empty state from an absent one", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			value   string
+			present bool
+		}{
+			{"supplied empty", "", true},
+			{"absent", "", false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+				httpSession := mocks_sessionstore.NewStore(t)
+				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+				database := mocks_data.NewDatabase(t)
+				tokenParser := mocks_oauth.NewTokenParser(t)
+				auditLogger := mocks_audit.NewAuditLogger(t)
+				handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+				req, _ := http.NewRequest("GET", "/auth/logout", nil)
+				rr := httptest.NewRecorder()
+				req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
+
+				httpHelper.On("GetFromUrlQueryOrFormPost", req, mock.Anything).Return("")
+				httpHelper.On("LookupFromUrlQueryOrFormPost", req, "state").Return(tc.value, tc.present)
+
+				var bound map[string]interface{}
+				httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logout_consent.html",
+					mock.MatchedBy(func(data map[string]interface{}) bool {
+						bound = data
+						return true
+					})).Return(nil)
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, tc.present, bound["statePresent"])
+				assert.Equal(t, tc.value, bound["state"])
+			})
+		}
+	})
+
+	// The global locale middleware reads the query only, so a GET's ui_locales already reaches it.
+	// This case exists to pin that the handler's own refinement does not undo that, and it is the
+	// half of decision 17 the POST case below completes.
+	t.Run("Hintless GET honours ui_locales", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		handler := HandleAccountLogoutGet(httpHelper, httpSession, authHelper, database, tokenParser, auditLogger)
+
+		req, _ := http.NewRequest("GET", "/auth/logout?ui_locales=pt-BR", nil)
+		rr := httptest.NewRecorder()
+		req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, mock.Anything).Return("")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("", false)
+		httpHelper.On("RenderTemplate", rr, mock.MatchedBy(func(rendered *http.Request) bool {
+			return i18n.T(rendered.Context(), "logout_consent.title") == "Sair"
+		}), "/layouts/auth_layout.html", "/logout_consent.html", mock.Anything).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
 		httpHelper.AssertExpectations(t)
 	})
 
@@ -1055,12 +1171,61 @@ func TestHandleExistingSessionOnLogout(t *testing.T) {
 	})
 }
 
+// logoutPostRequest builds a hintless POST the way the consent form submits one: a real
+// urlencoded body, because refineLogoutLocale reads ui_locales straight off the request with
+// r.FormValue rather than through the mocked HttpHelper.
+func logoutPostRequest(t *testing.T, form url.Values) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", "/auth/logout", strings.NewReader(form.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req.WithContext(context.WithValue(req.Context(), constants.ContextKeySettings, &models.Settings{}))
+}
+
+// withSessionIdentifier puts the identifier the session-identifier middleware would have attached,
+// which it does only when the cookie's session still resolves to a live row.
+func withSessionIdentifier(req *http.Request, sessionIdentifier string) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier))
+}
+
+// expectCookieWipedBeforeSave stubs the session store for a request that reaches the terminal
+// response, and pins the ordering the wipe depends on: the session must already be empty at the
+// moment it is serialized.
+//
+// Two things make this the only assertion that works, and both were demonstrated by mutation rather
+// than reasoned about. The wipe replaces the map on the session in place, so reading the same pointer
+// after the handler returns cannot tell a wipe that ran before the save from one that ran after it,
+// and moving it after the save leaves such a check green. And seeding the session non-empty is what
+// makes an omitted wipe fail at all, so a case that starts from an empty map proves nothing on this
+// axis whatever it asserts afterwards.
+//
+// The invariant is unconditional and belongs on every branch: the cookie IS the OP session, so a
+// response that writes it back still carrying the session identifier leaves the End-User signed in
+// at the OP immediately after asking to be signed out. It matters most on the redirect branch, where
+// the browser goes straight back to a relying party (#109).
+func expectCookieWipedBeforeSave(t *testing.T, httpSession *mocks_sessionstore.Store) *sessions.Session {
+	t.Helper()
+	sess := &sessions.Session{Values: map[interface{}]interface{}{"something": "here"}}
+	httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(sess, nil)
+	httpSession.On("Save", mock.Anything, mock.Anything, sess).
+		Run(func(args mock.Arguments) {
+			assert.Empty(t, args.Get(2).(*sessions.Session).Values,
+				"the OP session cookie must be cleared before it is written back")
+		}).Return(nil)
+	return sess
+}
+
+// TestHandleAccountLogoutPost covers the hintless half of the endpoint. Reaching the POST binding
+// without a hint means the confirming submission of the consent page, so these cases are what a
+// user sees after answering "yes".
+//
+// Every one of them asserts the teardown, whatever the redirect target turned out to be. That is
+// the property #109 is about: the parameters used to be validated first and every failure returned
+// before both the database teardown and the cookie wipe, so a user who asked to be logged out and
+// got an error page was still logged in.
 func TestHandleAccountLogoutPost(t *testing.T) {
-	origAuthServerBaseUrl := config.GetAuthServer().BaseURL
-	config.GetAuthServer().BaseURL = "http://localhost:8080"
-	defer func() { config.GetAuthServer().BaseURL = origAuthServerBaseUrl }()
 
-	t.Run("Successful logout", func(t *testing.T) {
+	t.Run("Deletes the whole session and lands on the signed-out page", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		httpSession := mocks_sessionstore.NewStore(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
@@ -1069,94 +1234,530 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 
 		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
 
-		req, err := http.NewRequest("POST", "/logout", nil)
-		assert.NoError(t, err)
-
+		req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
 		rr := httptest.NewRecorder()
 
-		sessionIdentifier := "test-session"
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)
-		req = req.WithContext(ctx)
-
-		// Mock GetFromUrlQueryOrFormPost to return empty string (no id_token_hint)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
-		mockSession := &sessions.Session{
-			Values: make(map[interface{}]interface{}),
-		}
-		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(mockSession, nil)
-		httpSession.On("Save", mock.Anything, mock.Anything, mockSession).Return(nil)
-
-		userSession := &models.UserSession{
-			Id:     1,
-			UserId: 123,
-		}
-		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
-
-		loggedInSubject := "user-123"
-		authHelper.On("GetLoggedInSubject", mock.Anything).Return(loggedInSubject)
-
-		auditLogger.On("Log", constants.AuditLogout, mock.MatchedBy(func(details map[string]interface{}) bool {
-			return details["userId"] == int64(123) &&
-				details["sessionIdentifier"] == sessionIdentifier &&
-				details["loggedInUser"] == loggedInSubject
-		})).Return()
-
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusFound, rr.Code)
-		assert.Equal(t, config.GetAuthServer().BaseURL, rr.Header().Get("Location"))
-
-		httpSession.AssertExpectations(t)
-		database.AssertExpectations(t)
-		authHelper.AssertExpectations(t)
-		auditLogger.AssertExpectations(t)
-	})
-
-	t.Run("Session not found", func(t *testing.T) {
-		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
-		httpSession := mocks_sessionstore.NewStore(t)
-		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
-		database := mocks_data.NewDatabase(t)
-		auditLogger := mocks_audit.NewAuditLogger(t)
-
-		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
-
-		req, err := http.NewRequest("POST", "/logout", nil)
-		assert.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-
-		sessionIdentifier := "test-session"
-		ctx := req.Context()
-		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, sessionIdentifier)
-		req = req.WithContext(ctx)
-
-		// Mock GetFromUrlQueryOrFormPost to return empty string (no id_token_hint)
-		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
-
-		mockSession := &sessions.Session{
-			Values: make(map[interface{}]interface{}),
-		}
-		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(mockSession, nil)
-		httpSession.On("Save", mock.Anything, mock.Anything, mockSession).Return(nil)
-
-		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(nil, nil)
+		userSession := &models.UserSession{Id: 42, UserId: 123}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(userSession, nil)
+		database.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil)
 
 		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
 
-		auditLogger.On("Log", constants.AuditLogout, mock.Anything).Return()
+		auditLogger.On("Log", constants.AuditDeletedUserSession, mock.MatchedBy(func(details map[string]interface{}) bool {
+			return details["userSessionId"] == int64(42) && details["loggedInUser"] == "user-123"
+		})).Return()
+		auditLogger.On("Log", constants.AuditLogout, mock.MatchedBy(func(details map[string]interface{}) bool {
+			return details["userId"] == int64(123) &&
+				details["sessionIdentifier"] == "test-session" &&
+				details["loggedInUser"] == "user-123"
+		})).Return()
+
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
+
+		httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+			mock.MatchedBy(func(data map[string]interface{}) bool {
+				return data["redirectDeclined"] == false
+			})).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+		httpHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		httpSession.AssertExpectations(t)
+	})
+
+	// Decision 4: client_id is the "other means of confirming the legitimacy of the post-logout
+	// redirection target" the spec requires when there is no id_token_hint to read a signed aud
+	// from. The state here is the one the concatenation this replaced could not carry: "+" decoded
+	// to a space, "/" and "=" were left raw, and "#" and "&" truncated it or injected parameters.
+	t.Run("client_id plus a registered URI redirects, with exactly one state and no sid", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+		req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
+		rr := httptest.NewRecorder()
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("https://example.com/out?state=registered&lang=en")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return("test_client")
+		httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("aB+cd/efgh==#&x=1", true)
+
+		client := &models.Client{
+			ClientIdentifier: "test_client",
+			RedirectURIs:     []models.RedirectURI{{URI: "https://example.com/out?state=registered&lang=en"}},
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+		database.On("ClientLoadRedirectURIs", mock.Anything, client).Return(nil)
+
+		userSession := &models.UserSession{Id: 42, UserId: 123}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(userSession, nil)
+		database.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil)
+
+		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+		auditLogger.On("Log", mock.Anything, mock.Anything).Return()
+
+		// The redirect branch is the one where an omitted or late wipe hides: the browser leaves for
+		// the relying party immediately, so nothing else in the response would show that the OP
+		// session cookie went back out intact.
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
 
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusFound, rr.Code)
-		assert.Equal(t, config.GetAuthServer().BaseURL, rr.Header().Get("Location"))
-
-		httpSession.AssertExpectations(t)
+		location, err := url.Parse(rr.Header().Get("Location"))
+		assert.NoError(t, err)
+		assert.Equal(t, "https://example.com/out", location.Scheme+"://"+location.Host+location.Path)
+		assert.Equal(t, []string{"aB+cd/efgh==#&x=1"}, location.Query()["state"],
+			"exactly one state, byte-identical to what the RP sent")
+		assert.Equal(t, "en", location.Query().Get("lang"), "the registered query survives")
+		assert.Empty(t, location.Query().Get("sid"), "sid is not a parameter RP-initiated logout defines")
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
 		database.AssertExpectations(t)
-		authHelper.AssertExpectations(t)
-		auditLogger.AssertExpectations(t)
+		httpSession.AssertExpectations(t)
+	})
+
+	// Every way a target fails to authorize. Each one still tears the session down and lands on the
+	// signed-out page with the note, because whether a redirect can be honoured is a question about
+	// the response and never about whether the logout happens (#109).
+	//
+	// The table is three groups that fail for different reasons, and only the first is ordinary.
+	// Rows 1 to 3 are plain refusals: the request did not earn a redirect. Rows 4 to 11 are near
+	// misses, where the requested URI differs from a registered one in a way exact string comparison
+	// catches and a looser one does not; they exist because no plain refusal can tell those apart,
+	// so every loose comparison listed below passed this table before its row was added. Rows 12 to
+	// 14 are faults, a database that will not answer and a registered URI that will not parse, and
+	// those are the shapes where a plausible future edit turns "lose the redirect" into "return a
+	// 500", which would put a user who is still signed in on a terminal page. Every row asserts the
+	// whole teardown and the absence of an InternalServerError, not just the absent Location.
+	//
+	// The near misses come in two families, and each row differs from its registration in exactly
+	// one respect so that it names the comparison it kills. Rows 4 to 6 kill comparisons that are
+	// loose about the string: prefix in either direction, substring, and case folding. Rows 7 to 11
+	// kill comparisons that parse the URI and then compare or normalize selected components, which
+	// is the family that survives a table built only from the first: each of query omission, scheme
+	// omission, trailing-slash normalization, percent-decoding the path, and default-port
+	// normalization accepts a URI no operator registered.
+	t.Run("A target that cannot be authorized is declined, and the logout still happens", func(t *testing.T) {
+		const unparseableURI = "https://example.com/out\x7f"
+
+		// One registered URI on test_client, so a row need only say how the requested URI differs.
+		registers := func(uri string) func(*mocks_data.Database) {
+			return func(database *mocks_data.Database) {
+				client := &models.Client{
+					ClientIdentifier: "test_client",
+					RedirectURIs:     []models.RedirectURI{{URI: uri}},
+				}
+				database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+				database.On("ClientLoadRedirectURIs", mock.Anything, client).Return(nil)
+			}
+		}
+
+		// A near-miss row reaches the state lookup only if the comparison has been loosened, so the
+		// stub is optional. Allowing it means a loosened build runs on and fails on the assertions
+		// that state the property, rather than dying earlier on an unexpected mock call.
+		allowStateLookup := func(httpHelper *mocks_handlerhelpers.HttpHelper) {
+			httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("abc", true).Maybe()
+		}
+
+		for _, tc := range []struct {
+			name        string
+			clientId    string
+			redirectURI string
+			stubDB      func(database *mocks_data.Database)
+			stubHelper  func(httpHelper *mocks_handlerhelpers.HttpHelper)
+		}{
+			{
+				name:     "no client_id, so nothing can confirm the target",
+				clientId: "",
+				stubDB:   func(database *mocks_data.Database) {},
+			},
+			{
+				name:     "client_id names no client",
+				clientId: "ghost_client",
+				stubDB: func(database *mocks_data.Database) {
+					database.On("GetClientByClientIdentifier", mock.Anything, "ghost_client").Return(nil, nil)
+				},
+			},
+			{
+				name:     "the URI is not registered to the named client",
+				clientId: "test_client",
+				stubDB:   registers("https://example.com/somewhere-else"),
+			},
+			{
+				// The classic loose-match bypass. The requested URI begins with the whole registered
+				// value, so HasPrefix or Contains accepts it, while url.Parse reads
+				// "trusted.example" as userinfo and sends the browser to evil.example. Only exact
+				// string comparison refuses it, which both governing texts require: RP-Initiated
+				// Logout 1.0 section 3, "the OP also MUST NOT perform post-logout redirection if the
+				// post_logout_redirect_uri value supplied does not exactly match one of the
+				// previously registered post_logout_redirect_uris values", and RFC 9700 section 2.1,
+				// "authorization servers MUST utilize exact string matching".
+				name:        "the requested URI only starts with a registered one",
+				clientId:    "test_client",
+				redirectURI: "https://trusted.example@evil.example/callback",
+				stubDB:      registers("https://trusted.example"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// The same defect with the operands reversed, which a comparison written as
+				// HasPrefix(registered, requested) would accept.
+				name:        "a registered URI merely extends the requested one",
+				clientId:    "test_client",
+				redirectURI: "https://example.com/out",
+				stubDB:      registers("https://example.com/out/deeper"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// Exact means byte for byte, so a case-folded comparison is too loose as well. The
+				// path differs in case here and not only the host, and paths are case-sensitive
+				// under RFC 3986 section 6.2.2.1.
+				name:        "the requested URI differs from a registered one only in case",
+				clientId:    "test_client",
+				redirectURI: "https://EXAMPLE.com/OUT",
+				stubDB:      registers("https://example.com/out"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// Scheme, authority and path all match, and only the query differs, so a comparison
+				// that parses both and omits RawQuery accepts this. That hands an initiator who
+				// knows nothing but a public client_id the ability to choose the query the trusted
+				// RP's logout endpoint is called with, on a URI its operator never registered.
+				name:        "the requested URI differs from a registered one only in its query",
+				clientId:    "test_client",
+				redirectURI: "https://trusted.example/logout?fixed=2",
+				stubDB:      registers("https://trusted.example/logout?fixed=1"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// Omitting the scheme is the same family and the worst member of it: it turns a
+				// registered https target into a cleartext one, so the state the RP relies on for
+				// its own CSRF check travels in the clear.
+				name:        "the requested URI differs from a registered one only in its scheme",
+				clientId:    "test_client",
+				redirectURI: "http://example.com/out",
+				stubDB:      registers("https://example.com/out"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// "Exact string matching" leaves no room for the tidying a canonicalizer does, and a
+				// trailing slash is the tidying most likely to be reached for. Under RFC 3986
+				// section 6.2.2.3 these are different paths, and on many RPs they are different
+				// routes.
+				name:        "the requested URI differs from a registered one only by a trailing slash",
+				clientId:    "test_client",
+				redirectURI: "https://example.com/out/",
+				stubDB:      registers("https://example.com/out"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// The subtlest member, and the one a careful implementation walks into: url.URL.Path
+				// is percent-decoded, so comparing it rather than EscapedPath() makes %6f and o the
+				// same character. Byte-for-byte equality is what both texts ask for, not equality
+				// after decoding.
+				name:        "the requested URI differs from a registered one only in percent-encoding",
+				clientId:    "test_client",
+				redirectURI: "https://example.com/%6fut",
+				stubDB:      registers("https://example.com/out"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				// A URL canonicalizer drops the port when it is the scheme's default, which makes
+				// this pair equal to it and unequal to string comparison. Same family, and it is the
+				// one that reads most like a harmless normalization.
+				name:        "the requested URI differs from a registered one only by an explicit default port",
+				clientId:    "test_client",
+				redirectURI: "https://example.com:443/out",
+				stubDB:      registers("https://example.com/out"),
+				stubHelper:  allowStateLookup,
+			},
+			{
+				name:     "the client lookup fails",
+				clientId: "test_client",
+				stubDB: func(database *mocks_data.Database) {
+					database.On("GetClientByClientIdentifier", mock.Anything, "test_client").
+						Return(nil, errors.New("client lookup exploded"))
+				},
+			},
+			{
+				name:     "the client's registered URIs cannot be loaded",
+				clientId: "test_client",
+				stubDB: func(database *mocks_data.Database) {
+					client := &models.Client{ClientIdentifier: "test_client"}
+					database.On("GetClientByClientIdentifier", mock.Anything, "test_client").Return(client, nil)
+					database.On("ClientLoadRedirectURIs", mock.Anything, client).
+						Return(errors.New("load redirect URIs exploded"))
+				},
+			},
+			{
+				// The registered URI matches exactly and then fails to parse, so this row reaches
+				// buildPostLogoutRedirect's error return, which nothing else here does. A DEL byte
+				// is what url.Parse refuses; the shape is defensive rather than reachable through
+				// the admin UI, and defensive is exactly why it needs pinning.
+				name:        "the redirect cannot be built from the registered URI",
+				clientId:    "test_client",
+				redirectURI: unparseableURI,
+				stubDB:      registers(unparseableURI),
+				stubHelper: func(httpHelper *mocks_handlerhelpers.HttpHelper) {
+					httpHelper.On("LookupFromUrlQueryOrFormPost", mock.Anything, "state").Return("abc", true)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+				httpSession := mocks_sessionstore.NewStore(t)
+				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+				database := mocks_data.NewDatabase(t)
+				auditLogger := mocks_audit.NewAuditLogger(t)
+
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+				req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
+				rr := httptest.NewRecorder()
+
+				redirectURI := tc.redirectURI
+				if redirectURI == "" {
+					redirectURI = "https://example.com/out"
+				}
+
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return(redirectURI)
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "client_id").Return(tc.clientId)
+				tc.stubDB(database)
+				if tc.stubHelper != nil {
+					tc.stubHelper(httpHelper)
+				}
+
+				userSession := &models.UserSession{Id: 42, UserId: 123}
+				database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(userSession, nil)
+				database.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil)
+
+				authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+				auditLogger.On("Log", constants.AuditDeletedUserSession, mock.MatchedBy(func(details map[string]interface{}) bool {
+					return details["userSessionId"] == int64(42) && details["loggedInUser"] == "user-123"
+				})).Return()
+				auditLogger.On("Log", constants.AuditLogout, mock.MatchedBy(func(details map[string]interface{}) bool {
+					return details["userId"] == int64(123) && details["sessionIdentifier"] == "test-session"
+				})).Return()
+
+				mockSession := expectCookieWipedBeforeSave(t, httpSession)
+
+				httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+					mock.MatchedBy(func(data map[string]interface{}) bool {
+						return data["redirectDeclined"] == true
+					})).Return(nil)
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Empty(t, rr.Header().Get("Location"), "a declined target must never become a redirect")
+				assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+				httpHelper.AssertNotCalled(t, "InternalServerError", mock.Anything, mock.Anything, mock.Anything)
+				database.AssertExpectations(t)
+				httpHelper.AssertExpectations(t)
+				auditLogger.AssertExpectations(t)
+				httpSession.AssertExpectations(t)
+			})
+		}
+	})
+
+	// Decision 8: a database error and a session that is simply not there used to be one branch,
+	// which returned a variable that was sometimes nil to mean both. They have different answers.
+	t.Run("A failed teardown is a 500", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			stubDB func(database *mocks_data.Database)
+			errMsg string
+		}{
+			{
+				name: "the session lookup fails",
+				stubDB: func(database *mocks_data.Database) {
+					database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").
+						Return(nil, errors.New("lookup exploded"))
+				},
+				errMsg: "lookup exploded",
+			},
+			{
+				name: "the delete fails",
+				stubDB: func(database *mocks_data.Database) {
+					userSession := &models.UserSession{Id: 42, UserId: 123}
+					database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(userSession, nil)
+					database.On("DeleteUserSession", mock.Anything, int64(42)).Return(errors.New("delete exploded"))
+				},
+				errMsg: "delete exploded",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+				httpSession := mocks_sessionstore.NewStore(t)
+				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+				database := mocks_data.NewDatabase(t)
+				auditLogger := mocks_audit.NewAuditLogger(t)
+
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+				req := withSessionIdentifier(logoutPostRequest(t, url.Values{}), "test-session")
+				rr := httptest.NewRecorder()
+
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+				tc.stubDB(database)
+
+				httpHelper.On("InternalServerError", mock.Anything, mock.Anything,
+					mock.MatchedBy(func(err error) bool { return err.Error() == tc.errMsg })).
+					Run(func(args mock.Arguments) {
+						args.Get(0).(http.ResponseWriter).WriteHeader(http.StatusInternalServerError)
+					}).Return()
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusInternalServerError, rr.Code)
+				// A failed teardown must not be reported as a completed logout.
+				auditLogger.AssertNotCalled(t, "Log", constants.AuditLogout, mock.Anything)
+				httpHelper.AssertExpectations(t)
+			})
+		}
+	})
+
+	// Decision 10: a hintless logout has nothing to fall back on when the cookie names no live
+	// session, because the session-identifier middleware attaches the identifier only when it
+	// resolves and there is no id_token_hint to read a sid claim from. Having no session to end is
+	// not a failure, so both shapes complete rather than erroring.
+	t.Run("Nothing to tear down still completes", func(t *testing.T) {
+		for _, tc := range []struct {
+			name              string
+			sessionIdentifier string
+			stubDB            func(database *mocks_data.Database)
+		}{
+			{
+				name:              "no session identifier on the request",
+				sessionIdentifier: "",
+				stubDB:            func(database *mocks_data.Database) {},
+			},
+			{
+				name:              "the session row is gone",
+				sessionIdentifier: "test-session",
+				stubDB: func(database *mocks_data.Database) {
+					database.On("GetUserSessionBySessionIdentifier", mock.Anything, "test-session").Return(nil, nil)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+				httpSession := mocks_sessionstore.NewStore(t)
+				authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+				database := mocks_data.NewDatabase(t)
+				auditLogger := mocks_audit.NewAuditLogger(t)
+
+				handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+				req := logoutPostRequest(t, url.Values{})
+				if tc.sessionIdentifier != "" {
+					req = withSessionIdentifier(req, tc.sessionIdentifier)
+				}
+				rr := httptest.NewRecorder()
+
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+				httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+				tc.stubDB(database)
+
+				authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+				auditLogger.On("Log", constants.AuditLogout, mock.MatchedBy(func(details map[string]interface{}) bool {
+					return details["userId"] == int64(0) && details["sessionIdentifier"] == tc.sessionIdentifier
+				})).Return()
+
+				mockSession := expectCookieWipedBeforeSave(t, httpSession)
+
+				httpHelper.On("RenderTemplate", rr, mock.Anything, "/layouts/auth_layout.html", "/logged_out.html",
+					mock.Anything).Return(nil)
+
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusOK, rr.Code)
+				assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+				database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+				auditLogger.AssertNotCalled(t, "Log", constants.AuditDeletedUserSession, mock.Anything)
+				auditLogger.AssertExpectations(t)
+			})
+		}
+	})
+
+	// Decision 17: the confirming POST carries ui_locales in its body, where the global locale
+	// middleware cannot see it, so without the handler's own refinement the signed-out page would
+	// render in a different language from the consent page the user had just read.
+	t.Run("ui_locales in the body only renders the signed-out page in that locale", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+		req := logoutPostRequest(t, url.Values{"ui_locales": {"pt-BR"}})
+		rr := httptest.NewRecorder()
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+
+		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+		auditLogger.On("Log", mock.Anything, mock.Anything).Return()
+
+		mockSession := expectCookieWipedBeforeSave(t, httpSession)
+
+		httpHelper.On("RenderTemplate", rr, mock.MatchedBy(func(rendered *http.Request) bool {
+			return i18n.T(rendered.Context(), "logged_out.title") == "Sessão encerrada"
+		}), "/layouts/auth_layout.html", "/logged_out.html", mock.Anything).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, mockSession.Values, "the OP session cookie must be cleared")
+		httpHelper.AssertExpectations(t)
+	})
+
+	// The other half of decision 17 on this method, and the half the case above cannot reach. A POST
+	// carrying a hint returns before doLogoutWithoutIdToken is ever called, so the refinement has to
+	// happen above that branch rather than inside the hintless one. Move it down and the case above
+	// still passes while every hinted POST that renders anything renders it in the fallback language,
+	// which an RP posting ui_locales in its body has no way to correct.
+	//
+	// Which page comes back is deliberately not asserted: the hinted branch is stage 4's to rewrite,
+	// and the property here is that whatever this handler renders is localized from the body. Today
+	// the shortest hinted render is the missing-target error page.
+	t.Run("ui_locales in the body only reaches a hinted POST's render", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+		req := logoutPostRequest(t, url.Values{
+			"id_token_hint": {"a.b.c"},
+			"ui_locales":    {"pt-BR"},
+		})
+		rr := httptest.NewRecorder()
+
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("a.b.c")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
+
+		httpHelper.On("RenderTemplate", rr, mock.MatchedBy(func(rendered *http.Request) bool {
+			return i18n.T(rendered.Context(), "logout_consent.title") == "Sair"
+		}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		handler.ServeHTTP(rr, req)
+
+		httpHelper.AssertExpectations(t)
+		database.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
 	})
 
 	t.Run("Session store error", func(t *testing.T) {
@@ -1168,27 +1769,23 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 
 		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
 
-		req, err := http.NewRequest("POST", "/logout", nil)
-		assert.NoError(t, err)
-
+		req := logoutPostRequest(t, url.Values{})
 		rr := httptest.NewRecorder()
 
-		// Mock GetFromUrlQueryOrFormPost to return empty string (no id_token_hint)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
-		sessionError := errors.New("session store error")
-		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(nil, sessionError)
+		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+		auditLogger.On("Log", mock.Anything, mock.Anything).Return()
 
-		httpHelper.On("InternalServerError",
-			mock.Anything,
-			mock.Anything,
-			mock.MatchedBy(func(err error) bool {
-				return err.Error() == "session store error"
-			}),
-		).Run(func(args mock.Arguments) {
-			w := args.Get(0).(http.ResponseWriter)
-			w.WriteHeader(http.StatusInternalServerError)
-		}).Return()
+		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).
+			Return(nil, errors.New("session store error"))
+
+		httpHelper.On("InternalServerError", mock.Anything, mock.Anything,
+			mock.MatchedBy(func(err error) bool { return err.Error() == "session store error" })).
+			Run(func(args mock.Arguments) {
+				args.Get(0).(http.ResponseWriter).WriteHeader(http.StatusInternalServerError)
+			}).Return()
 
 		handler.ServeHTTP(rr, req)
 
@@ -1206,27 +1803,21 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 
 		handler := HandleAccountLogoutPost(httpHelper, httpSession, authHelper, database, auditLogger)
 
-		req, err := http.NewRequest("POST", "/logout", nil)
-		assert.NoError(t, err)
-
+		req := logoutPostRequest(t, url.Values{})
 		rr := httptest.NewRecorder()
 
-		// Mock GetFromUrlQueryOrFormPost to return empty string (no id_token_hint)
 		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "id_token_hint").Return("")
+		httpHelper.On("GetFromUrlQueryOrFormPost", mock.Anything, "post_logout_redirect_uri").Return("")
 
-		mockSession := &sessions.Session{
-			Values: make(map[interface{}]interface{}),
-		}
+		authHelper.On("GetLoggedInSubject", mock.Anything).Return("user-123")
+		auditLogger.On("Log", mock.Anything, mock.Anything).Return()
+
+		mockSession := &sessions.Session{Values: make(map[interface{}]interface{})}
 		httpSession.On("Get", mock.Anything, constants.AuthServerSessionName).Return(mockSession, nil)
 		httpSession.On("Save", mock.Anything, mock.Anything, mockSession).Return(errors.New("session save error"))
 
-		httpHelper.On("InternalServerError",
-			mock.AnythingOfType("*httptest.ResponseRecorder"),
-			mock.AnythingOfType("*http.Request"),
-			mock.MatchedBy(func(err error) bool {
-				return err.Error() == "session save error"
-			}),
-		).Return()
+		httpHelper.On("InternalServerError", mock.Anything, mock.Anything,
+			mock.MatchedBy(func(err error) bool { return err.Error() == "session save error" })).Return()
 
 		handler.ServeHTTP(rr, req)
 

--- a/src/authserver/internal/handlers/handler_account_logout_test.go
+++ b/src/authserver/internal/handlers/handler_account_logout_test.go
@@ -1234,3 +1234,216 @@ func TestHandleAccountLogoutPost(t *testing.T) {
 		httpHelper.AssertExpectations(t)
 	})
 }
+
+func TestBuildPostLogoutRedirect(t *testing.T) {
+	tests := []struct {
+		name          string
+		registeredURI string
+		state         string
+		statePresent  bool
+		expected      string
+		expectError   bool
+	}{
+		{
+			name:          "Base64 state survives byte-identical",
+			registeredURI: "https://app.example.com/out",
+			state:         "aB+cd/efgh==",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=aB%2Bcd%2Fefgh%3D%3D",
+		},
+		{
+			name:          "Fragment and parameter separators in state are escaped",
+			registeredURI: "https://app.example.com/out",
+			state:         "a#b&c=d",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=a%23b%26c%3Dd",
+		},
+		{
+			name:          "Absent state writes no query",
+			registeredURI: "https://app.example.com/out",
+			state:         "",
+			statePresent:  false,
+			expected:      "https://app.example.com/out",
+		},
+		{
+			name:          "Empty state supplied comes back empty",
+			registeredURI: "https://app.example.com/out",
+			state:         "",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=",
+		},
+		{
+			name:          "Whitespace-only state is not trimmed",
+			registeredURI: "https://app.example.com/out",
+			state:         "   ",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=+++",
+		},
+		{
+			name:          "A registered query is preserved",
+			registeredURI: "https://app.example.com/out?lang=en",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?lang=en&state=abc",
+		},
+		{
+			name:          "A registered state is replaced, not duplicated",
+			registeredURI: "https://app.example.com/out?state=fixed",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=abc",
+		},
+		{
+			// The counterpart to the row above, and it reads like a bug beside it: with
+			// no state supplied the builder writes nothing at all, so whatever the
+			// registered URI carried survives untouched, including its own state.
+			name:          "A registered state survives when none is supplied",
+			registeredURI: "https://app.example.com/out?state=fixed",
+			state:         "",
+			statePresent:  false,
+			expected:      "https://app.example.com/out?state=fixed",
+		},
+		{
+			// What forces url.Parse over the model's url.ParseRequestURI: the latter
+			// keeps the "#" in the path and yields ".../out%23frag?state=abc".
+			name:          "A fragment stays a fragment",
+			registeredURI: "https://app.example.com/out#frag",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=abc#frag",
+		},
+		{
+			// Registered parameters keep their order. Decoding the query into url.Values
+			// and re-encoding it sorts by key, which would rewrite a query an RP signs
+			// over as a raw string.
+			name:          "Registered parameter order is preserved",
+			registeredURI: "https://app.example.com/out?b=2&a=1",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?b=2&a=1&state=abc",
+		},
+		{
+			// The shape that made round-tripping through url.Values lossy: url.ParseQuery
+			// rejects a literal semicolon and url.Query throws the error away, so the whole
+			// registered query used to vanish and the RP landed on a bare path.
+			name:          "A semicolon-separated registered query survives",
+			registeredURI: "https://app.example.com/out?lang=en;mode=dark",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?lang=en;mode=dark&state=abc",
+		},
+		{
+			// The same URI with no state, which never went through url.Values at all. The
+			// pair is what stops preservation depending on whether the RP sent a state.
+			name:          "A semicolon-separated registered query survives with no state",
+			registeredURI: "https://app.example.com/out?lang=en;mode=dark",
+			state:         "",
+			statePresent:  false,
+			expected:      "https://app.example.com/out?lang=en;mode=dark",
+		},
+		{
+			name:          "A valueless registered field does not gain an equals sign",
+			registeredURI: "https://app.example.com/out?flag",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?flag&state=abc",
+		},
+		{
+			name:          "Registered percent-escapes are not normalised",
+			registeredURI: "https://app.example.com/out?p=%7Eok",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?p=%7Eok&state=abc",
+		},
+		{
+			// Field names are decoded before they are compared, so a registered state
+			// cannot survive alongside the RP's by hiding behind an escape.
+			name:          "A percent-encoded registered state key is still replaced",
+			registeredURI: "https://app.example.com/out?%73tate=fixed",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=abc",
+		},
+		{
+			name:          "A repeated registered parameter survives intact",
+			registeredURI: "https://app.example.com/out?a=1&a=2",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?a=1&a=2&state=abc",
+		},
+		{
+			// An empty field is data the operator registered, not noise. Skipping empty
+			// fields while copying is the tidy-looking change that quietly rewrites the
+			// target: this row came back as ".../out?a=1&b=2&state=abc" until it did not.
+			name:          "An interior empty registered field survives",
+			registeredURI: "https://app.example.com/out?a=1&&b=2",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?a=1&&b=2&state=abc",
+		},
+		{
+			// The pair for the row above, on the path that returns the parsed URI
+			// untouched. Together they stop preservation depending on whether the RP
+			// happened to send a state.
+			name:          "An interior empty registered field survives with no state",
+			registeredURI: "https://app.example.com/out?a=1&&b=2",
+			state:         "",
+			statePresent:  false,
+			expected:      "https://app.example.com/out?a=1&&b=2",
+		},
+		{
+			name:          "A leading empty registered field survives",
+			registeredURI: "https://app.example.com/out?&a=1",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?&a=1&state=abc",
+		},
+		{
+			name:          "A trailing empty registered field survives",
+			registeredURI: "https://app.example.com/out?a=1&",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?a=1&&state=abc",
+		},
+		{
+			// Dropping the registered state leaves the empty field behind, so the query
+			// opens with a separator. That is the preservation rule applied literally
+			// rather than a stray ampersand.
+			name:          "A registered state is replaced beside a trailing empty field",
+			registeredURI: "https://app.example.com/out?state=fixed&",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?&state=abc",
+		},
+		{
+			// What the RawQuery != "" guard is for. url.Parse leaves RawQuery empty here
+			// and sets ForceQuery, and strings.Split("", "&") yields one empty field, so
+			// copying unconditionally would emit ".../out?&state=abc".
+			name:          "A registered URI ending in a bare question mark gains only state",
+			registeredURI: "https://app.example.com/out?",
+			state:         "abc",
+			statePresent:  true,
+			expected:      "https://app.example.com/out?state=abc",
+		},
+		{
+			name:          "An unparseable registered URI is an error, not a panic",
+			registeredURI: "://bad",
+			state:         "abc",
+			statePresent:  true,
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := buildPostLogoutRedirect(tc.registeredURI, tc.state, tc.statePresent)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/src/authserver/internal/handlers/interfaces.go
+++ b/src/authserver/internal/handlers/interfaces.go
@@ -23,6 +23,7 @@ type HttpHelper interface {
 	JsonError(w http.ResponseWriter, r *http.Request, err error)
 	EncodeJson(w http.ResponseWriter, r *http.Request, data interface{})
 	GetFromUrlQueryOrFormPost(r *http.Request, key string) string
+	LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool)
 }
 
 type AuthHelper interface {

--- a/src/authserver/internal/server/routes.go
+++ b/src/authserver/internal/server/routes.go
@@ -112,7 +112,7 @@ func (s *Server) initRoutes() {
 		// Token endpoint with ROPC rate limiting (RFC 6749 §4.3.2 MUST protect against brute force)
 		r.With(rateLimiter.LimitROPC).Post("/token", handlers.HandleTokenPost(httpHelper, userSessionManager, s.database, tokenIssuer, tokenValidator, auditLogger))
 		r.Get("/logout", handlers.HandleAccountLogoutGet(httpHelper, s.sessionStore, authHelper, s.database, tokenParser, auditLogger))
-		r.Post("/logout", handlers.HandleAccountLogoutPost(httpHelper, s.sessionStore, authHelper, s.database, auditLogger))
+		r.Post("/logout", handlers.HandleAccountLogoutPost(httpHelper, s.sessionStore, authHelper, s.database, tokenParser, auditLogger))
 	})
 
 	s.router.Route("/account", func(r chi.Router) {

--- a/src/authserver/tests/integration/api_account_logout_request_test.go
+++ b/src/authserver/tests/integration/api_account_logout_request_test.go
@@ -73,7 +73,8 @@ func TestAPIAccountLogoutRequest_Success_And_LogoutFlow_WithAndWithoutCookie(t *
 	assert.Equal(t, code.RedirectURI, q.Get("post_logout_redirect_uri"))
 	assert.Equal(t, reqBody.State, q.Get("state"))
 
-	// 1) Call /auth/logout with cookies: expect 302 to post_logout_redirect with sid present
+	// 1) Call /auth/logout with cookies: expect 302 to post_logout_redirect, carrying state and
+	// nothing else this specification does not define
 	req1, _ := http.NewRequest("GET", out.LogoutUrl, nil)
 	resp1, err := httpClientWithCookies.Do(req1)
 	assert.NoError(t, err)
@@ -83,9 +84,14 @@ func TestAPIAccountLogoutRequest_Success_And_LogoutFlow_WithAndWithoutCookie(t *
 	assert.NoError(t, err)
 	assert.Equal(t, code.RedirectURI, loc1.Scheme+"://"+loc1.Host+loc1.Path)
 	assert.Equal(t, reqBody.State, loc1.Query().Get("state"))
-	assert.Equal(t, code.SessionIdentifier, loc1.Query().Get("sid"))
+	// RP-Initiated Logout 1.0 defines exactly one parameter on the way back to the RP. sid belongs to
+	// Front-Channel Logout, a different endpoint travelling the other direction, and no RP is told to
+	// read it here, so sending it only leaked the identifier into the RP's URL bar, history and access
+	// logs (#109 decision 5).
+	assert.NotContains(t, loc1.RawQuery, "sid=", "sid is not a parameter RP-initiated logout defines")
 
-	// 2) Call /auth/logout without cookies (new client): expect 302 with sid from id_token_hint (fallback)
+	// 2) Call /auth/logout without cookies (new client): the hint's own sid names the session, which
+	// is what makes RP-initiated logout work from a relying party that cannot reach the browser session
 	httpClientNoCookies := createHttpClient(t)
 	req2, _ := http.NewRequest("GET", out.LogoutUrl, nil)
 	resp2, err := httpClientNoCookies.Do(req2)
@@ -96,7 +102,75 @@ func TestAPIAccountLogoutRequest_Success_And_LogoutFlow_WithAndWithoutCookie(t *
 	assert.NoError(t, err)
 	assert.Equal(t, code.RedirectURI, loc2.Scheme+"://"+loc2.Host+loc2.Path)
 	assert.Equal(t, reqBody.State, loc2.Query().Get("state"))
-	assert.Equal(t, code.SessionIdentifier, loc2.Query().Get("sid"))
+	assert.NotContains(t, loc2.RawQuery, "sid=", "sid is not a parameter RP-initiated logout defines")
+}
+
+// TestLogout_WithIdTokenHint_NoRedirectTarget_LogsTheUserOut is #109 item 1, the defect the issue is
+// named for, at the tier where it is observable end to end.
+//
+// post_logout_redirect_uri is OPTIONAL in RP-Initiated Logout 1.0 and this endpoint treated it as
+// required. The check returned before both the database teardown and the cookie wipe, so the most
+// ordinary conforming request in the specification, a valid hint and nothing else, rendered an error
+// page and left the End-User signed in believing they had signed out.
+//
+// The session row going is the assertion that matters. The page is the visible half; the row is the
+// half a user could not have checked.
+func TestLogout_WithIdTokenHint_NoRedirectTarget_LogsTheUserOut(t *testing.T) {
+	grant := createOfflineGrant(t)
+	idToken, _ := sessionBoundGrantOnSameSession(t, grant)
+
+	before, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, before, "the ceremony should have left a session row to tear down")
+
+	resp, err := grant.httpClient.Get(config.GetAuthServer().BaseURL +
+		"/auth/logout?id_token_hint=" + url.QueryEscape(idToken))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Location"), "no target was asked for, so there is nothing to redirect to")
+	// No note, because the RP asked for no return: being told that a return failed would be worse than
+	// saying nothing.
+	assertSignedOutPage(t, resp, signedOutEnglish, false)
+
+	after, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, after, "a hinted logout with no redirect target must still tear the session down")
+}
+
+// TestLogout_RejectedHint_AsksTheEndUserAndRefusesTheRedirect is decision 15 driven through the real
+// stack, and it is deliberately the same request as TestLogout_Hintless_ClientIdAuthorizesTheRedirect
+// with one parameter added: an id_token_hint that cannot be confirmed.
+//
+// Without the hint those parameters redirect. With it they must not, because RP-Initiated Logout 1.0
+// section 4 forbids using information that failed to validate and forbids redirecting once an error is
+// detected. The mechanism is that the consent page a rejected hint renders drops client_id, so the
+// confirming POST has nothing left to authorize a target with, and the note appears instead.
+//
+// The teardown still happens, which is the property the whole change turns on: a hint the OP cannot
+// confirm costs the RP its redirect and costs the End-User nothing.
+func TestLogout_RejectedHint_AsksTheEndUserAndRefusesTheRedirect(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	// Rejected at the parse gate. Seam 2's unit table owns every other way a hint fails; what this tier
+	// adds is that a rejected hint reaches a consent page a browser can actually submit.
+	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
+		"id_token_hint":            {"not.a.token"},
+		"post_logout_redirect_uri": {grant.redirectURI},
+		"client_id":                {grant.client.ClientIdentifier},
+		"state":                    {gofakeit.LetterN(8)},
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Location"),
+		"a rejected hint earns no redirect, however good the client_id beside it looks")
+	assertSignedOutPage(t, resp, signedOutEnglish, true)
+
+	gone, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "the consent page precedes the teardown, it does not replace it")
 }
 
 // The two cases below pin that #129 changed NOTHING about RP-initiated logout (decision 3). The

--- a/src/authserver/tests/integration/api_account_logout_request_test.go
+++ b/src/authserver/tests/integration/api_account_logout_request_test.go
@@ -1,12 +1,16 @@
 package integrationtests
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
@@ -254,4 +258,633 @@ func TestAPIAccountLogoutRequest_ValidationErrors_And_Scope(t *testing.T) {
 	resp4 := makeAPIRequest(t, "POST", urlLogoutReq, tok, api.AccountLogoutRequest{PostLogoutRedirectUri: "https://example.com/"})
 	defer func() { _ = resp4.Body.Close() }()
 	assert.Equal(t, http.StatusForbidden, resp4.StatusCode)
+}
+
+// What logoutThroughConsentPage models while it reproduces the browser's submission of the consent
+// form, and, because the refusals below are easy to mistake for more than they are, what it does not.
+// Anything outside these sets fails the test rather than being skipped: a browser acts on every
+// element, every attribute and every class the form's subtree carries, so a helper that silently
+// ignores the ones nobody taught it lets a page no browser can submit keep the cases below green.
+//
+// What it establishes is the payload a browser would submit from this form, and that nothing the
+// document declares sends that payload elsewhere or forbids it outright. Four dimensions, because a
+// page can be spoiled along each independently and closing one leaves the others open. An earlier
+// version closed only the second, and three mutations walked straight through it: a <fieldset
+// disabled> wrapped round the Yes button, which is an element nobody had declared; "hidden" added to
+// that button's class, which is a hostile value of a permitted attribute; and the Yes and No labels
+// swapped, which changes nothing structural at all.
+//
+//  1. consentFormTags: the element types allowed anywhere inside the form. A <fieldset> disables
+//     every control it wraps, a <select> or <textarea> goes out in a browser's payload and not in
+//     this one, and a <script> cancels the submission outright. None of them is a tag below.
+//  2. The attribute sets: what each of those elements may carry. Deliberately absent, each honoured
+//     by a browser: disabled makes a control unsubmittable, so a disabled Yes button leaves the page
+//     dead and a disabled hidden field drops a parameter; formaction, formmethod, formenctype and
+//     formnovalidate let the submitter override where, how and whether the form goes; form reassigns
+//     which form a control belongs to; required blocks submission until a field is filled; hidden
+//     removes the control from the page.
+//  3. consentClassTokens: every class token logout_consent.html actually uses inside its form. A
+//     class is styling until it is "hidden", and then it is a control the End-User cannot reach, so
+//     an allowlist of keys that never looks at values is not a boundary. Restyling the page means
+//     adding the new tokens here.
+//  4. The document around the form, which decides where the submission goes and whether it happens at
+//     all, and none of which is anywhere near the form: no <base> element, since that is the one thing
+//     that moves what a relative action resolves against; no <style> block, which is the only CSS a
+//     parsed document carries; consentAncestorTags for the element types the form may sit inside;
+//     consentMetaEquivs for what the head may instruct the browser to do, a refresh being enough to
+//     navigate the page away before the End-User could confirm; and consentCSPDirectives for the
+//     policy the response header and that head may carry.
+//
+// Adding an element, an attribute or a class to logout_consent.html means teaching this helper what
+// a browser does with it (#109).
+//
+// What it does not establish is that a browser can use this page. Three inputs to that are outside a
+// parsed document altogether and no refusal here reaches them:
+//
+//   - Style from an external stylesheet. The layout links /static/main.css and two CDN stylesheets,
+//     any of which can hide a control this helper has just read and approved. What the document
+//     declares itself is refused, the style attribute above the form and inside it and a <style>
+//     block anywhere in it; what another file declares needs a CSS engine.
+//   - Script. A handler registered from /static/utils.js or from the layout's JSBootstrap block can
+//     cancel the submit event. The sets below refuse an inline handler on the form and on the
+//     affirmative control, and refuse a <script> inside the form, which is the part the template
+//     declares; the rest needs a JavaScript engine.
+//   - An ancestor attribute outside consentHidingAttrs, which is a denylist for the reason recorded
+//     on it, so its tail is open by construction where every other set here is closed.
+//
+// Closing those three means running the page in a browser, which is a decision about this
+// repository's test dependencies rather than something this file can settle (#109).
+var (
+	consentFormAttrs   = map[string]bool{"action": true, "method": true, "class": true}
+	consentInputAttrs  = map[string]bool{"type": true, "name": true, "value": true, "class": true}
+	consentButtonAttrs = map[string]bool{"type": true, "name": true, "value": true, "class": true, "onclick": true}
+	consentLayoutAttrs = map[string]bool{"class": true}
+
+	consentFormTags = map[string]map[string]bool{
+		"input":  consentInputAttrs,
+		"button": consentButtonAttrs,
+		"div":    consentLayoutAttrs,
+		"p":      consentLayoutAttrs,
+	}
+
+	consentClassTokens = map[string]bool{
+		"mt-2": true, "mt-5": true, "mt-6": true, "mt-8": true,
+		"text-center": true, "text-error": true,
+		"grid": true, "grid-cols-2": true, "gap-3": true,
+		"w-full": true, "btn": true, "btn-primary": true, "btn-secondary": true,
+	}
+
+	// The element types the form may sit inside, which is the auth layout's own structure. An
+	// allowlist works here where it does not for the layout's attributes, because a wrapper element
+	// is exactly the kind of thing that decides whether the controls inside it can be reached at all:
+	// a closed <details> collapses its contents to the summary alone, a <dialog> without open is not
+	// rendered, a <template>'s contents are inert markup a browser never lays out, and a <fieldset>
+	// disables every control it wraps. Naming the four the layout uses refuses all of them, and the
+	// next wrapper nobody has thought of with them.
+	consentAncestorTags = map[string]bool{"html": true, "body": true, "main": true, "div": true}
+
+	// Applied to the form's ancestors, and the one denylist here rather than an allowlist: the auth
+	// layout is shared by every page in the app and its styling is none of this test's business, so
+	// refusing an attribute it has not declared would fail this test for edits that cannot affect
+	// logout. The cost of that choice is that this set alone has an open tail, which the comment on
+	// the helper records as a residual rather than leaving implied.
+	//
+	// Each entry stops the End-User reaching the controls below it. hidden and inert are honoured on
+	// any element, inert additionally making everything inside it unclickable while still visible;
+	// popover renders its element hidden until something shows it; disabled is honoured only on
+	// form-associated elements, and is refused anyway because it costs nothing to refuse. style is
+	// refused whatever it contains, because reading a declaration properly means implementing CSS and
+	// the layout carries no inline style today, so the strict form is also the cheap one.
+	// A slice rather than a set, so a page carrying two of these always fails on the same one and the
+	// message a run reports is reproducible.
+	consentHidingAttrs = []string{"hidden", "inert", "popover", "disabled", "style"}
+
+	// Tailwind's screen-reader-only utility is deliberately absent, for two reasons that agree. It
+	// positions a container off-screen without disabling it, so the form still submits and assistive
+	// technology still reaches it, which makes it the one candidate that does not render the page
+	// unusable. And naming it here would ship a stylesheet rule for it: the CSS build harvests
+	// class-name candidates from this whole module rather than only from web/template as
+	// tailwind.config.js says, so a token spelled out in this file, comments included, appears in the
+	// generated web/static/main.css even though no template asks for it (#109).
+	consentHidingClasses = map[string]bool{"hidden": true, "invisible": true, "collapse": true}
+
+	// The Content-Security-Policy directives this helper has been taught, checked against both places
+	// a policy can arrive: the response header, which MiddlewareSecurityHeaders sets on every
+	// response, and a meta http-equiv in the document head. Those two are the whole of it, so an
+	// allowlist over the directives closes the question rather than sampling it.
+	//
+	// frame-ancestors is what the deployment sends today and it governs framing, not submission. The
+	// two that would refuse this POST outright are form-action, which names where a form may submit,
+	// and sandbox, which forbids submission entirely unless it carries allow-forms. Both would leave
+	// every case below green while no browser could log out, because this helper builds the POST
+	// itself and no policy applies to a Go http.Client. Hardening the deployment means deciding here
+	// whether the new directive permits this form's submission.
+	consentCSPDirectives = map[string]bool{"frame-ancestors": true}
+
+	// The http-equiv values the document head may carry, an allowlist for the same reason
+	// consentCSPDirectives is one: a meta http-equiv is an instruction to the browser and the set of
+	// them that does anything is not this test's to enumerate. The one that would leave every case
+	// below green while no End-User could ever confirm is "refresh", which navigates the document away
+	// on a timer this helper never waits for.
+	//
+	// x-ua-compatible is what both layouts carry today and it does nothing to submission.
+	// content-security-policy is admitted here and then read against consentCSPDirectives, because the
+	// deployment sends a policy and refusing the channel outright would fail on a header it already
+	// sets (#109).
+	consentMetaEquivs = map[string]bool{"x-ua-compatible": true, "content-security-policy": true}
+)
+
+// consentLabels is what the two answer buttons must read in one locale, which is what ties each
+// button to the answer it gives. Without it the affirmative control is identified structurally, by
+// being the one with no cancelling script, and swapping the two translation references leaves the
+// page submitting on visible No and cancelling on visible Yes with every case still green.
+type consentLabels struct{ yes, no string }
+
+// Keyed by the ui_locales the case asks for, empty meaning the default locale, so a case that drives
+// the page in a language nobody recorded labels for fails rather than skipping the check.
+var consentLabelsByLocale = map[string]consentLabels{
+	"":      {yes: "Yes", no: "No"},
+	"pt-BR": {yes: "Sim", no: "Não"},
+}
+
+// unmodelledAttrs names every attribute across the selection that the given set does not cover, each
+// tagged with the element carrying it so a failure says which control to go and look at.
+func unmodelledAttrs(sel *goquery.Selection, modelled map[string]bool) []string {
+	found := []string{}
+	for _, node := range sel.Nodes {
+		for _, attr := range node.Attr {
+			if !modelled[strings.ToLower(attr.Key)] {
+				found = append(found, node.Data+"["+attr.Key+"]")
+			}
+		}
+	}
+	return found
+}
+
+// unmodelledClasses names every class token across the selection that consentClassTokens does not
+// cover. Same contract as unmodelledAttrs, one level down: the attribute is permitted, its value is
+// what has to be read.
+func unmodelledClasses(sel *goquery.Selection) []string {
+	found := []string{}
+	for _, node := range sel.Nodes {
+		for _, attr := range node.Attr {
+			if strings.ToLower(attr.Key) != "class" {
+				continue
+			}
+			for _, token := range strings.Fields(attr.Val) {
+				if !consentClassTokens[token] {
+					found = append(found, node.Data+"."+token)
+				}
+			}
+		}
+	}
+	return found
+}
+
+// unmodelledCSPDirectives names every Content-Security-Policy directive in the given policy that
+// consentCSPDirectives does not cover. An empty policy yields nothing, which is also the answer when
+// that delivery channel carried no policy at all.
+func unmodelledCSPDirectives(policy string) []string {
+	found := []string{}
+	for _, directive := range strings.Split(policy, ";") {
+		fields := strings.Fields(directive)
+		if len(fields) == 0 {
+			continue
+		}
+		if name := strings.ToLower(fields[0]); !consentCSPDirectives[name] {
+			found = append(found, name)
+		}
+	}
+	return found
+}
+
+// logoutThroughConsentPage drives a hintless logout the way a browser does: GET /auth/logout, read
+// the consent page, then submit exactly the fields that page carries. It returns the raw response to
+// the confirming POST, because what the End-User lands on is what the cases below are about.
+//
+// Submitting the page's own fields rather than a hand-built form is the point. The hidden fields are
+// how post_logout_redirect_uri, client_id, state and ui_locales survive a form action that
+// deliberately drops the query string it was served with, and the id_token_hint's absence from that
+// set is the invariant the POST binding's CSRF exemption rests on: a hintless POST had to pass CSRF,
+// so it came from this page (#109).
+//
+// It submits the page the way the page says to submit it, and refuses to submit a page whose rules it
+// does not know. The method and action come off the form, the payload is the successful controls only,
+// the affirmative control has to be one a browser would submit with and has to be the one the
+// End-User reads as Yes, and every element, attribute and class token outside the sets above is a
+// failure rather than an omission. A helper that builds its own POST regardless is precisely what
+// lets a form drifted to GET, an inert Yes button, a Yes button no browser would show, or a submitter
+// overriding the form's destination keep every case below green while no browser can log out.
+//
+// It still builds the POST itself, so what it establishes is bounded by what a parsed document shows.
+// The three inputs outside that boundary are listed above consentFormAttrs, and stylesheets are the
+// one to keep in mind when reading a green run: this helper reads the class tokens the markup carries
+// and cannot know what a stylesheet does with them.
+func logoutThroughConsentPage(t *testing.T, httpClient *http.Client, query url.Values) *http.Response {
+	t.Helper()
+
+	labels, labelled := consentLabelsByLocale[query.Get("ui_locales")]
+	require.True(t, labelled,
+		"no Yes/No labels recorded for ui_locales=%q, so which button means which answer is unknown",
+		query.Get("ui_locales"))
+
+	logoutURL := config.GetAuthServer().BaseURL + "/auth/logout"
+	if len(query) > 0 {
+		logoutURL += "?" + query.Encode()
+	}
+	resp, err := httpClient.Get(logoutURL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"a request with no id_token_hint must render the consent page, which the spec makes a MUST")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(body))
+	require.NoError(t, err)
+
+	// Where the form's action resolves to, which is its real destination however local the attribute
+	// reads. A <base href> moves the document's base URL, so "/auth/logout" would resolve against
+	// whatever origin that names and a browser would deliver this form's payload, CSRF token included,
+	// to that origin while the action assertion below still passed. HTML gives a document exactly one
+	// way to move its base URL, so refusing the element settles this rather than sampling it: with no
+	// <base>, the base URL is the response's own URL, which is what the POST below is built against
+	// (#109).
+	require.Equal(t, 0, doc.Find("base").Length(),
+		"a <base> moves what the form's relative action resolves against, so a browser would submit this page to an origin this helper does not")
+
+	// The one CSS this helper can see. A declaration can hide the form or any control inside it, and
+	// reading one properly means implementing CSS, so the element is refused whatever it contains,
+	// exactly as the style attribute is: no template in either app carries one, which makes the strict
+	// form the cheap one too. A linked stylesheet stays outside this boundary and is recorded above as a
+	// residual, because that one needs a fetch and an engine rather than a parse (#109).
+	require.Equal(t, 0, doc.Find("style").Length(),
+		"a <style> block can hide the form or its controls, and this helper does not implement CSS")
+
+	// And what the head instructs the browser to do, including whether the submission is permitted at
+	// all. Both CSP delivery channels, because a policy from either applies in a browser and neither
+	// applies to the Go client below: see consentCSPDirectives and consentMetaEquivs.
+	require.Empty(t, unmodelledCSPDirectives(resp.Header.Get("Content-Security-Policy")),
+		"the response carries a Content-Security-Policy directive this helper does not model, and a browser may refuse this form's submission because of it")
+	doc.Find("meta[http-equiv]").Each(func(_ int, meta *goquery.Selection) {
+		equiv := strings.ToLower(strings.TrimSpace(meta.AttrOr("http-equiv", "")))
+		require.True(t, consentMetaEquivs[equiv],
+			"the document head carries <meta http-equiv=%q>, whose effect on this page this helper does not model", equiv)
+		if equiv != "content-security-policy" {
+			return
+		}
+		require.Empty(t, unmodelledCSPDirectives(meta.AttrOr("content", "")),
+			"the document head carries a Content-Security-Policy directive this helper does not model, and a browser may refuse this form's submission because of it")
+	})
+
+	// One form, so which form owns a control is never ambiguous, and nothing anywhere on the page
+	// names a form owner of its own, which is how a browser would be told to submit a control this
+	// helper cannot see or to leave out one it reads.
+	require.Equal(t, 1, doc.Find("form").Length(), "the consent page carries exactly one form")
+	require.Equal(t, 0, doc.Find("[form]").Length(),
+		"no control may name a form owner, which would change what a browser submits")
+	formSel := doc.Find("form")
+
+	require.Empty(t, unmodelledAttrs(formSel, consentFormAttrs),
+		"the form carries an attribute this helper does not model, so a browser and these cases would disagree about how the page submits")
+	require.Empty(t, unmodelledClasses(formSel), "the form carries a class token this helper does not model")
+
+	// The whole subtree, not just the controls. A browser reads every element between the form and
+	// its buttons, so an element type nobody declared is an unknown rule rather than decoration:
+	// <fieldset disabled> is the shortest way to render the affirmative control unusable without
+	// touching it, and it is invisible to any check that starts from Find("input, button").
+	formSel.Find("*").Each(func(_ int, el *goquery.Selection) {
+		tag := goquery.NodeName(el)
+		modelled, known := consentFormTags[tag]
+		require.True(t, known,
+			"the consent form contains a <%s>, whose effect on submission this helper does not model", tag)
+		require.Empty(t, unmodelledAttrs(el, modelled),
+			"an element inside the form carries an attribute this helper does not model, and a browser would act on it")
+		require.Empty(t, unmodelledClasses(el),
+			"an element inside the form carries a class token this helper does not model; a class that hides or disables it would leave the page unusable with these cases green")
+	})
+
+	// Above the form, where a container can still hide or disable everything inside it without the form
+	// itself changing at all. An allowlist on the element types, per consentAncestorTags, and a
+	// denylist on the attributes and class tokens, per consentHidingAttrs and consentHidingClasses,
+	// which is where this helper's one open tail is.
+	formSel.Parents().Each(func(_ int, ancestor *goquery.Selection) {
+		tag := goquery.NodeName(ancestor)
+		require.True(t, consentAncestorTags[tag],
+			"the form sits inside a <%s>, whose effect on reaching the controls this helper does not model", tag)
+		for _, attr := range consentHidingAttrs {
+			_, present := ancestor.Attr(attr)
+			require.False(t, present,
+				"a container above the form carries %q, which stops the End-User reaching every control inside it", attr)
+		}
+		for _, token := range strings.Fields(ancestor.AttrOr("class", "")) {
+			require.False(t, consentHidingClasses[token],
+				"a container above the form carries %q, which hides every control inside it", token)
+		}
+	})
+
+	action, ok := formSel.Attr("action")
+	require.True(t, ok)
+	require.Equal(t, "/auth/logout", action,
+		`an explicit action, because action="" would carry the query string and with it the hint`)
+
+	// A GET form would defeat this path twice over, which is why the method is asserted here and then
+	// used below rather than assumed: the GET binding renders the consent page again instead of
+	// tearing anything down, so no End-User could ever confirm a logout, and a GET carries no CSRF
+	// token, which is the only thing that makes a hintless teardown trustworthy without a confirmable
+	// hint. An absent method attribute means GET, so it fails here too (#109).
+	method := formSel.AttrOr("method", "")
+	require.True(t, strings.EqualFold("post", method),
+		"the confirming request must be a POST, got method=%q", method)
+
+	form := url.Values{}
+	formSel.Find("input").Each(func(_ int, input *goquery.Selection) {
+		require.Equal(t, "hidden", strings.ToLower(input.AttrOr("type", "")),
+			"every input on this form is hidden; any other type brings submission rules of its own")
+		name, hasName := input.Attr("name")
+		require.True(t, hasName, "a nameless control is never submitted, so one here would be a mistake")
+		require.False(t, form.Has(name),
+			"two controls named %q would both reach the handler from a browser and only one from here", name)
+		form.Set(name, input.AttrOr("value", ""))
+	})
+	require.NotEmpty(t, form.Get("gorilla.csrf.Token"), "the confirming POST is CSRF protected")
+
+	// Which button gives which answer, read the way the End-User reads it. Identifying the affirmative
+	// control structurally is not enough on its own: swap the two translation references and the
+	// unscripted submit button is the one labelled No, so visible No logs the user out, visible Yes
+	// cancels, and every case below still passes.
+	buttons := formSel.Find("button")
+	require.Equal(t, 2, buttons.Length(),
+		"the consent form asks one question and carries one button per answer")
+	affirmative := buttons.FilterFunction(func(_ int, button *goquery.Selection) bool {
+		return strings.TrimSpace(button.Text()) == labels.yes
+	})
+	declining := buttons.FilterFunction(func(_ int, button *goquery.Selection) bool {
+		return strings.TrimSpace(button.Text()) == labels.no
+	})
+	require.Equal(t, 1, affirmative.Length(), "exactly one button must read %q", labels.yes)
+	require.Equal(t, 1, declining.Length(), "exactly one button must read %q", labels.no)
+
+	// The affirmative control must be one a browser would submit with, or the page is unusable however
+	// correct the handler is: no cancelling handler of its own, and a type that submits, which a button
+	// carrying no type attribute already is per HTML's missing-value default. That it is enabled, shown
+	// and overrides none of the form's action, method or encoding follows from the sets above rather
+	// than from checks of its own (#109).
+	require.Empty(t, affirmative.AttrOr("onclick", ""),
+		"the button labelled %q must not be the one wired to cancel the submission", labels.yes)
+	require.True(t, strings.EqualFold("submit", affirmative.AttrOr("type", "submit")),
+		"the affirmative control must be able to submit the form, got type=%q", affirmative.AttrOr("type", ""))
+
+	// And the declining control must not be able to submit it. Today an inline handler calls
+	// preventDefault(), since a button with no type attribute is a submit control; an explicit
+	// type="button" would do the same without script, and either satisfies this.
+	require.True(t,
+		!strings.EqualFold("submit", declining.AttrOr("type", "submit")) || declining.AttrOr("onclick", "") != "",
+		`the button labelled %q must not submit the form: give it type="button" or keep its cancelling handler`,
+		labels.no)
+
+	// A named submitter is itself a successful control, so a browser would send it too.
+	if name, hasName := affirmative.Attr("name"); hasName {
+		require.False(t, form.Has(name),
+			"the submitter is named %q, which a hidden field already carries; a browser would send both", name)
+		form.Set(name, affirmative.AttrOr("value", ""))
+	}
+
+	// Read off the finished payload rather than off the markup, because the invariant is about what
+	// reaches the handler and any control can carry a parameter: a submit button named id_token_hint
+	// puts one in the body just as a hidden input does. A hintless POST is what the CSRF exemption for
+	// the POST binding rests on, so this is decision 13's invariant and not a tidiness check (#109).
+	require.False(t, form.Has("id_token_hint"),
+		"the confirming POST must not carry an id_token_hint back, whichever control would have carried it")
+
+	// The default encoding, which is what the absent enctype leaves in force: it is modelled on
+	// neither the form nor the submitter, so any attempt to change it fails above rather than here.
+	destURL := config.GetAuthServer().BaseURL + action
+	req, err := http.NewRequest(strings.ToUpper(method), destURL, strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", destURL)
+	req.Header.Set("Origin", config.GetAuthServer().BaseURL)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// signedOutTexts is what the terminal page must render in one locale. It is a struct rather than a
+// bare string per assertion because every field is a separate translation reference in
+// logged_out.html, and i18n.T renders a missing key as the key itself, so a reference that goes stale
+// is visible only to an assertion that looks where it belongs. page_title and title carry the same
+// string in both locales, which is exactly why a substring search over the body cannot tell a broken
+// page_title from a broken title: one lives in <title> and the other in the page heading (#109).
+type signedOutTexts struct {
+	pageTitle string
+	heading   string
+	message   string
+	declined  string
+}
+
+var (
+	signedOutEnglish = signedOutTexts{
+		pageTitle: "Logged out",
+		heading:   "Logged out",
+		message:   "You have been logged out.",
+		declined:  "We could not return you to the application that logged you out.",
+	}
+	signedOutPortuguese = signedOutTexts{
+		pageTitle: "Sessão encerrada",
+		heading:   "Sessão encerrada",
+		message:   "Você saiu da sua conta.",
+		declined:  "Não foi possível retornar você ao aplicativo que solicitou a saída.",
+	}
+)
+
+// assertSignedOutPage reads the terminal page through its rendered markup and checks all four of the
+// template's translation references plus both sides of its one conditional.
+//
+// declined says whether a post-logout target was refused. Both directions are asserted because the
+// note is the page's only variable part and each direction fails for its own reason: missing when a
+// target was refused, the RP's user is left with no idea why they are still here; present when none
+// was asked for, they are told a return failed that nobody requested.
+func assertSignedOutPage(t *testing.T, resp *http.Response, texts signedOutTexts, declined bool) {
+	t.Helper()
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(bodyString(t, resp)))
+	require.NoError(t, err)
+
+	assert.Contains(t, doc.Find("title").Text(), texts.pageTitle, "the browser tab title")
+	require.Equal(t, 1, doc.Find("h2").Length(), "the page has one heading, which the next line names")
+	assert.Equal(t, texts.heading, strings.TrimSpace(doc.Find("h2").Text()), "the page heading")
+
+	rendered := doc.Text()
+	assert.Contains(t, rendered, texts.message,
+		"the signed-out page renders, rather than a redirect to the auth server root")
+	if declined {
+		assert.Contains(t, rendered, texts.declined, "a target that was refused must say so")
+	} else {
+		assert.NotContains(t, rendered, texts.declined,
+			"a user who asked for no return must not be told that a return failed")
+	}
+}
+
+// TestLogout_Hintless_DeletesTheSessionRowAndSparesOfflineGrants is what the endpoint used to get
+// wrong on this path: confirming the consent page cleared the browser cookie and wrote nothing to
+// user_sessions, so session-bound refresh tokens kept working and the row was orphaned from a
+// browser that could no longer name it.
+//
+// Both halves are asserted together because each is the other's control. Deleting the row is the fix;
+// the offline grant still refreshing afterwards is decision 2's boundary, and it is why the teardown
+// deletes the row rather than calling the whole-session termination #129 built, which would revoke
+// offline grants too.
+func TestLogout_Hintless_DeletesTheSessionRowAndSparesOfflineGrants(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	first := grant.refresh(t)
+	require.NotEmpty(t, first["access_token"], "the grant should refresh before logout: %v", first)
+	grant.refreshToken = first["refresh_token"].(string)
+
+	before, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, before, "the ceremony should have left a session row to tear down")
+
+	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"with no post_logout_redirect_uri the confirmation ends on the signed-out page")
+	assertSignedOutPage(t, resp, signedOutEnglish, false)
+
+	after, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, after, "confirming the consent page must delete the session row, not just clear the cookie")
+
+	refreshed := grant.refresh(t)
+	assert.NotEmpty(t, refreshed["access_token"],
+		"an offline grant survives logout, decision 2: %v", refreshed)
+}
+
+// TestLogout_Hintless_ClientIdAuthorizesTheRedirect covers the shape that got no redirect at all
+// before: post_logout_redirect_uri and client_id with no id_token_hint. The spec calls that
+// client_id's most common use, and it is the "other means of confirming the legitimacy of the
+// post-logout redirection target" section 3 requires.
+//
+// The state is the one string that broke every part of the concatenation this replaced: "+" arrived
+// as a space, "/" and "=" went out raw, "#" turned the tail into a fragment the RP's server never
+// saw, and "&injected=1" arrived as a real parameter. Asserting it byte-identical through the real
+// stack is the whole point of doing this at the HTTP tier.
+func TestLogout_Hintless_ClientIdAuthorizesTheRedirect(t *testing.T) {
+	grant := createOfflineGrant(t)
+	const state = "aB+cd/efgh==#&injected=1"
+
+	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
+		"post_logout_redirect_uri": {grant.redirectURI},
+		"client_id":                {grant.client.ClientIdentifier},
+		"state":                    {state},
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	location, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, grant.redirectURI, location.Scheme+"://"+location.Host+location.Path)
+	assert.Equal(t, []string{state}, location.Query()["state"],
+		"exactly one state reaches the RP, byte-identical to what it sent")
+	assert.Empty(t, location.Fragment, `the "#" in state must stay in the query, not become a fragment`)
+	assert.Empty(t, location.Query().Get("injected"), "state must not be able to inject parameters")
+	assert.NotContains(t, location.RawQuery, "sid=",
+		"RP-Initiated Logout defines state and nothing else on the way back, decision 5")
+
+	gone, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "the redirect does not replace the teardown, it follows it")
+}
+
+// TestLogout_Hintless_AbsentAndEmptyStateAreDifferentRedirects drives the real consent page twice
+// and reads what reaches the RP, because absent and empty state is a contract no mocked assertion
+// can prove. It lives at this tier for one specific reason: the distinction is carried by the
+// template's {{if .statePresent}} guard, and the handler unit test can only see the flag it binds.
+// Make that hidden field unconditional and the handler is still correct, the bind assertion still
+// passes, and every RP that sent no state starts receiving "state=" it never asked for.
+//
+// The two rows have to be read together. Neither alone catches the mutation: the empty case passes
+// with an unconditional field, and the absent case passes with no field at all.
+func TestLogout_Hintless_AbsentAndEmptyStateAreDifferentRedirects(t *testing.T) {
+
+	t.Run("no state sent means no state key comes back", func(t *testing.T) {
+		grant := createOfflineGrant(t)
+
+		resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
+			"post_logout_redirect_uri": {grant.redirectURI},
+			"client_id":                {grant.client.ClientIdentifier},
+		})
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+		location, err := url.Parse(resp.Header.Get("Location"))
+		require.NoError(t, err)
+		_, present := location.Query()["state"]
+		assert.False(t, present,
+			"an RP that sent no state must not have one invented for it by the consent form: %q",
+			location.RawQuery)
+	})
+
+	t.Run("state sent empty comes back empty", func(t *testing.T) {
+		grant := createOfflineGrant(t)
+
+		resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
+			"post_logout_redirect_uri": {grant.redirectURI},
+			"client_id":                {grant.client.ClientIdentifier},
+			"state":                    {""},
+		})
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+		location, err := url.Parse(resp.Header.Get("Location"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{""}, location.Query()["state"],
+			"exactly one state, empty, because the RP asked for one and left it empty: %q",
+			location.RawQuery)
+	})
+}
+
+// TestLogout_Hintless_UnregisteredTargetIsDeclinedButTheLogoutHappens is the property the whole
+// change turns on, at the tier where it is observable: a target the OP may not redirect to costs the
+// RP its redirect and nothing else. The user is signed out either way, which is what the seven error
+// returns this replaced got wrong.
+//
+// It also renders the one extra sentence the signed-out page carries in this case, which the unit
+// tier cannot see because it mocks the template away.
+func TestLogout_Hintless_UnregisteredTargetIsDeclinedButTheLogoutHappens(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
+		"post_logout_redirect_uri": {"https://example.com/not-registered"},
+		"client_id":                {grant.client.ClientIdentifier},
+		"state":                    {gofakeit.LetterN(8)},
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Location"), "a target that fails validation must never be redirected to")
+	assertSignedOutPage(t, resp, signedOutEnglish, true)
+
+	gone, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "the teardown reads nothing the redirect resolution produced")
+}
+
+// TestLogout_Hintless_UILocalesSurvivesTheConsentForm pins decision 17. The global locale middleware
+// reads the query only, deliberately, so it cannot see the confirming POST's body. Without the
+// handler's own refinement the user would read a consent page in one language and a signed-out page
+// in another, which this change would have introduced rather than fixed.
+func TestLogout_Hintless_UILocalesSurvivesTheConsentForm(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{"ui_locales": {"pt-BR"}})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	// Every reference on the page, in pt-BR: the whole template has to follow the locale the consent
+	// page was read in, not only the line this case used to check.
+	assertSignedOutPage(t, resp, signedOutPortuguese, false)
 }

--- a/src/authserver/tests/integration/api_account_logout_request_test.go
+++ b/src/authserver/tests/integration/api_account_logout_request_test.go
@@ -557,11 +557,6 @@ func unmodelledCSPDirectives(policy string) []string {
 func logoutThroughConsentPage(t *testing.T, httpClient *http.Client, query url.Values) *http.Response {
 	t.Helper()
 
-	labels, labelled := consentLabelsByLocale[query.Get("ui_locales")]
-	require.True(t, labelled,
-		"no Yes/No labels recorded for ui_locales=%q, so which button means which answer is unknown",
-		query.Get("ui_locales"))
-
 	logoutURL := config.GetAuthServer().BaseURL + "/auth/logout"
 	if len(query) > 0 {
 		logoutURL += "?" + query.Encode()
@@ -570,6 +565,25 @@ func logoutThroughConsentPage(t *testing.T, httpClient *http.Client, query url.V
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode,
 		"a request with no id_token_hint must render the consent page, which the spec makes a MUST")
+
+	return confirmLogoutConsentPage(t, httpClient, resp, query.Get("ui_locales"))
+}
+
+// confirmLogoutConsentPage is the second half of the helper above, split out because the consent
+// page is reached two ways and both have to be driven the same. A GET renders it directly; a POST
+// whose id_token_hint could not be confirmed is answered with a 303 to the GET binding, and only
+// then does the page appear. That second route is the one the CSRF exemption creates, and the whole
+// point of decision 18 is that the page it lands on is submittable, so it has to be submitted by
+// the helper that refuses every way a page can fail to be (#109).
+//
+// uiLocales is what the request asked for, which decides which Yes and No this helper reads.
+func confirmLogoutConsentPage(t *testing.T, httpClient *http.Client, resp *http.Response, uiLocales string) *http.Response {
+	t.Helper()
+
+	labels, labelled := consentLabelsByLocale[uiLocales]
+	require.True(t, labelled,
+		"no Yes/No labels recorded for ui_locales=%q, so which button means which answer is unknown",
+		uiLocales)
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -961,4 +975,319 @@ func TestLogout_Hintless_UILocalesSurvivesTheConsentForm(t *testing.T) {
 	// Every reference on the page, in pt-BR: the whole template has to follow the locale the consent
 	// page was read in, not only the line this case used to check.
 	assertSignedOutPage(t, resp, signedOutPortuguese, false)
+}
+
+// The cases below drive POST /auth/logout the way a relying party's own page would: from a foreign
+// origin, with the End-User's cookies riding along and no CSRF token, because the RP has no way to
+// obtain one. That request shape is what OpenID Connect RP-Initiated Logout 1.0 section 2 makes
+// mandatory, "OpenID Providers MUST support the use of the HTTP GET and POST methods defined in RFC
+// 7231", and what gorilla/csrf refused outright until this exemption existed (#109 decision 9).
+//
+// It is also the classic CSRF shape, which is why the exemption is conditional and why every case
+// here asserts what was torn down and not merely which status came back.
+
+// crossOriginLogoutPost posts form to /auth/logout as another origin would: the Origin header names
+// a site this deployment does not trust, and the body carries no gorilla.csrf.Token.
+//
+// The client is the caller's, so the End-User's session cookie rides along. That is deliberate for
+// the safety cases: without a cookie they would pass for the wrong reason, having proved only that a
+// request with nothing to tear down tears nothing down.
+//
+// It is NOT what a browser does, and the difference is worth stating rather than glossing. The auth
+// server sets its session cookie SameSite=Lax (cmd/goiabada-authserver/main.go), and a browser
+// applying Lax withholds that cookie on a cross-site form POST; Go's cookiejar implements no SameSite
+// rule at all, so it sends it. This helper is therefore the more permissive shape of the two, which
+// is the right way round for the cases asserting that something is refused or torn down.
+// TestLogout_CrossOriginPost_ConfirmedHint_WithoutTheSessionCookie covers the browser's shape, where
+// the cookie is absent and the hint is the only authority the request carries.
+func crossOriginLogoutPost(t *testing.T, httpClient *http.Client, form url.Values) *http.Response {
+	t.Helper()
+
+	const foreignOrigin = "https://relying-party.example"
+
+	req, err := http.NewRequest(http.MethodPost,
+		config.GetAuthServer().BaseURL+"/auth/logout", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", foreignOrigin)
+	req.Header.Set("Referer", foreignOrigin+"/signed-out")
+
+	require.False(t, form.Has("gorilla.csrf.Token"),
+		"a foreign origin cannot obtain a CSRF token, so sending one would model nothing")
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// followSeeOther performs the GET a browser would perform on a 303, and returns that response. It
+// asserts the status here rather than at the call site because a 302 would be followed by a browser
+// with the original method and body, which is not what any caller below means.
+func followSeeOther(t *testing.T, httpClient *http.Client, resp *http.Response) *http.Response {
+	t.Helper()
+
+	require.Equal(t, http.StatusSeeOther, resp.StatusCode,
+		"only 303 tells the browser to re-request by GET, which is what RFC 7231 section 6.4.4 defines it as")
+	location := resp.Header.Get("Location")
+	_ = resp.Body.Close()
+
+	target, err := url.Parse(config.GetAuthServer().BaseURL)
+	require.NoError(t, err)
+	next, err := target.Parse(location)
+	require.NoError(t, err)
+
+	followed, err := httpClient.Get(next.String())
+	require.NoError(t, err)
+	return followed
+}
+
+// TestLogout_CrossOriginPost_WithHintInTheBody_LogsTheUserOut is decision 9's reason for existing,
+// end to end. Before the exemption this returned 403 with the user still signed in, so the POST
+// binding the spec makes mandatory was reachable only from Goiabada's own pages.
+//
+// The hint travels in the BODY deliberately, which is both the shape that keeps an ID token out of
+// browser history and access logs and the shape that pins the exemption's one hazard: finding the
+// hint means parsing the form in middleware, and a form parse consumes the request body. If the
+// handler could not read that body afterwards it would see a request with no parameters at all.
+//
+// The redirect is what makes this case able to see that, and it is not decoration. A teardown alone
+// proves nothing here: a POST whose hint went missing is a HINTLESS POST, which the handler treats as
+// the consent page's confirmation and tears the session down anyway, so "the row is gone" is true
+// down both paths and an assertion that stops there passes on the broken one. That was not
+// hypothetical, it was this case's first version, and a mutation that consumed the body walked
+// straight through it.
+//
+// A redirect can only come from the hint. It carries no client_id, so with the hint the target is
+// authorized by the aud the hint is signed over and the answer is a 302; without it there is nothing
+// left to authorize any target and the answer is the signed-out page. 302 against 200 is therefore
+// the difference between the two teardowns, which is what this case is really about.
+func TestLogout_CrossOriginPost_WithHintInTheBody_LogsTheUserOut(t *testing.T) {
+	grant := createOfflineGrant(t)
+	idToken, _ := sessionBoundGrantOnSameSession(t, grant)
+	state := gofakeit.LetterN(8)
+
+	before, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, before, "the ceremony should have left a session row to tear down")
+
+	resp := crossOriginLogoutPost(t, grant.httpClient, url.Values{
+		"id_token_hint":            {idToken},
+		"post_logout_redirect_uri": {grant.redirectURI},
+		"state":                    {state},
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+		"a POST carrying an id_token_hint must not be refused by CSRF, which is the whole of decision 9")
+	require.Equal(t, http.StatusFound, resp.StatusCode,
+		"the hint reached the handler out of the body, so it authorized the target and the RP gets its redirect")
+
+	location, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, grant.redirectURI, location.Scheme+"://"+location.Host+location.Path)
+	assert.Equal(t, state, location.Query().Get("state"),
+		"state travelled in the body too, so it is the second reading of the same property")
+
+	after, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, after,
+		"a confirmed hint tears the session down on the POST binding exactly as it does on the GET one")
+}
+
+// TestLogout_CrossOriginPost_ConfirmedHint_WithoutTheSessionCookie is the case above in the shape a
+// real browser produces, which is not the shape crossOriginLogoutPost's own client produces.
+//
+// The auth server's session cookie is SameSite=Lax, so a browser withholds it on a cross-site form
+// POST; Go's cookiejar ignores SameSite and sends it. Every other case here therefore runs with a
+// cookie the RP's self-submitting form would not actually carry, and the difference is not cosmetic:
+// it is the whole question of what authorizes this teardown. This case answers it by removing the
+// cookie entirely, so the signed hint is the only authority the request has left.
+//
+// It must still log the user out, because the teardown is scoped to the session the hint's sid names
+// and the client its signed aud names, neither of which is read from the cookie. If this ever starts
+// failing while the cookie-bearing case passes, the endpoint has grown a dependency on the browser's
+// cookie and the POST binding is broken for every relying party using it from their own page, which
+// is the one shape the binding exists for.
+func TestLogout_CrossOriginPost_ConfirmedHint_WithoutTheSessionCookie(t *testing.T) {
+	grant := createOfflineGrant(t)
+	idToken, _ := sessionBoundGrantOnSameSession(t, grant)
+
+	before, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, before, "the ceremony should have left a session row to tear down")
+
+	// A second client, never used for the ceremony, so its jar holds nothing for this origin. Same
+	// transport and same no-follow policy as the first, so the cookie is the only difference.
+	cookieless := createHttpClient(t)
+
+	// Asserted rather than assumed. An empty jar is this case's entire premise: if a cookie were
+	// somehow riding along, every assertion below would still pass and would mean nothing.
+	base, err := url.Parse(config.GetAuthServer().BaseURL)
+	require.NoError(t, err)
+	require.Empty(t, cookieless.Jar.Cookies(base),
+		"the point of this case is the absence of the session cookie, so its absence is checked")
+
+	resp := crossOriginLogoutPost(t, cookieless, url.Values{"id_token_hint": {idToken}})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+		"the exemption keys on the hint, and no cookie is involved in that decision either")
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"no post_logout_redirect_uri was sent, so a confirmed hint ends at the signed-out page")
+	assertSignedOutPage(t, resp, signedOutEnglish, false)
+
+	after, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, after,
+		"the hint's signed sid names the session, so the teardown does not need the browser's cookie")
+}
+
+// TestLogout_CrossOriginPost_WithoutHint_IsRefused is the other half of decision 9, and the half that
+// makes the exemption safe to grant: it is conditional on the hint, so the shape an attacker can
+// actually produce is still refused.
+//
+// A hintless POST is how the consent page confirms a logout, and the handler treats it as consent
+// precisely because it had to pass CSRF to arrive. Exempting the path unconditionally, as
+// /auth/authorize is exempted, would let any site force this teardown with no token and no hint,
+// bypassing the consent question the spec makes a MUST.
+func TestLogout_CrossOriginPost_WithoutHint_IsRefused(t *testing.T) {
+	grant := createOfflineGrant(t)
+
+	resp := crossOriginLogoutPost(t, grant.httpClient, url.Values{
+		"post_logout_redirect_uri": {grant.redirectURI},
+		"client_id":                {grant.client.ClientIdentifier},
+		"state":                    {gofakeit.LetterN(8)},
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"a cross-site POST with no id_token_hint has no claim on the exemption")
+
+	survived, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.NotNil(t, survived, "a refused request must tear nothing down")
+}
+
+// TestLogout_CrossOriginPost_RejectedHint_ReachesASubmittableConsentPage is decision 18 end to end,
+// and it is the case stage 4 could name but not run: nothing reached this branch cross-origin until
+// the exemption existed.
+//
+// The problem decision 18 answers. The exemption keys on the hint being PRESENT, because middleware
+// cannot judge whether a hint is genuine. gorilla/csrf returns on that skip flag before it saves the
+// CSRF cookie and before it attaches the token, so a consent page rendered on the skipped POST itself
+// would carry an empty token field, and its own confirming POST is hintless and therefore not exempt.
+// The End-User would be looking at a page they cannot submit while still signed in, which is the
+// class of defect this whole change exists to remove.
+//
+// The answer is the 303 asserted below: the follow-up GET is never exempt, so the page it renders has
+// a real token and a real cookie. Both halves are asserted, because the redirect alone proves nothing
+// if the page at the end of it still cannot be submitted, and confirmLogoutConsentPage is what
+// refuses a page a browser could not use.
+//
+// Decision 15 rides along and is the reason for the two parameter drops. client_id must not survive
+// the hop: the follow-up GET carries no hint, which is the shape where client_id authorizes a
+// post-logout redirect, so keeping it would hand this request the redirect its rejected hint was
+// specifically denied. id_token_hint must not survive either, for two reasons that are not "it would
+// loop": the follow-up is a GET, and a rejected hint on a GET renders the consent page rather than
+// redirecting again, so there is no loop to prevent. It is dropped because carrying it would put an
+// ID token in the address bar of a top-level navigation, which is the exposure the POST binding
+// exists to avoid, and because it feeds input already judged unusable back into the next request.
+func TestLogout_CrossOriginPost_RejectedHint_ReachesASubmittableConsentPage(t *testing.T) {
+	grant := createOfflineGrant(t)
+	state := gofakeit.LetterN(8)
+
+	// A registered URI and a real client_id, so the redirect below is refused because the hint was
+	// rejected and not because the target failed validation. Without the hint these same parameters
+	// redirect, which is what TestLogout_Hintless_ClientIdAuthorizesTheRedirect establishes.
+	resp := crossOriginLogoutPost(t, grant.httpClient, url.Values{
+		"id_token_hint":            {"not.a.token"},
+		"post_logout_redirect_uri": {grant.redirectURI},
+		"client_id":                {grant.client.ClientIdentifier},
+		"state":                    {state},
+	})
+
+	require.Equal(t, http.StatusSeeOther, resp.StatusCode,
+		"a POST whose hint cannot be confirmed is sent to the GET binding, which is where a usable consent page comes from")
+
+	location, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, "/auth/logout", location.Path)
+	assert.Equal(t, grant.redirectURI, location.Query().Get("post_logout_redirect_uri"),
+		"the target survives the hop, so the declined note can be shown for the right reason")
+	assert.Equal(t, state, location.Query().Get("state"))
+	assert.NotContains(t, location.RawQuery, "id_token_hint",
+		"a hint judged unusable must not be put in the address bar of the follow-up navigation")
+	assert.NotContains(t, location.RawQuery, "client_id",
+		"client_id authorizes the redirect on a hintless request, which is what a rejected hint must not earn")
+
+	stillThere, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, stillThere,
+		"the consent page precedes the teardown: an unconfirmable hint must not tear anything down before the End-User is asked")
+
+	// And the page at the end of the hop is one a browser can actually submit. The helper reads the
+	// token off the form, so an empty csrfField fails here rather than at the confirming POST.
+	consent := followSeeOther(t, grant.httpClient, resp)
+	require.Equal(t, http.StatusOK, consent.StatusCode)
+	confirmed := confirmLogoutConsentPage(t, grant.httpClient, consent, "")
+	defer func() { _ = confirmed.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, confirmed.StatusCode,
+		"the confirming POST is hintless, so it carried a CSRF token and was accepted on its merits")
+	assert.Empty(t, confirmed.Header.Get("Location"),
+		"a rejected hint earns no redirect, and dropping client_id is what enforces that here")
+	assertSignedOutPage(t, confirmed, signedOutEnglish, true)
+
+	gone, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "once the End-User confirms, the logout happens")
+}
+
+// TestLogout_CrossOriginPost_EmptyHint_ExemptsAndIsStillRejected is the two halves of the exemption
+// read against each other, which is the pair that turns it into a hole if they ever disagree.
+//
+// "id_token_hint=" is a parameter the request carried with no value. The middleware must read that as
+// a hint being PRESENT, or a relying party's empty parameter is a 403; the handler must read the same
+// parameter as a hint that cannot be confirmed, or the exempted POST takes the hintless branch, which
+// is the confirmation of the consent page and tears the whole session down without asking anybody
+// (#109 decision 13). Present here and Rejected there is the only pairing that is both usable and
+// safe, and it is why both halves call one extractor rather than each reading the parameter its own
+// way.
+//
+// Both arrival routes, because the middleware finds the parameter in the query without touching the
+// body and in the body only by parsing it, and those are two different pieces of code.
+func TestLogout_CrossOriginPost_EmptyHint_ExemptsAndIsStillRejected(t *testing.T) {
+	for _, route := range []struct {
+		name  string
+		query url.Values
+		form  url.Values
+	}{
+		{"in the query", url.Values{"id_token_hint": {""}}, url.Values{}},
+		{"in the body", url.Values{}, url.Values{"id_token_hint": {""}}},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			grant := createOfflineGrant(t)
+
+			req, err := http.NewRequest(http.MethodPost,
+				config.GetAuthServer().BaseURL+"/auth/logout?"+route.query.Encode(),
+				strings.NewReader(route.form.Encode()))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Origin", "https://relying-party.example")
+
+			resp, err := grant.httpClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+				"the exemption keys on the parameter being present, not on it having a value")
+			assert.Equal(t, http.StatusSeeOther, resp.StatusCode,
+				"and the handler reads that same empty parameter as a hint it cannot confirm, so it asks the End-User")
+
+			survived, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
+			require.NoError(t, err)
+			assert.NotNil(t, survived,
+				"an exempted POST whose hint cannot be confirmed must tear nothing down before the End-User is asked")
+		})
+	}
 }

--- a/src/authserver/web/template/logged_out.html
+++ b/src/authserver/web/template/logged_out.html
@@ -1,0 +1,18 @@
+{{define "title"}}{{ .appName }} - {{ T $.ctx "logged_out.page_title" }}{{end}}
+{{define "head"}}{{end}}
+
+{{define "body"}}
+
+    <h2 class='mb-2 text-xl font-semibold text-center'>{{ T $.ctx "logged_out.title" }}</h2>
+
+    <div class="mt-5">
+
+        <p>{{ T $.ctx "logged_out.message" }}</p>
+
+    </div>
+
+    {{if .redirectDeclined}}
+        <p class="mt-6">{{ T $.ctx "logged_out.redirect_declined" }}</p>
+    {{end}}
+
+{{end}}

--- a/src/authserver/web/template/logout_consent.html
+++ b/src/authserver/web/template/logout_consent.html
@@ -14,7 +14,24 @@
 {{define "body"}}
 
     <h2 class='mb-2 text-xl font-semibold text-center'>{{ T $.ctx "logout_consent.title" }}</h2>
-    <form action="" method="post">
+    <!-- An explicit action, not action="", because action="" resolves to the current URL
+         INCLUDING its query string, which on this page carries the id_token_hint that could
+         not be confirmed. Confirming this page must be a hintless POST: the CSRF token below
+         is then what proves the request came from here, and a POST carrying a hint is only
+         trusted when that hint validates. Sending the hint back would let a cross-site POST
+         with a bogus hint reach a teardown, since the CSRF exemption for the POST binding can
+         only key on the hint being present and cannot judge whether it is genuine (#109).
+
+         The parameters that must survive the round trip are hidden fields instead. state is
+         emitted whenever it was present, empty value included, because an RP that sent
+         "state=" must get "state=" back and one that sent nothing must get no state at all;
+         an unconditional field would make every confirmation look like the former. -->
+    <form action="{{.formAction}}" method="post">
+
+        {{if .postLogoutRedirectUri}}<input type="hidden" name="post_logout_redirect_uri" value="{{.postLogoutRedirectUri}}" />{{end}}
+        {{if .clientId}}<input type="hidden" name="client_id" value="{{.clientId}}" />{{end}}
+        {{if .statePresent}}<input type="hidden" name="state" value="{{.state}}" />{{end}}
+        {{if .uiLocales}}<input type="hidden" name="ui_locales" value="{{.uiLocales}}" />{{end}}
 
         <div class="mt-5">
 

--- a/src/core/handlerhelpers/http_helper.go
+++ b/src/core/handlerhelpers/http_helper.go
@@ -266,3 +266,32 @@ func (h *HttpHelper) GetFromUrlQueryOrFormPost(r *http.Request, key string) stri
 	}
 	return value
 }
+
+// LookupFromUrlQueryOrFormPost reports the value of key and whether the parameter was
+// supplied at all. GetFromUrlQueryOrFormPost cannot express that difference: it returns
+// "" both for a parameter that was absent and for one supplied empty.
+//
+// RP-initiated logout needs the distinction, because the OP echoes the RP's "state" back
+// on the post-logout redirect and the two cases have different answers: an RP that sent
+// "state=" must get "state=" back, and one that sent nothing must get no state parameter
+// at all. Collapsing them either invents a parameter the RP never sent or drops one it
+// did (#109).
+//
+// The value comes from GetFromUrlQueryOrFormPost rather than being re-derived, so the
+// query-beats-body precedence cannot drift between the two helpers. Presence is only
+// consulted when that value is empty, and r.PostForm is populated by then: an empty
+// query value is exactly the case where the legacy helper falls through to r.FormValue,
+// which parses the body.
+func (h *HttpHelper) LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool) {
+	value := h.GetFromUrlQueryOrFormPost(r, key)
+	if len(value) > 0 {
+		return value, true
+	}
+	if _, ok := r.URL.Query()[key]; ok {
+		return "", true
+	}
+	if _, ok := r.PostForm[key]; ok {
+		return "", true
+	}
+	return "", false
+}

--- a/src/core/handlerhelpers/http_helper.go
+++ b/src/core/handlerhelpers/http_helper.go
@@ -260,6 +260,26 @@ func (h *HttpHelper) EncodeJson(w http.ResponseWriter, r *http.Request, data int
 }
 
 func (h *HttpHelper) GetFromUrlQueryOrFormPost(r *http.Request, key string) string {
+	return GetFromUrlQueryOrFormPost(r, key)
+}
+
+func (h *HttpHelper) LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool) {
+	return LookupFromUrlQueryOrFormPost(r, key)
+}
+
+// The two functions below carry the behaviour and the methods above are delegates, because a
+// caller that has no HttpHelper still has to read a parameter exactly as a handler would.
+//
+// The CSRF middleware is that caller (#109). It decides whether to exempt POST /auth/logout on
+// whether an id_token_hint is PRESENT, and the logout handler then classifies the very same
+// parameter. Those two readings have to be the same reading: middleware saying "present" where the
+// handler says "absent" exempts a cross-site POST and then routes it down the hintless branch,
+// which tears the whole session down with no consent. A second implementation beside this one is
+// how that drift arrives, so there is one implementation and both halves call it.
+
+// GetFromUrlQueryOrFormPost returns the value of key from the URL query, falling back to the
+// form body. It cannot distinguish an absent parameter from one supplied empty: both are "".
+func GetFromUrlQueryOrFormPost(r *http.Request, key string) string {
 	value := r.URL.Query().Get(key)
 	if len(value) == 0 {
 		value = r.FormValue(key)
@@ -282,8 +302,8 @@ func (h *HttpHelper) GetFromUrlQueryOrFormPost(r *http.Request, key string) stri
 // consulted when that value is empty, and r.PostForm is populated by then: an empty
 // query value is exactly the case where the legacy helper falls through to r.FormValue,
 // which parses the body.
-func (h *HttpHelper) LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool) {
-	value := h.GetFromUrlQueryOrFormPost(r, key)
+func LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool) {
+	value := GetFromUrlQueryOrFormPost(r, key)
 	if len(value) > 0 {
 		return value, true
 	}

--- a/src/core/handlerhelpers/http_helper_test.go
+++ b/src/core/handlerhelpers/http_helper_test.go
@@ -228,3 +228,40 @@ func TestGetFromUrlQueryOrFormPost(t *testing.T) {
 		assert.Equal(t, "value", value)
 	})
 }
+
+func TestLookupFromUrlQueryOrFormPost(t *testing.T) {
+	templateFS := &mocks.TestFS{}
+	httpHelper := NewHttpHelper(templateFS)
+
+	// postForm builds a form-encoded POST, optionally with a query string of its own.
+	postForm := func(target string, body string) *http.Request {
+		req := httptest.NewRequest("POST", target, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return req
+	}
+
+	tests := []struct {
+		name          string
+		request       *http.Request
+		expectValue   string
+		expectPresent bool
+	}{
+		{"Absent from the query", httptest.NewRequest("GET", "/?other=1", nil), "", false},
+		{"Empty in the query is present", httptest.NewRequest("GET", "/?state=", nil), "", true},
+		{"Present in the query", httptest.NewRequest("GET", "/?state=abc", nil), "abc", true},
+		{"Whitespace in the query is untrimmed", httptest.NewRequest("GET", "/?state=%20%20%20", nil), "   ", true},
+		{"Present in the body", postForm("/", "state=abc"), "abc", true},
+		{"Empty in the body is present", postForm("/", "state="), "", true},
+		{"A non-empty query beats the body", postForm("/?state=abc", "state=xyz"), "abc", true},
+		{"An empty query falls through to the body", postForm("/?state=", "state=xyz"), "xyz", true},
+		{"Absent from the body", postForm("/", "other=1"), "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value, present := httpHelper.LookupFromUrlQueryOrFormPost(tc.request, "state")
+			assert.Equal(t, tc.expectValue, value)
+			assert.Equal(t, tc.expectPresent, present)
+		})
+	}
+}

--- a/src/core/handlerhelpers/mocks/http_helper_mock.go
+++ b/src/core/handlerhelpers/mocks/http_helper_mock.go
@@ -253,6 +253,72 @@ func (_c *HttpHelper_JsonError_Call) RunAndReturn(run func(w http.ResponseWriter
 	return _c
 }
 
+// LookupFromUrlQueryOrFormPost provides a mock function for the type HttpHelper
+func (_mock *HttpHelper) LookupFromUrlQueryOrFormPost(r *http.Request, key string) (string, bool) {
+	ret := _mock.Called(r, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LookupFromUrlQueryOrFormPost")
+	}
+
+	var r0 string
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(*http.Request, string) (string, bool)); ok {
+		return returnFunc(r, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*http.Request, string) string); ok {
+		r0 = returnFunc(r, key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(*http.Request, string) bool); ok {
+		r1 = returnFunc(r, key)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// HttpHelper_LookupFromUrlQueryOrFormPost_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LookupFromUrlQueryOrFormPost'
+type HttpHelper_LookupFromUrlQueryOrFormPost_Call struct {
+	*mock.Call
+}
+
+// LookupFromUrlQueryOrFormPost is a helper method to define mock.On call
+//   - r *http.Request
+//   - key string
+func (_e *HttpHelper_Expecter) LookupFromUrlQueryOrFormPost(r any, key any) *HttpHelper_LookupFromUrlQueryOrFormPost_Call {
+	return &HttpHelper_LookupFromUrlQueryOrFormPost_Call{Call: _e.mock.On("LookupFromUrlQueryOrFormPost", r, key)}
+}
+
+func (_c *HttpHelper_LookupFromUrlQueryOrFormPost_Call) Run(run func(r *http.Request, key string)) *HttpHelper_LookupFromUrlQueryOrFormPost_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *http.Request
+		if args[0] != nil {
+			arg0 = args[0].(*http.Request)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *HttpHelper_LookupFromUrlQueryOrFormPost_Call) Return(s string, b bool) *HttpHelper_LookupFromUrlQueryOrFormPost_Call {
+	_c.Call.Return(s, b)
+	return _c
+}
+
+func (_c *HttpHelper_LookupFromUrlQueryOrFormPost_Call) RunAndReturn(run func(r *http.Request, key string) (string, bool)) *HttpHelper_LookupFromUrlQueryOrFormPost_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RenderTemplate provides a mock function for the type HttpHelper
 func (_mock *HttpHelper) RenderTemplate(w http.ResponseWriter, r *http.Request, layoutName string, templateName string, data map[string]interface{}) error {
 	ret := _mock.Called(w, r, layoutName, templateName, data)

--- a/src/core/i18n/catalogs/active.en.toml
+++ b/src/core/i18n/catalogs/active.en.toml
@@ -1459,19 +1459,6 @@
 "handler.admin_resource_permissions.permission_identifier_required" = "Permission identifier is required."
 "handler.admin_resource_permissions.description_too_long" = "The description cannot exceed a maximum length of {{.max}} characters."
 
-# --- Logout handler (LocalizedError-backed) ----------------------------------
-
-"handler.logout.error_title" = "Logout error"
-"handler.logout.post_logout_redirect_uri_required" = "The post_logout_redirect_uri parameter is required. This parameter must match one of the redirect URIs that was registered for this client."
-"handler.logout.id_token_hint_decrypt_failed" = "Failed to decrypt the id_token_hint."
-"handler.logout.id_token_hint_invalid" = "The id_token_hint parameter is invalid."
-"handler.logout.id_token_hint_iss_missing" = "The id_token_hint parameter is invalid: the iss claim is missing."
-"handler.logout.id_token_hint_iss_mismatch" = "The id_token_hint parameter is invalid: the iss claim does not match the issuer of this server."
-"handler.logout.aud_claim_missing" = "The aud claim is missing in id_token_hint."
-"handler.logout.invalid_client" = "Invalid client."
-"handler.logout.client_id_mismatch" = "The client_id parameter does not match the aud claim in id_token_hint."
-"handler.logout.invalid_post_logout_redirect_uri" = "Invalid post_logout_redirect_uri."
-
 # --- Password validator (LocalizedError-backed) ------------------------------
 
 "validator.password.too_short" = "The minimum length for the password is {{.min}} characters"

--- a/src/core/i18n/catalogs/active.en.toml
+++ b/src/core/i18n/catalogs/active.en.toml
@@ -80,6 +80,13 @@
 "logout_consent.title" = "Logout"
 "logout_consent.confirm" = "Are you sure you want to logout?"
 
+# --- Logged out (auth/logout) -----------------------------------------------
+
+"logged_out.page_title" = "Logged out"
+"logged_out.title" = "Logged out"
+"logged_out.message" = "You have been logged out."
+"logged_out.redirect_declined" = "We could not return you to the application that logged you out."
+
 # --- OAuth/internal error page (auth_error.html) ----------------------------
 
 "auth_error.page_title" = "Error"

--- a/src/core/i18n/catalogs/active.pt-BR.toml
+++ b/src/core/i18n/catalogs/active.pt-BR.toml
@@ -78,6 +78,13 @@
 "logout_consent.title" = "Sair"
 "logout_consent.confirm" = "Tem certeza de que deseja sair?"
 
+# --- Sessão encerrada (auth/logout) ------------------------------------------
+
+"logged_out.page_title" = "Sessão encerrada"
+"logged_out.title" = "Sessão encerrada"
+"logged_out.message" = "Você saiu da sua conta."
+"logged_out.redirect_declined" = "Não foi possível retornar você ao aplicativo que solicitou a saída."
+
 # --- Página de erro OAuth/interno (auth_error.html) --------------------------
 
 "auth_error.page_title" = "Erro"

--- a/src/core/i18n/catalogs/active.pt-BR.toml
+++ b/src/core/i18n/catalogs/active.pt-BR.toml
@@ -1402,17 +1402,6 @@
 "handler.admin_resource_permissions.permission_identifier_required" = "O identificador da permissão é obrigatório."
 "handler.admin_resource_permissions.description_too_long" = "A descrição não pode ter mais que {{.max}} caracteres."
 
-"handler.logout.error_title" = "Erro de logout"
-"handler.logout.post_logout_redirect_uri_required" = "O parâmetro post_logout_redirect_uri é obrigatório. Este parâmetro precisa corresponder a uma das URIs de redirecionamento cadastradas para este cliente."
-"handler.logout.id_token_hint_decrypt_failed" = "Falha ao descriptografar o id_token_hint."
-"handler.logout.id_token_hint_invalid" = "O parâmetro id_token_hint é inválido."
-"handler.logout.id_token_hint_iss_missing" = "O parâmetro id_token_hint é inválido: a claim iss está ausente."
-"handler.logout.id_token_hint_iss_mismatch" = "O parâmetro id_token_hint é inválido: a claim iss não corresponde ao issuer deste servidor."
-"handler.logout.aud_claim_missing" = "A claim aud está ausente no id_token_hint."
-"handler.logout.invalid_client" = "Cliente inválido."
-"handler.logout.client_id_mismatch" = "O parâmetro client_id não corresponde à claim aud do id_token_hint."
-"handler.logout.invalid_post_logout_redirect_uri" = "post_logout_redirect_uri inválido."
-
 "validator.password.too_short" = "O comprimento mínimo para a senha é {{.min}} caracteres"
 "validator.password.too_long" = "O comprimento máximo para a senha é {{.max}} caracteres"
 "validator.password.lowercase_required" = "Conforme nossa política, é obrigatório um caractere minúsculo na senha."

--- a/src/core/i18n/error_codes.go
+++ b/src/core/i18n/error_codes.go
@@ -86,19 +86,12 @@ const (
 	ErrCodeAdminResourcePermissionsIdentifierRequired        = "handler.admin_resource_permissions.permission_identifier_required"
 	ErrCodeAdminResourcePermissionsDescriptionTooLong        = "handler.admin_resource_permissions.description_too_long" // Args: {"max": int}
 
-	// Logout handler — RP-initiated logout via /auth/logout. Errors render
-	// the auth_error.html page; underlying diagnostic detail is logged via
-	// slog rather than concatenated into the user-visible message.
-	ErrCodeLogoutErrorTitle                  = "handler.logout.error_title"
-	ErrCodeLogoutPostLogoutRedirectRequired  = "handler.logout.post_logout_redirect_uri_required"
-	ErrCodeLogoutIdTokenHintDecryptFailed    = "handler.logout.id_token_hint_decrypt_failed"
-	ErrCodeLogoutIdTokenHintInvalid          = "handler.logout.id_token_hint_invalid"
-	ErrCodeLogoutIdTokenHintIssMissing       = "handler.logout.id_token_hint_iss_missing"
-	ErrCodeLogoutIdTokenHintIssMismatch      = "handler.logout.id_token_hint_iss_mismatch"
-	ErrCodeLogoutAudClaimMissing             = "handler.logout.aud_claim_missing"
-	ErrCodeLogoutInvalidClient               = "handler.logout.invalid_client"
-	ErrCodeLogoutClientIdMismatch            = "handler.logout.client_id_mismatch"
-	ErrCodeLogoutInvalidPostLogoutRedirect   = "handler.logout.invalid_post_logout_redirect_uri"
+	// RP-initiated logout via /auth/logout carries no error codes. It used to
+	// carry ten, all of which rendered an error page to the End-User instead of
+	// logging them out. A hint the OP cannot confirm is now answered with the
+	// consent page the spec requires, and a redirect target it may not use costs
+	// the request its redirect and nothing else, so there is no failure left on
+	// that endpoint that the End-User is the right audience for (#109).
 
 	// Profile validator — username, names, nickname, website, gender,
 	// date of birth, zone info, locale.

--- a/src/core/i18n/error_codes.md
+++ b/src/core/i18n/error_codes.md
@@ -96,25 +96,6 @@ resource-permissions page.
 | `handler.admin_resource_permissions.permission_identifier_required` | (none) | Permission identifier is required. |
 | `handler.admin_resource_permissions.description_too_long` | `max` (int) | The description cannot exceed a maximum length of {{.max}} characters. |
 
-## Logout handler
-
-RP-initiated logout (`/auth/logout`) error page (`auth_error.html`). Underlying
-diagnostic detail (decryption failures, JWT parse errors) is logged via slog
-rather than concatenated into the user-visible message.
-
-| Code | Args | English message |
-|---|---|---|
-| `handler.logout.error_title` | (none) | Logout error |
-| `handler.logout.post_logout_redirect_uri_required` | (none) | The post_logout_redirect_uri parameter is required. This parameter must match one of the redirect URIs that was registered for this client. |
-| `handler.logout.id_token_hint_decrypt_failed` | (none) | Failed to decrypt the id_token_hint. |
-| `handler.logout.id_token_hint_invalid` | (none) | The id_token_hint parameter is invalid. |
-| `handler.logout.id_token_hint_iss_missing` | (none) | The id_token_hint parameter is invalid: the iss claim is missing. |
-| `handler.logout.id_token_hint_iss_mismatch` | (none) | The id_token_hint parameter is invalid: the iss claim does not match the issuer of this server. |
-| `handler.logout.aud_claim_missing` | (none) | The aud claim is missing in id_token_hint. |
-| `handler.logout.invalid_client` | (none) | Invalid client. |
-| `handler.logout.client_id_mismatch` | (none) | The client_id parameter does not match the aud claim in id_token_hint. |
-| `handler.logout.invalid_post_logout_redirect_uri` | (none) | Invalid post_logout_redirect_uri. |
-
 ## Password validator
 
 | Code | Args | English message |

--- a/src/core/middleware/middleware_csrf.go
+++ b/src/core/middleware/middleware_csrf.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/csrf"
+	"github.com/leodip/goiabada/core/handlerhelpers"
 )
 
 // csrfCookieMaxAgeSeconds keeps the CSRF cookie valid for a year so it never
@@ -56,13 +57,73 @@ var csrfExemptPrefixes = []string{
 	"/static/",
 }
 
-// shouldSkipCsrf reports whether CSRF protection should be bypassed for the
-// given request path. CSRF defends cookie-authenticated, state-changing
-// requests; the exempt paths carry no session cookie (they are bearer/client-
-// authenticated or safe-method static assets), so a CSRF token would never be
-// present and enforcing it would only break legitimate non-browser clients.
-// See csrfExemptExactPaths and csrfExemptPrefixes for the per-endpoint rationale.
-func shouldSkipCsrf(path string) bool {
+// csrfConditionalExemptions lists endpoints whose exemption depends on the request rather than only
+// on its path. Matched EXACTLY, like csrfExemptExactPaths, and the predicate decides the rest; a
+// path absent from all three tables keeps full CSRF protection.
+//
+//	/auth/logout - RP-initiated logout, exempt only for a POST carrying an id_token_hint. See
+//	               logoutIdTokenHintPresent.
+//
+// This table exists because an unconditional entry above would be a hole: any site could then POST
+// to /auth/logout with no hint and no token, and the handler treats a hintless POST as the
+// confirmation of its consent page, so the End-User would be signed out without ever being asked.
+var csrfConditionalExemptions = map[string]func(*http.Request) bool{
+	"/auth/logout": logoutIdTokenHintPresent,
+}
+
+// logoutIdTokenHintPresent reports whether this is a POST to the logout endpoint carrying an
+// id_token_hint, which is the one shape of /auth/logout that must work cross-site.
+//
+// OpenID Connect RP-Initiated Logout 1.0 section 2 is a MUST here: "OpenID Providers MUST support
+// the use of the HTTP GET and POST methods defined in RFC 7231". Without an exemption gorilla/csrf
+// rejects every cross-origin POST, so the binding exists for relying parties that cannot reach it,
+// and an RP that wants a self-submitting form to keep the ID token out of the URL has no way in.
+//
+// PRESENCE, not a value, and read through the same function the handler classifies the parameter
+// with. The two readings must agree in one direction above all: this saying "present" where the
+// handler reads "absent" would exempt a cross-site POST and then send it down the hintless branch,
+// which tears the whole session down with no consent. Sharing handlerhelpers'
+// LookupFromUrlQueryOrFormPost is what makes that agreement structural rather than a promise, and
+// it is why "id_token_hint=" is exempt here and Rejected there (#109).
+//
+// Presence alone is safe because middleware cannot judge whether a hint is genuine and the handler
+// does not trust it to: a POST whose hint fails to validate tears nothing down, it is answered with
+// a redirect to the GET binding and ends at the consent page. So the exemption buys an attacker a
+// consent page they cannot confirm, which is where a plain link to /auth/logout already lands.
+//
+// POST only. Everything gorilla/csrf checks is a POST here in practice, and confining it means the
+// form parse below happens on one path and one method rather than on requests that have no business
+// being read.
+//
+// The admin console registers this same middleware and mounts only GET /auth/logout, so a POST
+// there is answered by chi with 405 before any handler runs. Exempting a route that does not exist
+// changes nothing; noted so the shared table does not read as an oversight.
+// Reading the body here does let a foreign origin have its body parsed before it is turned away,
+// where gorilla/csrf would previously have rejected it on the Origin header alone. That is inherent
+// to decision 9 rather than introduced by reading the body: the same origin need only move the hint
+// into the query to reach the handler, which parses the body itself to honour ui_locales. Go bounds
+// the parse the same way it bounds every other form endpoint here, and middleware_ratelimiter and
+// middleware_jwt already parse forms on this side of the chain.
+func logoutIdTokenHintPresent(r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		return false
+	}
+	// Reads the query first and only then the body, so a hint in the query costs no parse. When it
+	// does parse, Go caches the result in r.PostForm and the handler's own r.FormValue reuses it,
+	// which is what stops this middleware consuming the body the handler is about to read.
+	_, present := handlerhelpers.LookupFromUrlQueryOrFormPost(r, "id_token_hint")
+	return present
+}
+
+// shouldSkipCsrf reports whether CSRF protection should be bypassed for this request. CSRF defends
+// cookie-authenticated, state-changing requests; the exempt paths carry no session cookie (they are
+// bearer/client-authenticated or safe-method static assets), so a CSRF token would never be present
+// and enforcing it would only break legitimate non-browser clients. See csrfExemptExactPaths,
+// csrfExemptPrefixes and csrfConditionalExemptions for the per-endpoint rationale.
+//
+// The path is passed in rather than read off the request because the caller has already resolved
+// chi's normalized RoutePath, which is what a trailing slash arrives as.
+func shouldSkipCsrf(r *http.Request, path string) bool {
 	if csrfExemptExactPaths[path] {
 		return true
 	}
@@ -70,6 +131,11 @@ func shouldSkipCsrf(path string) bool {
 		if strings.HasPrefix(path, prefix) {
 			return true
 		}
+	}
+	// Last, so an unconditional entry always wins and no predicate is consulted, and with it no
+	// request body read, for a path that was exempt anyway.
+	if exempt, ok := csrfConditionalExemptions[path]; ok {
+		return exempt(r)
 	}
 	return false
 }
@@ -86,7 +152,7 @@ func MiddlewareSkipCsrf() func(next http.Handler) http.Handler {
 				path = rctx.RoutePath
 			}
 
-			if shouldSkipCsrf(path) {
+			if shouldSkipCsrf(r, path) {
 				r = csrf.UnsafeSkipCheck(r)
 			}
 			next.ServeHTTP(w, r.WithContext(r.Context()))

--- a/src/core/middleware/middleware_csrf_test.go
+++ b/src/core/middleware/middleware_csrf_test.go
@@ -2,8 +2,10 @@ package middleware
 
 import (
 	"encoding/hex"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -17,52 +19,107 @@ const skipCheckKey string = "gorilla.csrf.Skip"
 func TestMiddlewareSkipCsrf(t *testing.T) {
 	tests := []struct {
 		name string
-		path string
+		// method defaults to GET, which is what every path-only row wants: the exemption those rows
+		// describe does not depend on the method.
+		method string
+		path   string
+		// body is sent as application/x-www-form-urlencoded when set, which is how a relying party
+		// serializes logout parameters into a POST per OpenID Connect Core's Form Serialization.
+		body string
 		skip bool
 	}{
 		// Exempt: exact-match endpoints (bearer/client-authenticated, no cookie).
-		{"Authorize exact", "/auth/authorize", true},
-		{"Token exact", "/auth/token", true},
-		{"Callback exact", "/auth/callback", true},
-		{"Userinfo exact", "/userinfo", true},
-		{"DCR register exact", "/connect/register", true},
+		{"Authorize exact", "", "/auth/authorize", "", true},
+		{"Token exact", "", "/auth/token", "", true},
+		{"Callback exact", "", "/auth/callback", "", true},
+		{"Userinfo exact", "", "/userinfo", "", true},
+		{"DCR register exact", "", "/connect/register", "", true},
 
 		// Exempt: intentional subtree prefixes.
-		{"API admin subtree", "/api/v1/admin/users", true},
-		{"API account subtree", "/api/v1/account/profile", true},
-		{"API public settings", "/api/public/settings", true},
-		{"Static css", "/static/file.css", true},
-		{"Static nested js", "/static/js/app.js", true},
+		{"API admin subtree", "", "/api/v1/admin/users", "", true},
+		{"API account subtree", "", "/api/v1/account/profile", "", true},
+		{"API public settings", "", "/api/public/settings", "", true},
+		{"Static css", "", "/static/file.css", "", true},
+		{"Static nested js", "", "/static/js/app.js", "", true},
 
 		// Drift guards: sibling routes under a formerly-prefixed path must NOT
 		// inherit the exemption now that single endpoints are matched exactly.
-		{"Token introspect not skipped", "/auth/token-introspect", false},
-		{"Tokeninfo not skipped", "/auth/tokeninfo", false},
-		{"Tokens not skipped", "/auth/tokens", false},
-		{"Userinfo export not skipped", "/userinfo-export", false},
-		{"Userinfo typo not skipped", "/userinfoo", false},
-		{"Connect register status not skipped", "/connect/register-status", false},
-		{"Connect bare not skipped", "/connect/", false},
-		{"Static without slash not skipped", "/static-secret", false},
-		{"Authorize-extra not skipped", "/auth/authorize-extra", false},
+		{"Token introspect not skipped", "", "/auth/token-introspect", "", false},
+		{"Tokeninfo not skipped", "", "/auth/tokeninfo", "", false},
+		{"Tokens not skipped", "", "/auth/tokens", "", false},
+		{"Userinfo export not skipped", "", "/userinfo-export", "", false},
+		{"Userinfo typo not skipped", "", "/userinfoo", "", false},
+		{"Connect register status not skipped", "", "/connect/register-status", "", false},
+		{"Connect bare not skipped", "", "/connect/", "", false},
+		{"Static without slash not skipped", "", "/static-secret", "", false},
+		{"Authorize-extra not skipped", "", "/auth/authorize-extra", "", false},
 
 		// Cookie-authenticated routes must keep CSRF protection.
-		{"Auth pwd protected", "/auth/pwd", false},
-		{"Auth otp protected", "/auth/otp", false},
-		{"Auth consent protected", "/auth/consent", false},
-		{"Auth logout protected", "/auth/logout", false},
-		{"Account register protected", "/account/register", false},
-		{"Account profile protected", "/account/profile", false},
-		{"Admin console page protected", "/admin/clients", false},
-		{"Forgot password protected", "/forgot-password", false},
-		{"Reset password protected", "/reset-password", false},
-		{"Root protected", "/", false},
-		{"Other path", "/other", false},
+		{"Auth pwd protected", "", "/auth/pwd", "", false},
+		{"Auth otp protected", "", "/auth/otp", "", false},
+		{"Auth consent protected", "", "/auth/consent", "", false},
+		{"Auth logout protected", "", "/auth/logout", "", false},
+		{"Account register protected", "", "/account/register", "", false},
+		{"Account profile protected", "", "/account/profile", "", false},
+		{"Admin console page protected", "", "/admin/clients", "", false},
+		{"Forgot password protected", "", "/forgot-password", "", false},
+		{"Reset password protected", "", "/reset-password", "", false},
+		{"Root protected", "", "/", "", false},
+		{"Other path", "", "/other", "", false},
+
+		// The one conditional exemption: POST /auth/logout carrying an id_token_hint, which
+		// RP-Initiated Logout 1.0 section 2 makes a MUST ("OpenID Providers MUST support the use of
+		// the HTTP GET and POST methods defined in RFC 7231") and which gorilla/csrf otherwise
+		// refuses from every foreign origin (#109 decision 9).
+		//
+		// Both arrival routes, because a relying party may put the parameter in the query or
+		// serialize it into the body, and the handler reads both.
+		{"Logout POST with a hint in the query", http.MethodPost, "/auth/logout?id_token_hint=abc", "", true},
+		{"Logout POST with a hint in the body", http.MethodPost, "/auth/logout", "id_token_hint=abc", true},
+
+		// PRESENCE, not a value, and this pair is the reason the shared extractor exists. The
+		// handler classifies "id_token_hint=" as a hint that was supplied and cannot be confirmed,
+		// so it asks the End-User. Were this predicate to read the same parameter as no hint at all,
+		// the exempted POST would take the hintless branch instead, which is the confirmation of the
+		// consent page and tears the whole session down without asking anybody (#109 decision 13).
+		{"Logout POST with an empty hint in the query", http.MethodPost, "/auth/logout?id_token_hint=", "", true},
+		{"Logout POST with an empty hint in the body", http.MethodPost, "/auth/logout", "id_token_hint=", true},
+
+		// And the hintless POST keeps full protection, which is the whole reason the exemption is
+		// conditional: an unconditional entry would let any site force a logout with no token at all.
+		{"Logout POST with no hint", http.MethodPost, "/auth/logout", "", false},
+		{"Logout POST with only other parameters", http.MethodPost, "/auth/logout", "state=abc&client_id=x", false},
+		{"Logout POST with a lookalike parameter", http.MethodPost, "/auth/logout?id_token_hintx=abc", "", false},
+		{"Logout POST with a lookalike parameter in the body", http.MethodPost, "/auth/logout", "id_token_hint_x=abc", false},
+
+		// Methods other than POST are not exempted even with a hint. GET is never checked by
+		// gorilla/csrf anyway; PUT and DELETE are, and neither is routed here, so exempting them
+		// would widen the hole for a route that would have to be added deliberately.
+		{"Logout GET with a hint", http.MethodGet, "/auth/logout?id_token_hint=abc", "", false},
+		{"Logout PUT with a hint", http.MethodPut, "/auth/logout?id_token_hint=abc", "", false},
+		{"Logout DELETE with a hint", http.MethodDelete, "/auth/logout?id_token_hint=abc", "", false},
+
+		// The predicate is bound to its exact path, like the exact-match table above and for the same
+		// drift reason: an id_token_hint on any other endpoint exempts nothing.
+		{"Auth pwd POST with a hint", http.MethodPost, "/auth/pwd?id_token_hint=abc", "", false},
+		{"Logout sibling route with a hint", http.MethodPost, "/auth/logout-extra?id_token_hint=abc", "", false},
+		{"Logout prefix route with a hint", http.MethodPost, "/auth/logout/confirm?id_token_hint=abc", "", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tt.path, nil)
+			method := tt.method
+			if method == "" {
+				method = http.MethodGet
+			}
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+			req := httptest.NewRequest(method, tt.path, body)
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			}
 			rr := httptest.NewRecorder()
 
 			handler := MiddlewareSkipCsrf()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +136,79 @@ func TestMiddlewareSkipCsrf(t *testing.T) {
 			}))
 
 			handler.ServeHTTP(rr, req)
+		})
+	}
+}
+
+// TestMiddlewareSkipCsrf_LogoutBodySurvivesTheHintCheck is the case decision 9 names as the thing
+// that has to be pinned: looking for the hint in a POST body means parsing the form in middleware,
+// and a form parse consumes the request body.
+//
+// It survives because Go caches the parse in r.PostForm and r.Form, and the handler's r.FormValue
+// reads the cache rather than the socket. If it ever stopped surviving, the logout handler would see
+// a request with no ui_locales, no state and no post_logout_redirect_uri, which is a page in the
+// wrong language and a redirect that silently does not happen, so this asserts the siblings and not
+// only the hint itself.
+func TestMiddlewareSkipCsrf_LogoutBodySurvivesTheHintCheck(t *testing.T) {
+	body := url.Values{
+		"id_token_hint":            {"a.b.c"},
+		"post_logout_redirect_uri": {"https://rp.example/bye"},
+		"state":                    {"opaque+value/=="},
+		"ui_locales":               {"pt-BR"},
+	}
+
+	var seen url.Values
+	var skipped bool
+	handler := MiddlewareSkipCsrf()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		skipped, _ = r.Context().Value(skipCheckKey).(bool)
+		seen = url.Values{}
+		for _, key := range []string{"id_token_hint", "post_logout_redirect_uri", "state", "ui_locales"} {
+			seen.Set(key, r.FormValue(key))
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !skipped {
+		t.Fatal("a POST carrying an id_token_hint in its body must be exempted")
+	}
+	for key, want := range body {
+		if got := seen.Get(key); got != want[0] {
+			t.Errorf("handler read %s = %q after the middleware parsed the body, want %q", key, got, want[0])
+		}
+	}
+}
+
+// TestMiddlewareSkipCsrf_OtherPathsKeepAnUnreadBody is the boundary on the test above: the body is
+// read for the one path that has a predicate and for nothing else.
+//
+// It matters because the exempt prefixes include the whole /api/ subtree, whose handlers decode JSON
+// straight off r.Body. A predicate table that grew a prefix entry, or a parse hoisted out of the
+// predicate and up into the middleware, would leave those handlers reading an empty body and the
+// failure would look nothing like a CSRF change.
+func TestMiddlewareSkipCsrf_OtherPathsKeepAnUnreadBody(t *testing.T) {
+	const payload = `{"name":"unread"}`
+
+	for _, path := range []string{"/api/v1/admin/users", "/auth/token", "/auth/pwd", "/auth/logout-extra"} {
+		t.Run(path, func(t *testing.T) {
+			var got string
+			handler := MiddlewareSkipCsrf()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				raw, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("reading the body: %v", err)
+				}
+				got = string(raw)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got != payload {
+				t.Errorf("handler read %q from the body, want %q: the middleware consumed it", got, payload)
+			}
 		})
 	}
 }
@@ -111,32 +241,57 @@ func TestMiddlewareSkipCsrf_CombinedChain(t *testing.T) {
 		r.Post("/userinfo", inner)
 		r.Post("/userinfo-export", inner)
 		r.Post("/api/v1/admin/users", inner)
+		r.Post("/auth/logout", inner)
+		r.Post("/auth/logout-extra", inner)
 		return r
 	}
 
 	tests := []struct {
 		name       string
 		path       string
+		body       string
 		wantStatus int
 	}{
 		// Exempt endpoints let the foreign-origin POST through.
-		{"POST /auth/authorize foreign origin reaches handler", "/auth/authorize", http.StatusOK},
-		{"POST /auth/authorize/ trailing slash reaches handler", "/auth/authorize/", http.StatusOK},
-		{"POST /auth/token reaches handler", "/auth/token", http.StatusOK},
-		{"POST /userinfo reaches handler", "/userinfo", http.StatusOK},
-		{"POST /api/v1/admin/users reaches handler", "/api/v1/admin/users", http.StatusOK},
+		{"POST /auth/authorize foreign origin reaches handler", "/auth/authorize", "", http.StatusOK},
+		{"POST /auth/authorize/ trailing slash reaches handler", "/auth/authorize/", "", http.StatusOK},
+		{"POST /auth/token reaches handler", "/auth/token", "", http.StatusOK},
+		{"POST /userinfo reaches handler", "/userinfo", "", http.StatusOK},
+		{"POST /api/v1/admin/users reaches handler", "/api/v1/admin/users", "", http.StatusOK},
 
 		// Non-exempt routes are still blocked (403 origin invalid).
-		{"POST /auth/pwd foreign origin still blocked", "/auth/pwd", http.StatusForbidden},
-		{"POST /auth/authorize-extra not skipped", "/auth/authorize-extra", http.StatusForbidden},
-		{"POST /auth/token-introspect not skipped", "/auth/token-introspect", http.StatusForbidden},
-		{"POST /userinfo-export not skipped", "/userinfo-export", http.StatusForbidden},
+		{"POST /auth/pwd foreign origin still blocked", "/auth/pwd", "", http.StatusForbidden},
+		{"POST /auth/authorize-extra not skipped", "/auth/authorize-extra", "", http.StatusForbidden},
+		{"POST /auth/token-introspect not skipped", "/auth/token-introspect", "", http.StatusForbidden},
+		{"POST /userinfo-export not skipped", "/userinfo-export", "", http.StatusForbidden},
+
+		// The logout binding, which is what the exemption is for: a relying party POSTs a hint from
+		// its own origin and must reach the handler. Both arrival routes and the trailing-slash form,
+		// since the path the predicate is matched against comes from chi's StripSlashes.
+		{"POST /auth/logout with a hint in the query reaches handler", "/auth/logout?id_token_hint=abc", "", http.StatusOK},
+		{"POST /auth/logout with a hint in the body reaches handler", "/auth/logout", "id_token_hint=abc", http.StatusOK},
+		{"POST /auth/logout/ trailing slash with a hint reaches handler", "/auth/logout/?id_token_hint=abc", "", http.StatusOK},
+		{"POST /auth/logout with an empty hint reaches handler", "/auth/logout?id_token_hint=", "", http.StatusOK},
+
+		// And the shape the exemption must never cover. This is the case that makes the conditional
+		// table worth its complexity: an unconditional /auth/logout entry would answer this 200 and
+		// any site could force a logout (#109 decision 9).
+		{"POST /auth/logout with no hint is still blocked", "/auth/logout", "", http.StatusForbidden},
+		{"POST /auth/logout with only other parameters is still blocked", "/auth/logout", "state=abc", http.StatusForbidden},
+		{"POST /auth/logout-extra with a hint is still blocked", "/auth/logout-extra?id_token_hint=abc", "", http.StatusForbidden},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := newRouter()
-			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+			req := httptest.NewRequest(http.MethodPost, tt.path, body)
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			}
 			req.Header.Set("Origin", foreignOrigin)
 			rr := httptest.NewRecorder()
 


### PR DESCRIPTION
Closes #109.

`/auth/logout` implements OpenID Connect RP-Initiated Logout 1.0 and nothing else. Three defects the
issue reports, plus four more found while verifying it, are fixed here. The headline one is that the
most common conforming request failed closed in the worst possible way: a `GET /auth/logout` with a
valid `id_token_hint` and no `post_logout_redirect_uri` rendered an error page **and left the user
signed in**, because both the database teardown and the cookie wipe sat after that early return.
`post_logout_redirect_uri` is OPTIONAL in the spec.

## What changed

**One rule replaced seven special cases.** `doLogoutWithIdToken` and the no-hint half of
`HandleAccountLogoutPost` collapsed into a single pipeline that both HTTP methods enter, with four
independent stages: classify the hint, decide whether to ask the End-User, resolve the redirect
target, tear down and respond.

The property that fixes the reported defect and its six siblings at once, and the one to check first
when reviewing: **the teardown reads nothing the redirect resolution produced.** Hint validity decides
whether the End-User is asked. Redirect-target validity decides only whether a redirect happens.
Neither decides whether the logout happens, which always does.

| Request | Response |
|---|---|
| Valid hint matching the current session | tear down, then redirect if the target validates, else the signed-out page |
| No hint, or a hint that cannot be confirmed | consent page; on the confirming POST tear down, then redirect if `client_id` validates the target, else the signed-out page |
| Any redirect target that cannot be validated | tear down anyway, then the signed-out page, never a redirect |

**The hint gets three states, not two: confirmed, absent, and supplied-but-rejected.** Collapsing
"rejected" into "absent" is what let a detected `client_id`/`aud` mismatch go on to authorize a
redirect, which section 4 of the spec forbids twice over: information that failed to validate MUST NOT
be used, and on detecting an error the OP MUST NOT perform post-logout redirection. A rejected hint now
permits consent and teardown and forbids any redirect, whatever `client_id` says.

**`state` is built with `url.Values` instead of string concatenation.** All four failure modes were
reproduced before being fixed: a base64 `state` had its `+` decoded to a space, breaking the RP's CSRF
check; a `#` truncated the value into a fragment; an `&` injected arbitrary parameters; and a
registered URI with its own query was corrupted to `lang=en?sid=...`. `state` now round-trips byte for
byte, is not trimmed (the spec calls it opaque), and arrives exactly once even when the registered URI
already carried one. An RP that sent `state=` gets `state=` back and one that sent nothing gets none,
which needed a presence-aware parameter lookup, since the existing helper returns `""` for both.

**The non-standard `sid` is gone from the redirect.** RP-Initiated Logout defines exactly one parameter
on the way back, `state`. `sid` belongs to Front-Channel Logout: a different endpoint, the opposite
direction, and a spec that requires `iss` alongside it. Nothing consumed it, and it was an identifier
disclosure into the RP's URL bar, history and access logs. Nothing replaces it.

**A hintless logout now actually ends the session.** It used to clear the cookie and redirect without
touching the database, so session-bound refresh tokens kept working and the row was orphaned from a
browser that could no longer reach it. Every confirmation of the consent page takes that branch. It now
loads the session by the cookie's identifier and deletes it, emitting `AuditDeletedUserSession` beside
the existing `AuditLogout`. Offline grants survive, which is OIDC Core section 11's reading and what
#129 adopted.

**A hint naming a different session no longer returns HTTP 500.** The spec says to ask the End-User
when the supplied ID Token does not belong to the current session, so it renders the consent page.
Reachable with no attacker: sign in, the RP holds an ID token, the session is replaced, the RP
initiates logout with the older one.

**An expired hint is accepted while its session lives.** The spec: the OP SHOULD accept ID Tokens whose
`aud` or `sid` has a current or recent session "even when the `exp` time has passed". The admin console
mints a 60-second hint, so an admin who paused on the way through failed logout. Parsing now runs with
the library's claims validation off and every claim is checked by hand, because the library's `false`
branch disables **all** claims checking rather than just `exp`. A past `exp` is tolerated only when the
`sid` resolves to a live session row.

**`POST /auth/logout` works cross-site, when and only when it carries an `id_token_hint`.** The spec is
a MUST: "OpenID Providers MUST support the use of the HTTP GET and POST methods defined in RFC 7231".
`/auth/logout` was absent from the CSRF exempt paths, so gorilla/csrf refused every cross-origin POST
and the binding was unreachable for the RPs it exists for. The exemption is a predicate over the
request rather than a path entry: POST only, and only on hint **presence**, since middleware cannot
judge validity.

A hintless POST keeps full CSRF protection, and that is what makes the exemption safe: a hintless POST
is exactly what the consent screen submits, so a cross-site one with a garbage hint gets the consent
page rather than a teardown. The consent form drops the hint, so confirming it is always hintless and
always CSRF-checked. A skipped POST with a rejected hint is answered `303 See Other` to
`GET /auth/logout`, carrying `post_logout_redirect_uri`, `state` and `ui_locales` and dropping
`id_token_hint` and `client_id`, because a CSRF-skipped response carries no token and its own consent
page would otherwise be unsubmittable.

**Ten logout error codes and `renderAuthError` are deleted**, 40 deletions across four files each. The
diagnostics rendered to the End-User, for whom "the `id_token_hint` parameter is invalid" is noise; the
reason belongs in the server log, and the four sites that lacked one gained it. A new `logged_out.html`
replaces them as the terminal page, with one optional note when a redirect target was supplied and not
honoured. It also replaces the old redirect to the auth server's base URL, which bounced a logged-out
RP user onto an admin sign-in page they had no reason to see.

## What did not change, deliberately

**Per-client teardown on the hinted path.** #129 decided grants survive logout and gave the reason: a
user logging out of one client would silently break the other clients still on that session. Its two
integration tests pass unedited, which was the check that the change had not exceeded its scope.
Client-scoped revocation is #135.

**The cookie wipe stays whole-session** while the database teardown stays per-client. The asymmetry is
real and recorded in a code comment: the RP asked the OP to log the End-User out, and that is the OP
session.

**`client_id` never scopes a teardown.** It is unauthenticated, so a caller could name any client. It
is trusted for exactly one thing, deciding whether a supplied URI is registered to the client it names,
which is self-limiting because the URI must already be in that client's set. Only a confirmed hint,
whose `aud` is signed, scopes the per-client teardown.

## Stages

| Stage | Commit | What landed |
|---|---|---|
| 1 | `a4a586d` | the post-logout redirect builder and the presence-aware parameter lookup |
| 2 | `7a6c039` | the hintless path end to end: real teardown, the signed-out page, 10 error codes deleted |
| 3 | `ad43d76` | hint classification into confirmed, absent and rejected |
| 4 | `6a0f47d` | the hinted pipeline, collapsing both bindings into one |
| 5 | `3972dc4` | the conditional CSRF exemption |

## Tests

Full suite green on all four engines: **9308 passing, zero failures**, 10m11s.

| Tier | Engines | Result |
|---|---|---|
| unit | n/a | 2800 pass |
| data | mysql, postgres, mssql, sqlite | 1564 pass |
| integration | mysql, postgres, mssql, sqlite | 4852 pass |

No migration and no new `Database` method: the teardown uses `GetUserSessionBySessionIdentifier` and
`DeleteUserSession`, and `user_session_clients` already cascades in all four engines.

Coverage sits at four seams. The redirect builder owns the encoding table exhaustively, including
`state` containing `+`, `/`, `=`, `#` and `&`, absent versus empty versus whitespace-only, and a
registered URI that already carries its own `state`. Hint classification owns one case per rejection
reason, each differing from the confirmed case in exactly one field, 34 rows. The two handlers own the
method-by-hint-state-by-target table. `shouldSkipCsrf` owns the exemption, including that a handler
downstream still reads the body after the middleware parsed it looking for the hint. Integration owns
only what mocks cannot show: a real `Location` header, a real cross-origin POST, the row actually gone,
and an offline grant still refreshing afterwards.

Mutation testing found a defect in this change's own tests, which is the most useful thing the run
produced. The cross-origin confirmed-hint case asserted a teardown happened, and passed under a
mutation that broke the feature, because a hintless POST tears the whole session down too. It now
requires the `302` that only a confirmed hint can authorize. A later round found the same shape again:
every cross-origin case ran with a session cookie a real browser would withhold under `SameSite=Lax`,
so a case was added with no cookie at all, where the signed hint is the request's only authority.

## Notes for review

Two **deferred decisions** are in [a comment below](https://github.com/leodip/goiabada/pull/150#issuecomment-5223581795):
whether the registered URI's query is preserved byte for byte or canonicalised, and whether the
consent page's integration coverage should drive a real browser. Both are cheap to reverse and both
name what reversing costs.

Three **drafted follow-ups** are in [a second comment](https://github.com/leodip/goiabada/pull/150#issuecomment-5223585941),
each with the `gh issue create` command that files it: a client/resource identifier namespace collision
that makes an access token indistinguishable from an ID token to audience validation (hardening, since
the one live instance is closed here), the consent page's No button submitting without JavaScript, and
the CSS build harvesting class names from the whole Go module. #146, #147, #148 and #149 were filed
during the run.

One decision was escalated and answered here: how a CSRF-skipped POST reaches a submittable consent
page, answered `A`, the `303`.
