### PR TITLE
fix(authserver): clear the auth context before the client response is committed

### DIFF
--- a/src/authserver/internal/handlers/handler_auth_completed.go
+++ b/src/authserver/internal/handlers/handler_auth_completed.go
@@ -197,14 +197,29 @@ func HandleAuthCompletedGet(
 			auditLogger.Log(constants.AuditUserDisabled, map[string]interface{}{
 				"userId": user.Id,
 			})
-			err := redirToClientWithError(w, r, templateFS, "access_denied", "The user account is disabled.",
-				authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+			// The clear goes FIRST. ClearAuthContext persists the deletion through a Set-Cookie
+			// on w, and redirToClientWithError commits the response in every response mode, so
+			// clearing afterwards leaves the header on a response already written and the
+			// browser keeps an auth context it can replay (#141).
+			err := authHelper.ClearAuthContext(w, r)
 			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
+				// The clear failed, so Save wrote no cookie and the browser still holds the
+				// auth context. The client is owed an error response regardless: its redirect
+				// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+				// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+				slog.Error("failed to clear the auth context, answering the client with server_error",
+					"error", err)
+				err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+					authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+				if err != nil {
+					// Nowhere left to send the client, so the 500 is the last resort here.
+					httpHelper.InternalServerError(w, r, err)
+				}
 				return
 			}
 
-			err = authHelper.ClearAuthContext(w, r)
+			err = redirToClientWithError(w, r, templateFS, "access_denied", "The user account is disabled.",
+				authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
 			if err != nil {
 				httpHelper.InternalServerError(w, r, err)
 				return
@@ -225,13 +240,28 @@ func HandleAuthCompletedGet(
 		// in the auth context replace the scope with the effective scope
 		authContext.SetScope(effectiveScope)
 		if len(authContext.Scope) == 0 {
-			err = redirToClientWithError(w, r, templateFS, "access_denied", "The user is not authorized to access any of the requested scopes", authContext.ResponseMode,
-				authContext.RedirectURI, authContext.State, authContext.ResponseType)
+			// The clear goes FIRST, for the same reason as the disabled-user refusal above: a
+			// Set-Cookie written after redirToClientWithError has committed never reaches the
+			// wire, so the browser keeps a replayable auth context (#141).
+			err = authHelper.ClearAuthContext(w, r)
 			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
+				// The clear failed, so Save wrote no cookie and the browser still holds the
+				// auth context. The client is owed an error response regardless: its redirect
+				// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+				// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+				slog.Error("failed to clear the auth context, answering the client with server_error",
+					"error", err)
+				err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+					authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+				if err != nil {
+					// Nowhere left to send the client, so the 500 is the last resort here.
+					httpHelper.InternalServerError(w, r, err)
+				}
+				return
 			}
 
-			err = authHelper.ClearAuthContext(w, r)
+			err = redirToClientWithError(w, r, templateFS, "access_denied", "The user is not authorized to access any of the requested scopes", authContext.ResponseMode,
+				authContext.RedirectURI, authContext.State, authContext.ResponseType)
 			if err != nil {
 				httpHelper.InternalServerError(w, r, err)
 				return

--- a/src/authserver/internal/handlers/handler_auth_completed_test.go
+++ b/src/authserver/internal/handlers/handler_auth_completed_test.go
@@ -550,7 +550,14 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 
 		auditLogger.On("Log", constants.AuditUserDisabled, mock.Anything).Return()
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// The clear has to reach the browser, so it must happen before the response is
+		// committed. rr.Header() is the live map the handler and this stub share, so it shows
+		// the sentinel under either ordering; rr.Result() reads the snapshot taken when the
+		// status line was written, which is the only unit-tier view that tells them apart.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -565,6 +572,273 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		assert.Equal(t, "access_denied", query.Get("error"))
 		assert.Contains(t, query.Get("error_description"), "The user account is disabled")
 		assert.Equal(t, "some-state", query.Get("state"))
+
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("User is not enabled, failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		templateFS := &mocks_test.TestFS{}
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "query",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: false,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		auditLogger.On("Log", constants.AuditUserDisabled, mock.Anything).Return()
+
+		// A failed clear writes no cookie, so the browser keeps the auth context whatever the
+		// handler does next. The client is still owed its error response, and server_error is
+		// the code RFC 6749 4.1.2.1 mints for a fault that cannot travel as a 500.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "access_denied")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("User is not enabled, failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		// Deliberately malformed, an unclosed action, so template.ParseFS fails and
+		// redirToClientWithError returns "unable to parse template" instead of committing.
+		// form_post is the only response mode whose arm can fail after the redirect URI has
+		// been validated, so it is how this branch is reached at all.
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: false,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		auditLogger.On("Log", constants.AuditUserDisabled, mock.Anything).Return()
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		// The clear failed and the server_error response the client is owed cannot be built
+		// either, so there is nowhere left to send it and the 500 is the last resort. Without
+		// this expectation the handler would answer nothing at all.
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		// Nothing reached the client: the form_post arm fails before it writes, and the 500 is
+		// the mock's, so no redirect is committed.
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("User is not enabled, unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: false,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		auditLogger.On("Log", constants.AuditUserDisabled, mock.Anything).Return()
+
+		// The other half of the same family: here the clear succeeds and it is the ordinary
+		// refusal that cannot be committed. This is the site's second and pre-existing 500,
+		// pinned separately so a future edit cannot delete either copy unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)
@@ -641,7 +915,11 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		// Simulate the scope being filtered to an empty string
 		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("", nil)
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// Same sentinel as the disabled-user case, for the second refusal in this handler.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -656,6 +934,262 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		assert.Equal(t, "access_denied", query.Get("error"))
 		assert.Contains(t, query.Get("error_description"), "The user is not authorized to access any of the requested scopes")
 		assert.Equal(t, "some-state", query.Get("state"))
+
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("Scope filtered to empty with a failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		templateFS := &mocks_test.TestFS{}
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "query",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: true,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("", nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "access_denied")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("Scope filtered to empty with a failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: true,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("", nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+		database.AssertExpectations(t)
+		auditLogger.AssertExpectations(t)
+		permissionChecker.AssertExpectations(t)
+	})
+
+	t.Run("Scope filtered to empty with an unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleAuthCompletedGet(httpHelper, authHelper, userSessionManager, database, templateFS, auditLogger, permissionChecker)
+
+		req, _ := http.NewRequest("GET", "/auth/completed", nil)
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateAuthenticationCompleted,
+			ClientId:     "test-client",
+			UserId:       1,
+			Scope:        "openid profile",
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "some-state",
+		}
+
+		sessionIdentifier := "test-session"
+		ctx := context.WithValue(req.Context(), constants.ContextKeySessionIdentifier, sessionIdentifier)
+		req = req.WithContext(ctx)
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		userSession := &models.UserSession{
+			Id:       1,
+			UserId:   1,
+			AcrLevel: enums.AcrLevel1.String(),
+			AuthTime: time.Now().UTC().Add(-5 * time.Minute),
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, sessionIdentifier).Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		client := &models.Client{
+			Id:                       1,
+			ClientIdentifier:         "test-client",
+			DefaultAcrLevel:          enums.AcrLevel1,
+			AuthorizationCodeEnabled: true,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
+			"", enums.AcrLevel1.String()).Return(userSession, nil)
+
+		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
+
+		user := &models.User{
+			Id:      1,
+			Enabled: true,
+		}
+		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
+
+		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("", nil)
+
+		// The clear succeeds and it is the ordinary refusal that cannot be committed. Before
+		// this change the handler carried on into the clear after answering the 500, which is
+		// the missing return decision 5 adds; the 500 is asserted Once() so a second one would
+		// fail the mock.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)

--- a/src/authserver/internal/handlers/handler_auth_issue.go
+++ b/src/authserver/internal/handlers/handler_auth_issue.go
@@ -47,8 +47,9 @@ func HandleIssueGet(
 			return
 		}
 
-		// id_token_hint sub enforcement (OIDC Core 3.1.2.1):
-		// "MUST NOT reply with an ID Token or Access Token for a different user"
+		// id_token_hint sub enforcement (OIDC Core 3.1.2.2, Authentication Request Validation):
+		// "The Authorization Server MUST NOT reply with an ID Token or Access Token for a
+		// different user, even if they have an active session with the Authorization Server."
 		// This is the critical safety net that catches mismatched users even after successful authentication.
 		if authContext.IdTokenHintSub != "" {
 			user, err := database.GetUserById(nil, authContext.UserId)
@@ -57,16 +58,37 @@ func HandleIssueGet(
 				return
 			}
 			if user == nil || user.Subject.String() != authContext.IdTokenHintSub {
-				// Cannot issue tokens for a different user than the hint identifies
-				err := redirToClientWithError(w, r, templateFS, constants.ErrorLoginRequired,
+				// Cannot issue tokens for a different user than the hint identifies.
+				//
+				// The clear goes FIRST, the order the prompt=none refusal below and the success
+				// path both use. ClearAuthContext persists the deletion through a Set-Cookie on
+				// w, and redirToClientWithError commits the response in every response mode, so
+				// clearing afterwards leaves the header on a response already written. This is
+				// the one refusal that leaves the context in ready_to_issue_code, the state that
+				// mints codes, so a browser keeping it can replay this endpoint with only the
+				// comparison above standing between the replay and a code (#141).
+				err := authHelper.ClearAuthContext(w, r)
+				if err != nil {
+					// The clear failed, so Save wrote no cookie and the browser still holds the
+					// auth context. The client is owed an error response regardless: its redirect
+					// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+					// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+					slog.Error("failed to clear the auth context, answering the client with server_error",
+						"error", err)
+					err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+						authContext.ResponseMode, authContext.RedirectURI, authContext.State,
+						authContext.ResponseType)
+					if err != nil {
+						// Nowhere left to send the client, so the 500 is the last resort here.
+						httpHelper.InternalServerError(w, r, err)
+					}
+					return
+				}
+
+				err = redirToClientWithError(w, r, templateFS, constants.ErrorLoginRequired,
 					"The authenticated user does not match the id_token_hint",
 					authContext.ResponseMode, authContext.RedirectURI, authContext.State,
 					authContext.ResponseType)
-				if err != nil {
-					httpHelper.InternalServerError(w, r, err)
-					return
-				}
-				err = authHelper.ClearAuthContext(w, r)
 				if err != nil {
 					httpHelper.InternalServerError(w, r, err)
 					return
@@ -143,11 +165,25 @@ func HandleIssueGet(
 				// ClearAuthContext persists the deletion through a Set-Cookie on w, and
 				// redirToClientWithError commits the response in every response mode, so
 				// clearing afterwards leaves the header on a response already written and
-				// the browser keeps a ready_to_issue_code context it can replay. Failing
-				// the clear is a 500 rather than a refusal the browser cannot record.
+				// the browser keeps a ready_to_issue_code context it can replay.
 				err := authHelper.ClearAuthContext(w, r)
 				if err != nil {
-					httpHelper.InternalServerError(w, r, err)
+					// Every error return in ChunkedCookieStore.Save is above its first
+					// http.SetCookie, so a failed clear writes zero cookies and the browser keeps
+					// the auth context whether this answers 500 or redirects. Withholding the
+					// client's response therefore buys nothing, and the client is owed one: its
+					// redirect URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6
+					// applies, and RFC 6749 4.1.2.1 mints server_error for exactly this
+					// condition (#141).
+					slog.Error("failed to clear the auth context, answering the client with server_error",
+						"error", err)
+					err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+						authContext.ResponseMode, authContext.RedirectURI, authContext.State,
+						authContext.ResponseType)
+					if err != nil {
+						// Nowhere left to send the client, so the 500 is the last resort here.
+						httpHelper.InternalServerError(w, r, err)
+					}
 					return
 				}
 				err = redirToClientWithError(w, r, templateFS, constants.ErrorLoginRequired,

--- a/src/authserver/internal/handlers/handler_auth_issue_test.go
+++ b/src/authserver/internal/handlers/handler_auth_issue_test.go
@@ -335,6 +335,162 @@ func TestHandleIssueGet(t *testing.T) {
 		codeIssuer.AssertExpectations(t)
 	})
 
+	t.Run("No session and prompt=none, failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "query",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+			Prompt:       "none",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		// This site's ordering was already correct, so what changes here is only the failure
+		// branch: a failed clear writes no cookie, so the browser keeps the auth context whether
+		// this answers 500 or redirects, and the client is owed its error response either way
+		// (#141 decision 7). It used to get nothing at all.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "https://example.com/callback")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "login_required")
+		assert.NotContains(t, location, "/auth/level1")
+
+		authHelper.AssertNotCalled(t, "SaveAuthContext")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
+	t.Run("No session and prompt=none, failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		// Deliberately malformed, an unclosed action, so template.ParseFS fails and
+		// redirToClientWithError returns "unable to parse template" instead of committing.
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "form_post",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+			Prompt:       "none",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		// The clear failed and the server_error response the client is owed cannot be built
+		// either, so there is nowhere left to send it and the 500 is the last resort.
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
+	t.Run("No session and prompt=none, unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateReadyToIssueCode,
+			ClientId:     "test-client",
+			UserId:       123,
+			ResponseMode: "form_post",
+			ResponseType: "code",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+			Prompt:       "none",
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		// The other half of the same family: the clear succeeds and it is the ordinary
+		// login_required refusal that cannot be committed. This 500 predates #141 and is pinned
+		// separately so a future edit cannot delete either copy unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		codeIssuer.AssertExpectations(t)
+	})
+
 	t.Run("Session lookup fails", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
@@ -1510,8 +1666,16 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		}
 		database.On("GetUserById", mock.Anything, int64(1)).Return(mockUser, nil)
 
-		// Mock clearing auth context (called after error redirect)
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// The clear has to reach the browser, so it must run before the response is committed.
+		// This refusal is the one that leaves the context in ready_to_issue_code, so a browser
+		// keeping it can replay this endpoint. The stub writes a sentinel where the CookieStore
+		// would write its cookie: rr.Header() is the live map the handler and the stub share and
+		// shows it under either ordering, while rr.Result() reads the snapshot taken when the
+		// status line was written.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		// Execute the handler
 		handler.ServeHTTP(rr, req)
@@ -1524,6 +1688,9 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		assert.Contains(t, location, "error_description=")
 		assert.Contains(t, location, "state=test-state")
 
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed, or the browser keeps a ready_to_issue_code context to replay")
+
 		// Verify CreateAuthCode was NEVER called
 		codeIssuer.AssertNotCalled(t, "CreateAuthCode")
 
@@ -1532,6 +1699,194 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		authHelper.AssertExpectations(t)
 		database.AssertExpectations(t)
 		auditLogger.AssertExpectations(t)
+	})
+
+	t.Run("IdTokenHintSub set different user, failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		templateFS := &mocks_test.TestFS{}
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		authContext := &oauth.AuthContext{
+			AuthState:      oauth.AuthStateReadyToIssueCode,
+			ClientId:       "test-client",
+			UserId:         1,
+			ResponseMode:   "query",
+			ResponseType:   "code",
+			RedirectURI:    "https://example.com/callback",
+			State:          "test-state",
+			IdTokenHintSub: userASubject.String(),
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		database.On("GetUserById", mock.Anything, int64(1)).Return(&models.User{
+			Id:      1,
+			Subject: userBSubject,
+			Email:   "userb@example.com",
+			Enabled: true,
+		}, nil)
+
+		// A failed clear writes no cookie, so the browser keeps the auth context whatever the
+		// handler does next. The client is still owed its error response, and server_error is
+		// the code RFC 6749 4.1.2.1 mints for a fault that cannot travel as a 500.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "https://example.com/callback")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "login_required")
+		assert.NotContains(t, location, "code=")
+
+		codeIssuer.AssertNotCalled(t, "CreateAuthCode")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+	})
+
+	t.Run("IdTokenHintSub set different user, failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		// Deliberately malformed, an unclosed action, so template.ParseFS fails and
+		// redirToClientWithError returns "unable to parse template" instead of committing.
+		// form_post is the only response mode whose arm can fail after the redirect URI has
+		// been validated, so it is how this branch is reached at all.
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		authContext := &oauth.AuthContext{
+			AuthState:      oauth.AuthStateReadyToIssueCode,
+			ClientId:       "test-client",
+			UserId:         1,
+			ResponseMode:   "form_post",
+			ResponseType:   "code",
+			RedirectURI:    "https://example.com/callback",
+			State:          "test-state",
+			IdTokenHintSub: userASubject.String(),
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		database.On("GetUserById", mock.Anything, int64(1)).Return(&models.User{
+			Id:      1,
+			Subject: userBSubject,
+			Email:   "userb@example.com",
+			Enabled: true,
+		}, nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		// The clear failed and the server_error response the client is owed cannot be built
+		// either, so there is nowhere left to send it and the 500 is the last resort. Without
+		// this expectation the handler would answer nothing at all.
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		// Nothing reached the client: the form_post arm fails before it writes, and the 500 is
+		// the mock's, so no redirect is committed.
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+	})
+
+	t.Run("IdTokenHintSub set different user, unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		codeIssuer := mocks_oauth.NewCodeIssuer(t)
+		tokenIssuer := mocks_oauth.NewTokenIssuer(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleIssueGet(httpHelper, authHelper, templateFS, codeIssuer, tokenIssuer, database, auditLogger)
+
+		req, err := http.NewRequest("GET", "/auth/issue", nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		authContext := &oauth.AuthContext{
+			AuthState:      oauth.AuthStateReadyToIssueCode,
+			ClientId:       "test-client",
+			UserId:         1,
+			ResponseMode:   "form_post",
+			ResponseType:   "code",
+			RedirectURI:    "https://example.com/callback",
+			State:          "test-state",
+			IdTokenHintSub: userASubject.String(),
+		}
+		authHelper.On("GetAuthContext", req).Return(authContext, nil)
+
+		database.On("GetUserById", mock.Anything, int64(1)).Return(&models.User{
+			Id:      1,
+			Subject: userBSubject,
+			Email:   "userb@example.com",
+			Enabled: true,
+		}, nil)
+
+		// The other half of the same family: here the clear succeeds and it is the ordinary
+		// login_required refusal that cannot be committed. This is the site's second and
+		// pre-existing 500, pinned separately so a future edit cannot delete either copy
+		// unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
 	})
 
 	t.Run("IdTokenHintSub empty - proceeds normally without check", func(t *testing.T) {

--- a/src/authserver/internal/handlers/handler_authorize.go
+++ b/src/authserver/internal/handlers/handler_authorize.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -159,14 +160,31 @@ func HandleAuthorizeGet(
 		}
 
 		redirToClientWithError := func(validationError *customerrors.ErrorDetail) {
-			err := redirToClientWithError(w, r, templateFS, validationError.GetCode(), validationError.GetDescription(),
-				r.FormValue("response_mode"), r.FormValue("redirect_uri"), r.FormValue("state"),
-				r.FormValue("response_type"))
+			// The clear goes FIRST. ClearAuthContext persists the deletion through a Set-Cookie
+			// on w, and redirToClientWithError commits the response in every response mode, so
+			// clearing afterwards leaves the header on a response already written and the
+			// browser keeps an auth context it can replay (#141).
+			err := authHelper.ClearAuthContext(w, r)
 			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
+				// The clear failed, so Save wrote no cookie and the browser still holds the
+				// auth context. The client is owed an error response regardless: its redirect
+				// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+				// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+				slog.Error("failed to clear the auth context, answering the client with server_error",
+					"error", err)
+				err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+					r.FormValue("response_mode"), r.FormValue("redirect_uri"), r.FormValue("state"),
+					r.FormValue("response_type"))
+				if err != nil {
+					// Nowhere left to send the client, so the 500 is the last resort here.
+					httpHelper.InternalServerError(w, r, err)
+				}
+				return
 			}
 
-			err = authHelper.ClearAuthContext(w, r)
+			err = redirToClientWithError(w, r, templateFS, validationError.GetCode(), validationError.GetDescription(),
+				r.FormValue("response_mode"), r.FormValue("redirect_uri"), r.FormValue("state"),
+				r.FormValue("response_type"))
 			if err != nil {
 				httpHelper.InternalServerError(w, r, err)
 				return
@@ -375,15 +393,33 @@ func HandleAuthorizeGet(
 // - Returns an error to the client if silent auth is not possible
 // - Issues a code silently if all conditions are met
 func handlePromptNone(w http.ResponseWriter, r *http.Request, httpHelper HttpHelper, authHelper AuthHelper, userSessionManager UserSessionManager, database data.Database, templateFS fs.FS, auditLogger AuditLogger, permissionChecker PermissionChecker, authContext *oauth.AuthContext, client *models.Client, sessionIdentifier string) {
-	// Helper to redirect with error and clear auth context
+	// Helper to clear the auth context and then redirect with error
 	redirectWithError := func(errorCode string, errorDescription string) {
-		err := redirToClientWithError(w, r, templateFS, errorCode, errorDescription,
-			authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+		// The clear goes FIRST. ClearAuthContext persists the deletion through a Set-Cookie on
+		// w, and redirToClientWithError commits the response in every response mode, so
+		// clearing afterwards leaves the header on a response already written and the browser
+		// keeps an auth context it can replay (#141).
+		err := authHelper.ClearAuthContext(w, r)
 		if err != nil {
-			httpHelper.InternalServerError(w, r, err)
+			// The clear failed, so Save wrote no cookie and the browser still holds the auth
+			// context. The client is owed an error response regardless: its redirect URI was
+			// validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies, and RFC 6749
+			// 4.1.2.1 mints server_error for exactly this condition (#141). A silent-renewal
+			// iframe reads that as "retry later" rather than "start an interactive login",
+			// which on a genuine server fault is the accurate instruction of the two.
+			slog.Error("failed to clear the auth context, answering the client with server_error",
+				"error", err)
+			err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+				authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+			if err != nil {
+				// Nowhere left to send the client, so the 500 is the last resort here.
+				httpHelper.InternalServerError(w, r, err)
+			}
 			return
 		}
-		err = authHelper.ClearAuthContext(w, r)
+
+		err = redirToClientWithError(w, r, templateFS, errorCode, errorDescription,
+			authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
 		if err != nil {
 			httpHelper.InternalServerError(w, r, err)
 			return

--- a/src/authserver/internal/handlers/handler_authorize.go
+++ b/src/authserver/internal/handlers/handler_authorize.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -637,9 +638,25 @@ func redirToClientWithError(w http.ResponseWriter, r *http.Request, templateFS f
 		if err != nil {
 			return errors.Wrap(err, "unable to parse template")
 		}
-		err = t.Execute(w, m)
+
+		// Render into a buffer, not straight to w. Execute writes as it walks the template, so a
+		// template that parses and then fails part way through would leave a partial body and an
+		// implicit 200 already on the wire. Every caller answers an error from here with
+		// httpHelper.InternalServerError as its last resort, and a WriteHeader after the response
+		// is committed changes nothing, so the client would be told 200 for a page that was never
+		// finished. form_post.html is operator supplied whenever GOIABADA_AUTHSERVER_TEMPLATEDIR
+		// is set, so this is reachable in a real deployment rather than only in tests. Buffering
+		// keeps the response uncommitted until there is a whole page to send (#141).
+		var rendered bytes.Buffer
+		err = t.Execute(&rendered, m)
 		if err != nil {
 			return errors.Wrap(err, "unable to execute template")
+		}
+		_, err = w.Write(rendered.Bytes())
+		if err != nil {
+			// The connection itself failed. Nothing can be recovered from here, including the
+			// caller's 500, but the error is still worth reporting rather than swallowing.
+			return errors.Wrap(err, "unable to write the form_post response")
 		}
 		return nil
 	}

--- a/src/authserver/internal/handlers/handler_authorize_test.go
+++ b/src/authserver/internal/handlers/handler_authorize_test.go
@@ -316,7 +316,14 @@ func TestHandleAuthorizeGet(t *testing.T) {
 				ac.Scope == "invalid"
 		})).Return(nil)
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// The clear has to reach the browser, so it must happen before the response is
+		// committed. rr.Header() is the live map the handler and this stub share, so it shows
+		// the sentinel under either ordering; rr.Result() reads the snapshot taken when the
+		// status line was written, which is the only unit-tier view that tells them apart.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
 		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
@@ -337,6 +344,191 @@ func TestHandleAuthorizeGet(t *testing.T) {
 
 		assert.Equal(t, http.StatusFound, rr.Code)
 		assert.Contains(t, rr.Header().Get("Location"), "https://example.com?error=")
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+	})
+
+	t.Run("Invalid scopes with a failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=invalid", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{PKCERequired: true}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+
+		// A failed clear writes no cookie, so the browser keeps the auth context whatever the
+		// handler does next. The client is still owed its error response, and server_error is
+		// the code RFC 6749 4.1.2.1 mints for a fault that cannot travel as a 500.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "invalid").Return(customerrors.NewErrorDetail("", "Invalid scope"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "https://example.com?error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+	})
+
+	t.Run("Invalid scopes with a failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+
+		// Deliberately malformed, an unclosed action, so template.ParseFS fails and
+		// redirToClientWithError returns "unable to parse template" instead of committing.
+		// form_post is the only response mode whose arm can fail after the redirect URI has
+		// been validated, so it is how this branch is reached at all.
+		templateFS := &mocks.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=invalid", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{PKCERequired: true}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		// The clear failed and the server_error response the client is owed cannot be built
+		// either, so there is nowhere left to send it and the 500 is the last resort. Without
+		// this expectation the handler would answer nothing at all.
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "invalid").Return(customerrors.NewErrorDetail("", "Invalid scope"))
+
+		handler.ServeHTTP(rr, req)
+
+		// Nothing reached the client: the form_post arm fails before it writes, and the 500 is
+		// the mock's, so no redirect is committed.
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+	})
+
+	t.Run("Invalid scopes with an unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+
+		templateFS := &mocks.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=invalid", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{PKCERequired: true}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+
+		// The other half of the same family: here the clear succeeds and it is the ordinary
+		// refusal that cannot be committed. This is the closure's second and pre-existing 500,
+		// pinned separately so a future edit cannot delete either copy unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "invalid").Return(customerrors.NewErrorDetail("", "Invalid scope"))
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)
@@ -1923,7 +2115,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// Same sentinel as the "Invalid scopes" case, for handlePromptNone's own refusal
+		// closure: rr.Result() reads the header snapshot taken at commit time, so the sentinel
+		// only appears there if the clear ran before the client response was committed.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
@@ -1931,6 +2129,293 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 		location := rr.Header().Get("Location")
 		assert.Contains(t, location, "https://example.com?error=login_required")
 		assert.Contains(t, location, "error_description=")
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+		tokenParser.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+	})
+
+	t.Run("prompt=none with a failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		hintSubject := uuid.New()
+		sessionSubject := uuid.New()
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{
+			PKCERequired: true,
+			Issuer:       "https://test-issuer.com",
+		}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, "session-999")
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "openid").Return(nil)
+		authorizeValidator.On("ValidatePrompt", "none").Return("none", nil)
+
+		differentUserToken := &oauth.JwtToken{
+			TokenBase64: "different-user-jwt",
+			Claims: jwt.MapClaims{
+				"iss": "https://test-issuer.com",
+				"sub": hintSubject.String(),
+			},
+		}
+		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
+
+		userSession := &models.UserSession{
+			Id:          1,
+			UserId:      999,
+			AcrLevel:    enums.AcrLevel1.String(),
+			AuthMethods: "pwd",
+			User: models.User{
+				Id:      999,
+				Enabled: true,
+				Subject: sessionSubject,
+			},
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "session-999").Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+
+		// The refusal this path would otherwise send is login_required. With the clear failing,
+		// the client gets server_error instead: a silent-renewal iframe reads that as "retry
+		// later" rather than "start an interactive login", which is the accurate instruction
+		// when the server has a fault the client will never learn about.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "https://example.com?error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "login_required")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+		tokenParser.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+	})
+
+	t.Run("prompt=none with a failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+
+		// handlePromptNone's closure carries its own copy of the last-resort 500, so removing
+		// site 1's copy leaves this one and vice versa. Each is pinned at its own site.
+		templateFS := &mocks.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		hintSubject := uuid.New()
+		sessionSubject := uuid.New()
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{
+			PKCERequired: true,
+			Issuer:       "https://test-issuer.com",
+		}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, "session-999")
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "openid").Return(nil)
+		authorizeValidator.On("ValidatePrompt", "none").Return("none", nil)
+
+		differentUserToken := &oauth.JwtToken{
+			TokenBase64: "different-user-jwt",
+			Claims: jwt.MapClaims{
+				"iss": "https://test-issuer.com",
+				"sub": hintSubject.String(),
+			},
+		}
+		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
+
+		userSession := &models.UserSession{
+			Id:          1,
+			UserId:      999,
+			AcrLevel:    enums.AcrLevel1.String(),
+			AuthMethods: "pwd",
+			User: models.User{
+				Id:      999,
+				Enabled: true,
+				Subject: sessionSubject,
+			},
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "session-999").Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+		database.AssertExpectations(t)
+		authorizeValidator.AssertExpectations(t)
+		tokenParser.AssertExpectations(t)
+		userSessionManager.AssertExpectations(t)
+	})
+
+	t.Run("prompt=none with an unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		userSessionManager := mocks_user.NewUserSessionManager(t)
+		database := mocks_data.NewDatabase(t)
+		authorizeValidator := mocks_validators.NewAuthorizeValidator(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+		permissionChecker := mocks_user.NewPermissionChecker(t)
+		tokenParser := mocks_oauth.NewTokenParser(t)
+
+		templateFS := &mocks.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
+
+		hintSubject := uuid.New()
+		sessionSubject := uuid.New()
+
+		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
+		assert.NoError(t, err)
+
+		settings := &models.Settings{
+			PKCERequired: true,
+			Issuer:       "https://test-issuer.com",
+		}
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, constants.ContextKeySettings, settings)
+		ctx = context.WithValue(ctx, constants.ContextKeySessionIdentifier, "session-999")
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		authHelper.On("SaveAuthContext", rr, req, mock.AnythingOfType("*oauth.AuthContext")).Return(nil)
+
+		authorizeValidator.On("ValidateClientAndRedirectURI", mock.AnythingOfType("*validators.ValidateClientAndRedirectURIInput")).Return(nil)
+		authorizeValidator.On("ValidateUnsupportedRequestParameters", mock.AnythingOfType("*validators.ValidateUnsupportedRequestParametersInput")).Return(nil)
+
+		client := &models.Client{
+			Id:               1,
+			ClientIdentifier: "test-client",
+			DefaultAcrLevel:  enums.AcrLevel1,
+		}
+		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(client, nil)
+
+		authorizeValidator.On("ValidateRequest", mock.AnythingOfType("*validators.ValidateRequestInput")).Return(nil)
+		authorizeValidator.On("ValidateScopes", "openid").Return(nil)
+		authorizeValidator.On("ValidatePrompt", "none").Return("none", nil)
+
+		differentUserToken := &oauth.JwtToken{
+			TokenBase64: "different-user-jwt",
+			Claims: jwt.MapClaims{
+				"iss": "https://test-issuer.com",
+				"sub": hintSubject.String(),
+			},
+		}
+		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
+
+		userSession := &models.UserSession{
+			Id:          1,
+			UserId:      999,
+			AcrLevel:    enums.AcrLevel1.String(),
+			AuthMethods: "pwd",
+			User: models.User{
+				Id:      999,
+				Enabled: true,
+				Subject: sessionSubject,
+			},
+		}
+		database.On("GetUserSessionBySessionIdentifier", mock.Anything, "session-999").Return(userSession, nil)
+		database.On("UserSessionLoadUser", mock.Anything, userSession).Return(nil)
+
+		userSessionManager.On("HasValidUserSession", mock.Anything, userSession, mock.AnythingOfType("*int")).Return(true)
+
+		// The clear succeeds here, so it is the login_required refusal itself that cannot be
+		// committed. Site 2's second and pre-existing 500, pinned separately from the nested one
+		// above.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)

--- a/src/authserver/internal/handlers/handler_authorize_test.go
+++ b/src/authserver/internal/handlers/handler_authorize_test.go
@@ -1048,6 +1048,62 @@ func TestRedirToClientWithError_FormPostResponseMode(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `<input type="hidden" name="state" value="def456">`)
 }
 
+// The form_post arm is the only one that can fail after the redirect URI has been validated, and it
+// can fail in two different places. A template that will not parse fails before anything is written,
+// which the per-site last-resort cases cover. A template that parses and then fails part way through
+// execution is the other member, and it is reachable in production: server.New serves templates from
+// os.DirFS(GOIABADA_AUTHSERVER_TEMPLATEDIR) when that variable is set, so the file is operator
+// supplied. Rendering straight to the ResponseWriter would commit a partial 200 the instant the
+// template emitted its first byte, and the caller's last-resort InternalServerError could then no
+// longer change the status the client sees. The render therefore goes to a buffer and reaches w only
+// once Execute has returned successfully (#141).
+func TestRedirToClientWithError_FormPostExecutionFailureLeavesResponseUncommitted(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/authorize", nil)
+
+	// Parses cleanly. "missing" is absent from the map, so index yields an untyped nil, and
+	// indexing that fails at execution time, after the <form> prefix has been emitted.
+	templateFS := &mocks.TestFS{
+		FileContents: map[string]string{
+			"form_post.html": `<form>{{index . "missing" 0}}</form>`,
+		},
+	}
+
+	err := redirToClientWithError(w, r, templateFS, "server_error", "Internal server error", "form_post",
+		"https://example.com/callback", "def456", "code")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to execute template")
+
+	// Nothing may have reached the client yet, or the caller's last resort is not a last resort.
+	assert.Empty(t, w.Body.String(), "a failed render must not put a partial body on the wire")
+
+	w.WriteHeader(http.StatusInternalServerError)
+	assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode,
+		"the caller must still be able to answer 500 after the form_post render failed")
+}
+
+// The third and last way the form_post arm can fail: the render succeeds and the connection does
+// not. Buffering cannot help here and is not meant to, since a client that cannot receive the page
+// cannot receive a 500 either. What it must still do is report the failure rather than swallow it,
+// so the caller logs something instead of treating a dead connection as a delivered refusal (#141).
+func TestRedirToClientWithError_FormPostWriteFailureIsReported(t *testing.T) {
+	w := &failingResponseWriter{}
+	r := httptest.NewRequest("GET", "/authorize", nil)
+
+	templateFS := &mocks.TestFS{
+		FileContents: map[string]string{
+			"form_post.html": `<form method="post" action="{{.redirectURI}}"></form>`,
+		},
+	}
+
+	err := redirToClientWithError(w, r, templateFS, "server_error", "Internal server error", "form_post",
+		"https://example.com/callback", "def456", "code")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to write the form_post response")
+}
+
 func TestRedirToClientWithError_DefaultToQueryResponseMode(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/authorize", nil)

--- a/src/authserver/internal/handlers/handler_consent.go
+++ b/src/authserver/internal/handlers/handler_consent.go
@@ -193,17 +193,37 @@ func HandleConsentPost(
 			consented = strings.TrimSpace(consented)
 
 			if len(consented) == 0 {
+				// The clear goes FIRST. ClearAuthContext persists the deletion through a
+				// Set-Cookie on w, and redirToClientWithError commits the response in every
+				// response mode, so clearing afterwards leaves the header on a response already
+				// written. The browser then keeps an auth context in requires_consent, which
+				// GET /auth/consent accepts: replaying it renders the consent screen again and
+				// the user may approve, so the client would receive access_denied and then a
+				// code for the same authorization request (#141).
+				err = authHelper.ClearAuthContext(w, r)
+				if err != nil {
+					// The clear failed, so Save wrote no cookie and the browser still holds the
+					// auth context. The client is owed an error response regardless: its redirect
+					// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+					// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+					slog.Error("failed to clear the auth context, answering the client with server_error",
+						"error", err)
+					err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+						authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+					if err != nil {
+						// Nowhere left to send the client, so the 500 is the last resort here.
+						httpHelper.InternalServerError(w, r, err)
+					}
+					return
+				}
+
 				err = redirToClientWithError(w, r, templateFS, "access_denied", "The user did not provide consent", authContext.ResponseMode,
 					authContext.RedirectURI, authContext.State, authContext.ResponseType)
 				if err != nil {
 					httpHelper.InternalServerError(w, r, err)
-				}
-
-				err = authHelper.ClearAuthContext(w, r)
-				if err != nil {
-					httpHelper.InternalServerError(w, r, err)
 					return
 				}
+				return
 			} else {
 
 				client, err := database.GetClientByClientIdentifier(nil, authContext.ClientId)
@@ -283,17 +303,34 @@ func HandleConsentPost(
 			}
 		} else {
 
+			// The clear goes FIRST, for the same reason as the no-scopes-consented refusal
+			// above: a Set-Cookie written after redirToClientWithError has committed never
+			// reaches the wire, so the browser keeps an auth context in requires_consent that
+			// a replay of GET /auth/consent can still turn into a code (#141).
+			err = authHelper.ClearAuthContext(w, r)
+			if err != nil {
+				// The clear failed, so Save wrote no cookie and the browser still holds the
+				// auth context. The client is owed an error response regardless: its redirect
+				// URI was validated upstream, so OIDC Core 1.0 3.1.2.2 with 3.1.2.6 applies,
+				// and RFC 6749 4.1.2.1 mints server_error for exactly this condition (#141).
+				slog.Error("failed to clear the auth context, answering the client with server_error",
+					"error", err)
+				err = redirToClientWithError(w, r, templateFS, "server_error", "Internal server error",
+					authContext.ResponseMode, authContext.RedirectURI, authContext.State, authContext.ResponseType)
+				if err != nil {
+					// Nowhere left to send the client, so the 500 is the last resort here.
+					httpHelper.InternalServerError(w, r, err)
+				}
+				return
+			}
+
 			err = redirToClientWithError(w, r, templateFS, "access_denied", "The user did not provide consent", authContext.ResponseMode,
 				authContext.RedirectURI, authContext.State, authContext.ResponseType)
 			if err != nil {
 				httpHelper.InternalServerError(w, r, err)
-			}
-
-			err = authHelper.ClearAuthContext(w, r)
-			if err != nil {
-				httpHelper.InternalServerError(w, r, err)
 				return
 			}
+			return
 		}
 	}
 }

--- a/src/authserver/internal/handlers/handler_consent_test.go
+++ b/src/authserver/internal/handlers/handler_consent_test.go
@@ -15,8 +15,10 @@ import (
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
 	"github.com/leodip/goiabada/core/i18n"
+	mocks_test "github.com/leodip/goiabada/core/mocks"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -456,12 +458,159 @@ func TestHandleConsentPost(t *testing.T) {
 		}
 		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// The clear has to reach the browser, so it must happen before the response is
+		// committed. rr.Header() is the live map the handler and this stub share, so it shows
+		// the sentinel under either ordering; rr.Result() reads the snapshot taken when the
+		// status line was written, which is the only unit-tier view that tells them apart.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusFound, rr.Code)
 		assert.Contains(t, rr.Header().Get("Location"), "https://example.com/callback?error=access_denied")
+
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("User cancels consent, failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, nil, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnCancel", "cancel")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "query",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		// A failed clear writes no cookie, so the browser keeps the auth context whatever the
+		// handler does next. The client is still owed its error response, and server_error is
+		// the code RFC 6749 4.1.2.1 mints for a fault that cannot travel as a 500.
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// httpHelper has no InternalServerError expectation, so the mock fails the test if the
+		// handler answers with a bare 500 instead of redirecting the client.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "access_denied")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("User cancels consent, failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		// Deliberately malformed, an unclosed action, so template.ParseFS fails and
+		// redirToClientWithError returns "unable to parse template" instead of committing.
+		// form_post is the only response mode whose arm can fail after the redirect URI has
+		// been validated, so it is how this branch is reached at all.
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, templateFS, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnCancel", "cancel")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		// The clear failed and the server_error response the client is owed cannot be built
+		// either, so there is nowhere left to send it and the 500 is the last resort. Without
+		// this expectation the handler would answer nothing at all.
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		// Nothing reached the client: the form_post arm fails before it writes, and the 500 is
+		// the mock's, so no redirect is committed.
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("User cancels consent, unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, templateFS, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnCancel", "cancel")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		// The other half of the same family: here the clear succeeds and it is the ordinary
+		// refusal that cannot be committed. This is the site's second and pre-existing 500,
+		// pinned separately so a future edit cannot delete either copy unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)
@@ -607,12 +756,145 @@ func TestHandleConsentPost(t *testing.T) {
 		}
 		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
 
-		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+		// Same sentinel as the cancel case, for the second refusal in this handler. This one is
+		// reached with btnSubmit and no consent boxes ticked rather than with btnCancel.
+		const clearedContextCookie = "cleared-auth-context"
+		authHelper.On("ClearAuthContext", rr, req).Run(func(args mock.Arguments) {
+			args.Get(0).(http.ResponseWriter).Header().Set("Set-Cookie", clearedContextCookie)
+		}).Return(nil)
 
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusFound, rr.Code)
 		assert.Contains(t, rr.Header().Get("Location"), "https://example.com/callback?error=access_denied")
+
+		assert.Equal(t, clearedContextCookie, rr.Result().Header.Get("Set-Cookie"),
+			"the auth context must be cleared before the client response is committed")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("No consent given, failing clear - server_error to the client", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, nil, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnSubmit", "submit")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "query",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		handler.ServeHTTP(rr, req)
+
+		// No InternalServerError expectation, so a bare 500 fails the mock instead of passing
+		// silently the way it would if the client were simply left unanswered.
+		assert.Equal(t, http.StatusFound, rr.Code)
+		location := rr.Result().Header.Get("Location")
+		assert.Contains(t, location, "error=server_error")
+		assert.Contains(t, location, "error_description=Internal+server+error")
+		assert.NotContains(t, location, "access_denied")
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("No consent given, failing clear and an unusable form_post template - last-resort 500", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, templateFS, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnSubmit", "submit")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		authHelper.On("ClearAuthContext", rr, req).Return(errors.New("the session store is unreachable"))
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
+
+		httpHelper.AssertExpectations(t)
+		authHelper.AssertExpectations(t)
+	})
+
+	t.Run("No consent given, unusable form_post template - 500 when the refusal itself cannot be sent", func(t *testing.T) {
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		templateFS := &mocks_test.TestFS{
+			FileContents: map[string]string{
+				"form_post.html": `<form action="{{ .redirectURI`,
+			},
+		}
+
+		handler := HandleConsentPost(httpHelper, authHelper, database, templateFS, auditLogger)
+
+		form := url.Values{}
+		form.Add("btnSubmit", "submit")
+		req, _ := http.NewRequest("POST", "/auth/consent", strings.NewReader(form.Encode()))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		authContext := &oauth.AuthContext{
+			AuthState:    oauth.AuthStateRequiresConsent,
+			ResponseMode: "form_post",
+			RedirectURI:  "https://example.com/callback",
+			State:        "test-state",
+		}
+		authHelper.On("GetAuthContext", mock.Anything).Return(authContext, nil)
+
+		// The clear succeeds here and the ordinary refusal is what cannot be committed, which
+		// is this site's pre-existing 500. It is pinned separately from the last-resort one so
+		// a future edit cannot delete either copy unnoticed.
+		authHelper.On("ClearAuthContext", rr, req).Return(nil)
+
+		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
+			return strings.Contains(err.Error(), "unable to parse template")
+		})).Once()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Empty(t, rr.Result().Header.Get("Location"))
 
 		httpHelper.AssertExpectations(t)
 		authHelper.AssertExpectations(t)

--- a/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
+++ b/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
@@ -1,0 +1,250 @@
+package integrationtests
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/hashutil"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// The two refusals in /auth/completed leave the browser holding an auth context in the
+// authentication_completed state unless the clear reaches it, and that state is one the handler
+// accepts: replaying the refused ceremony re-runs the same checks, refuses the client a second time
+// and re-bumps the session. Both tests below drive a real ceremony on a real cookie jar, take the
+// refusal, then replay GET /auth/completed and require it to land on the account profile, which is
+// the shared no-context branch. On a tree where the clear runs after the response is committed the
+// replay refuses again instead, so the second half of each test is what fails (#141).
+//
+// Both tests reassign one resp across seven hops, so each body is passed into its deferred close
+// rather than read out of resp when the test returns. The bare `defer func() { _ = resp.Body.Close()
+// }()` used elsewhere in this package captures the variable, so under reassignment every defer closes
+// the last response and the six before it are never closed.
+
+// TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed covers the disabled-user refusal. The user
+// is disabled between the /auth/level1completed and /auth/completed hops, since disabling before
+// login makes /auth/pwd reject the credentials and /auth/completed is never reached.
+func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
+	client := &models.Client{
+		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		Enabled:                  true,
+		AuthorizationCodeEnabled: true,
+		ConsentRequired:          false,
+		DefaultAcrLevel:          enums.AcrLevel1,
+	}
+
+	err := database.CreateClient(nil, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	redirectUri := &models.RedirectURI{
+		ClientId: client.Id,
+		URI:      gofakeit.URL(),
+	}
+
+	err = database.CreateRedirectURI(nil, redirectUri)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	password := gofakeit.Password(true, true, true, true, false, 8)
+	passwordHashed, err := hashutil.HashPassword(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user := &models.User{
+		Subject:      uuid.New(),
+		Enabled:      true,
+		Email:        gofakeit.Email(),
+		PasswordHash: passwordHashed,
+	}
+
+	err = database.CreateUser(nil, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestState := gofakeit.LetterN(8)
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&scope=" + url.QueryEscape("openid profile") +
+		"&state=" + requestState +
+		"&nonce=" + gofakeit.LetterN(8)
+
+	httpClient := createHttpClient(t)
+
+	resp, err := httpClient.Get(destUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation := assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation = assertRedirect(t, resp, "/auth/pwd")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	csrf := getCsrfValue(t, resp)
+
+	resp = authenticateWithPassword(t, httpClient, redirectLocation, user.Email, password, csrf)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation = assertRedirect(t, resp, "/auth/level1completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	completedUrl := assertRedirect(t, resp, "/auth/completed")
+
+	// The password has already been accepted and the session exists, so the account is disabled
+	// here rather than up front: this is the only window in which /auth/completed sees a disabled
+	// user.
+	user.Enabled = false
+	err = database.UpdateUser(nil, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp = loadPage(t, httpClient, completedUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	refusalUrl, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "access_denied", refusalUrl.Query().Get("error"))
+	assert.Equal(t, "The user account is disabled.", refusalUrl.Query().Get("error_description"))
+	assert.Equal(t, requestState, refusalUrl.Query().Get("state"))
+
+	// The refusal ended the ceremony, so the auth context is gone from the browser and the replay
+	// has nothing to resume: it lands on the account profile instead of refusing a second time.
+	resp = loadPage(t, httpClient, completedUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, config.GetAdminConsole().BaseURL+"/account/profile", resp.Header.Get("Location"),
+		"replaying the refused ceremony must not reach the auth context again")
+}
+
+// TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed covers the empty-effective-scope
+// refusal. The request asks for one resource:permission scope the user does not hold, and neither
+// openid nor offline_access, which FilterOutScopesWhereUserIsNotAuthorized always keeps. The
+// authorize validator only checks the scope exists, so the ceremony passes validation and the
+// filtering to nothing happens at /auth/completed.
+func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) {
+	client := &models.Client{
+		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		Enabled:                  true,
+		AuthorizationCodeEnabled: true,
+		ConsentRequired:          false,
+		DefaultAcrLevel:          enums.AcrLevel1,
+	}
+
+	err := database.CreateClient(nil, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	redirectUri := &models.RedirectURI{
+		ClientId: client.Id,
+		URI:      gofakeit.URL(),
+	}
+
+	err = database.CreateRedirectURI(nil, redirectUri)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	password := gofakeit.Password(true, true, true, true, false, 8)
+	passwordHashed, err := hashutil.HashPassword(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user := &models.User{
+		Subject:      uuid.New(),
+		Enabled:      true,
+		Email:        gofakeit.Email(),
+		PasswordHash: passwordHashed,
+	}
+
+	err = database.CreateUser(nil, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Created but deliberately not assigned to the user.
+	resource := createResource(t)
+	permission := createPermission(t, resource.Id)
+	requestScope := resource.ResourceIdentifier + ":" + permission.PermissionIdentifier
+
+	requestState := gofakeit.LetterN(8)
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&scope=" + url.QueryEscape(requestScope) +
+		"&state=" + requestState
+
+	httpClient := createHttpClient(t)
+
+	resp, err := httpClient.Get(destUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation := assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation = assertRedirect(t, resp, "/auth/pwd")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	csrf := getCsrfValue(t, resp)
+
+	resp = authenticateWithPassword(t, httpClient, redirectLocation, user.Email, password, csrf)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	redirectLocation = assertRedirect(t, resp, "/auth/level1completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	completedUrl := assertRedirect(t, resp, "/auth/completed")
+	resp = loadPage(t, httpClient, completedUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	refusalUrl, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "access_denied", refusalUrl.Query().Get("error"))
+	assert.Equal(t, "The user is not authorized to access any of the requested scopes",
+		refusalUrl.Query().Get("error_description"))
+	assert.Equal(t, requestState, refusalUrl.Query().Get("state"))
+
+	resp = loadPage(t, httpClient, completedUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, config.GetAdminConsole().BaseURL+"/account/profile", resp.Header.Get("Location"),
+		"replaying the refused ceremony must not reach the auth context again")
+}

--- a/src/authserver/tests/integration/authorize_id_token_hint_test.go
+++ b/src/authserver/tests/integration/authorize_id_token_hint_test.go
@@ -1,6 +1,7 @@
 package integrationtests
 
 import (
+	"io"
 	"net/url"
 	"testing"
 
@@ -99,34 +100,40 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 		"&state=" + requestStateA +
 		"&nonce=" + requestNonceA
 
-	// Start auth flow for User A
+	// Start auth flow for User A.
+	//
+	// The hops below reassign one respA, so each body is passed into its deferred close rather than
+	// read out of respA when the test returns: the bare `defer func() { _ = respA.Body.Close() }()`
+	// used elsewhere in this file captures the variable, so under reassignment every defer closes
+	// the last response and the earlier ones are never closed. The replay hop at the end of this
+	// function adds one more, which makes that worse.
 	respA, err := httpClientA.Get(destUrlA)
 	assert.NoError(t, err)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	redirectLocation := assertRedirect(t, respA, "/auth/level1")
 	respA = loadPage(t, httpClientA, redirectLocation)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	redirectLocation = assertRedirect(t, respA, "/auth/pwd")
 	respA = loadPage(t, httpClientA, redirectLocation)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	csrf := getCsrfValue(t, respA)
 	respA = authenticateWithPassword(t, httpClientA, redirectLocation, userA.Email, passwordA, csrf)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	redirectLocation = assertRedirect(t, respA, "/auth/level1completed")
 	respA = loadPage(t, httpClientA, redirectLocation)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	redirectLocation = assertRedirect(t, respA, "/auth/completed")
 	respA = loadPage(t, httpClientA, redirectLocation)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	redirectLocation = assertRedirect(t, respA, "/auth/issue")
 	respA = loadPage(t, httpClientA, redirectLocation)
-	defer func() { _ = respA.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respA.Body)
 
 	codeA, stateA := getCodeAndStateFromUrl(t, respA)
 	assert.Equal(t, requestStateA, stateA)
@@ -177,35 +184,35 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	// =========================================================================
 	respB, err := httpClientB.Get(destUrlB)
 	assert.NoError(t, err)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	// Should redirect to login even with prompt=login (since no session exists)
 	redirectLocation = assertRedirect(t, respB, "/auth/level1")
 	respB = loadPage(t, httpClientB, redirectLocation)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	redirectLocation = assertRedirect(t, respB, "/auth/pwd")
 	respB = loadPage(t, httpClientB, redirectLocation)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	csrf = getCsrfValue(t, respB)
 	respB = authenticateWithPassword(t, httpClientB, redirectLocation, userB.Email, passwordB, csrf)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	redirectLocation = assertRedirect(t, respB, "/auth/level1completed")
 	respB = loadPage(t, httpClientB, redirectLocation)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	redirectLocation = assertRedirect(t, respB, "/auth/completed")
 	respB = loadPage(t, httpClientB, redirectLocation)
-	defer func() { _ = respB.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	// =========================================================================
 	// Step 6: At /auth/issue, expect error=login_required due to mismatch
 	// =========================================================================
-	redirectLocation = assertRedirect(t, respB, "/auth/issue")
-	respB = loadPage(t, httpClientB, redirectLocation)
-	defer func() { _ = respB.Body.Close() }()
+	issueUrl := assertRedirect(t, respB, "/auth/issue")
+	respB = loadPage(t, httpClientB, issueUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
 
 	// Should redirect back to client with error
 	assert.Equal(t, 302, respB.StatusCode, "Expected redirect to client callback")
@@ -224,6 +231,20 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	location := respB.Header.Get("Location")
 	assert.Contains(t, location, redirectUri.URI,
 		"Should redirect to client's registered redirect_uri")
+
+	// =========================================================================
+	// Step 7: The refusal ended the ceremony, so it cannot be replayed
+	// =========================================================================
+	// This is the one refusal that left the browser holding a ready_to_issue_code context, the
+	// state that mints codes, with only the id_token_hint comparison between a replay and a code.
+	// The clear now reaches the browser, so replaying /auth/issue on the same jar has no context
+	// to resume and lands on the account profile instead of refusing a second time (#141).
+	respB = loadPage(t, httpClientB, issueUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(respB.Body)
+
+	assert.Equal(t, 302, respB.StatusCode)
+	assert.Equal(t, config.GetAdminConsole().BaseURL+"/account/profile", respB.Header.Get("Location"),
+		"replaying the refused ceremony must not reach the auth context again")
 }
 
 // TestIdTokenHint_PromptLogin_MatchingUser_Success verifies that when the

--- a/src/authserver/tests/integration/authorize_no_session_consent_test.go
+++ b/src/authserver/tests/integration/authorize_no_session_consent_test.go
@@ -2,6 +2,7 @@ package integrationtests
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -1649,40 +1650,44 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 
 	httpClient := createHttpClient(t)
 
+	// The hops below reassign one resp, so each body is passed into its deferred close rather than
+	// read out of resp when the test returns: the bare `defer func() { _ = resp.Body.Close() }()`
+	// used elsewhere in this file captures the variable, so under reassignment every defer closes
+	// the last response and the earlier ones are never closed.
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	redirectLocation := assertRedirect(t, resp, "/auth/level1")
 	resp = loadPage(t, httpClient, redirectLocation)
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	redirectLocation = assertRedirect(t, resp, "/auth/pwd")
 	resp = loadPage(t, httpClient, redirectLocation)
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	csrf := getCsrfValue(t, resp)
 
 	resp = authenticateWithPassword(t, httpClient, redirectLocation, user.Email, password, csrf)
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	redirectLocation = assertRedirect(t, resp, "/auth/level1completed")
 	resp = loadPage(t, httpClient, redirectLocation)
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	redirectLocation = assertRedirect(t, resp, "/auth/completed")
 	resp = loadPage(t, httpClient, redirectLocation)
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
-	redirectLocation = assertRedirect(t, resp, "/auth/consent")
-	resp = loadPage(t, httpClient, redirectLocation)
-	defer func() { _ = resp.Body.Close() }()
+	consentUrl := assertRedirect(t, resp, "/auth/consent")
+	resp = loadPage(t, httpClient, consentUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	csrf = getCsrfValue(t, resp)
-	resp = postConsent(t, httpClient, redirectLocation, []int{}, csrf) // Cancel consent
-	defer func() { _ = resp.Body.Close() }()
+	resp = postConsent(t, httpClient, consentUrl, []int{}, csrf) // Cancel consent
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
 
 	assert.Equal(t, http.StatusFound, resp.StatusCode)
 
@@ -1695,6 +1700,19 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 
 	assert.Equal(t, "access_denied", errorCode)
 	assert.Equal(t, "The user did not provide consent", errorDescription)
+
+	// The refusal ended the ceremony, so the auth context is gone from the browser and the replay
+	// has nothing to resume: it lands on the account profile rather than rendering the consent
+	// screen again. Without the clear reaching the browser the retained context stays in
+	// requires_consent, which this handler accepts, and the user could approve on the second
+	// screen: the client would then get access_denied and a code for the same authorization
+	// request (#141).
+	resp = loadPage(t, httpClient, consentUrl)
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, config.GetAdminConsole().BaseURL+"/account/profile", resp.Header.Get("Location"),
+		"replaying the refused ceremony must not reach the auth context again")
 }
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {

--- a/src/core/handlerhelpers/auth_helper_test.go
+++ b/src/core/handlerhelpers/auth_helper_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -14,8 +16,11 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/customerrors"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/sessionstore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAuthContext(t *testing.T) {
@@ -200,6 +205,90 @@ func TestSaveAuthContext(t *testing.T) {
 	})
 }
 
+// The fixtures below back the RealStore* subtests of TestClearAuthContext, which drive the real
+// ChunkedCookieStore instead of a mock. The session store is cookie-only, so a Set-Cookie is the
+// only way a deletion reaches the browser and there is no server-side row to fall back on. Every
+// other subtest here inspects sess.Values, which is the store's in-memory state and says nothing
+// about the wire: that is how seven handlers came to clear the auth context after committing the
+// client response, where the header is never sent (#141).
+const (
+	realStoreSessionName = "test-session"
+	realStoreBaseURL     = "https://as.example.com"
+	// Where a refused ceremony sends the client, and the commit these cases order against.
+	clientRefusalURL = "https://example.com/callback?error=access_denied"
+)
+
+// newRealStoreAuthHelper returns the helper and the store behind it. The store is returned because
+// requireSessionDecoded needs to read a replayed session directly, which is the only way to tell a
+// valid cleared session from an unreadable one.
+func newRealStoreAuthHelper(t *testing.T) (*AuthHelper, *sessionstore.ChunkedCookieStore) {
+	t.Helper()
+	authKey := []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	encKey := []byte("0123456789abcdef0123456789abcdef")
+	store := sessionstore.NewChunkedCookieStore(authKey, encKey)
+	return NewAuthHelper(store, realStoreSessionName, realStoreBaseURL, realStoreBaseURL), store
+}
+
+// requireSessionDecoded proves the session the browser holds on req decoded successfully, and must
+// accompany every assertion that the auth context is absent.
+//
+// ChunkedCookieStore.New swallows every load failure (a metadata cookie that will not decode, a
+// missing chunk, a failed SHA-256 integrity check, an undecodable payload) and hands back a new
+// empty session. GetAuthContext finds no auth context in that session and reports ErrNoAuthContext,
+// which is the same error a genuine clear produces. So ErrNoAuthContext alone cannot distinguish
+// "the clear reached the browser and it decoded" from "the clearing write reached the browser
+// corrupt", and a regression that emitted malformed clearing state would leave the absence cases
+// green. IsNew is false only when the whole load succeeded, so it separates the two (#141).
+func requireSessionDecoded(t *testing.T, store *sessionstore.ChunkedCookieStore, req *http.Request) {
+	t.Helper()
+	sess, err := store.Get(req, realStoreSessionName)
+	require.NoError(t, err)
+	require.False(t, sess.IsNew,
+		"the replayed session did not decode, so an absent auth context proves nothing about the clear")
+}
+
+// replayThroughJar pushes a committed response through a real net/http/cookiejar and returns a
+// fresh request carrying whatever the browser would then hold. extra is what the browser already
+// held beforehand, applied first so the response's own Set-Cookie headers land on top of it, as a
+// browser would apply them. This is the only view that answers "what does the browser hold", which
+// is the question sess.Values cannot answer.
+func replayThroughJar(t *testing.T, res *http.Response, extra []*http.Cookie) *http.Request {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := url.Parse(realStoreBaseURL + "/auth/issue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jar.SetCookies(u, extra)
+	jar.SetCookies(u, res.Cookies())
+
+	next := httptest.NewRequest(http.MethodGet, realStoreBaseURL+"/auth/issue", nil)
+	for _, c := range jar.Cookies(u) {
+		next.AddCookie(c)
+	}
+	return next
+}
+
+// multiChunkAuthContext returns a context whose encoded form spans more than one cookie chunk, so
+// every case also covers the stale higher chunks that a one-chunk clearing write leaves behind.
+func multiChunkAuthContext() *oauth.AuthContext {
+	long := ""
+	for i := 0; i < 400; i++ {
+		long += "scope" + string(rune('a'+i%26)) + ":permission "
+	}
+	return &oauth.AuthContext{
+		AuthState:   oauth.AuthStateReadyToIssueCode,
+		ClientId:    "test-client",
+		UserId:      123,
+		RedirectURI: "https://example.com/callback",
+		State:       "test-state",
+		Scope:       long,
+	}
+}
+
 func TestClearAuthContext(t *testing.T) {
 	const testSessionName = "test-session"
 
@@ -252,5 +341,127 @@ func TestClearAuthContext(t *testing.T) {
 
 		assert.Error(t, err)
 		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("RealStoreClearBeforeCommitReachesBrowser", func(t *testing.T) {
+		helper, store := newRealStoreAuthHelper(t)
+
+		seedReq := httptest.NewRequest(http.MethodGet, realStoreBaseURL+"/auth/issue", nil)
+		seedRR := httptest.NewRecorder()
+		err := helper.SaveAuthContext(seedRR, seedReq, multiChunkAuthContext())
+		require.NoError(t, err)
+
+		seedRes := seedRR.Result()
+		// Master plus at least two chunks. Keep this: a change to DefaultChunkSize that collapsed
+		// the context into a single cookie would leave all four cases passing while none of them
+		// still covered the stale higher chunks the clearing write has to survive.
+		assert.Greater(t, len(seedRes.Cookies()), 2)
+
+		browserReq := replayThroughJar(t, seedRes, nil)
+
+		rr := httptest.NewRecorder()
+		err = helper.ClearAuthContext(rr, browserReq)
+		require.NoError(t, err)
+		http.Redirect(rr, browserReq, clientRefusalURL, http.StatusFound)
+
+		res := rr.Result()
+		// A response carrying no cookies at all would satisfy the jar assertion below for entirely
+		// the wrong reason, so pin that the clear did write something.
+		assert.NotEmpty(t, res.Cookies())
+
+		replayed := replayThroughJar(t, res, seedRes.Cookies())
+		_, err = helper.GetAuthContext(replayed)
+		assert.ErrorIs(t, err, customerrors.ErrNoAuthContext)
+		requireSessionDecoded(t, store, replayed)
+	})
+
+	t.Run("RealStoreClearAfterCommitIsDropped", func(t *testing.T) {
+		// This case asserts the defect, and it is expected to keep passing once the handler sites
+		// are reordered, because it drives the helper directly and no handler. It is what makes
+		// the other three cases mean something: delete it as obsolete and nothing is left recording
+		// why the ordering is load-bearing rather than a matter of style (#141).
+		//
+		// This case needs no requireSessionDecoded: it asserts the retained auth context decodes
+		// and carries ready_to_issue_code, which an unreadable session cannot satisfy.
+		helper, _ := newRealStoreAuthHelper(t)
+
+		seedReq := httptest.NewRequest(http.MethodGet, realStoreBaseURL+"/auth/issue", nil)
+		seedRR := httptest.NewRecorder()
+		err := helper.SaveAuthContext(seedRR, seedReq, multiChunkAuthContext())
+		require.NoError(t, err)
+
+		seedRes := seedRR.Result()
+		browserReq := replayThroughJar(t, seedRes, nil)
+
+		rr := httptest.NewRecorder()
+		http.Redirect(rr, browserReq, clientRefusalURL, http.StatusFound)
+		err = helper.ClearAuthContext(rr, browserReq)
+		require.NoError(t, err)
+
+		res := rr.Result()
+		// The clear succeeded and its Set-Cookie headers are in the live header map, but the
+		// response was committed before they were written, so none of them reach the wire.
+		assert.Empty(t, res.Cookies())
+
+		// The dropped response set no cookies, so the browser still holds what it was seeded with.
+		authContext, err := helper.GetAuthContext(replayThroughJar(t, res, seedRes.Cookies()))
+		require.NoError(t, err)
+		assert.Equal(t, oauth.AuthStateReadyToIssueCode, authContext.AuthState)
+	})
+
+	t.Run("RealStoreSaveThenClearLastWins", func(t *testing.T) {
+		// The /auth/authorize shape at sites 1 and 2: SaveAuthContext has already written the
+		// context earlier in the same response, so clearing before the commit puts two session
+		// writes, under duplicate cookie names, in one response. Both must reach the wire and the
+		// later one must win (#141).
+		helper, store := newRealStoreAuthHelper(t)
+
+		req := httptest.NewRequest(http.MethodGet, realStoreBaseURL+"/auth/authorize?client_id=test-client", nil)
+		rr := httptest.NewRecorder()
+
+		err := helper.SaveAuthContext(rr, req, multiChunkAuthContext())
+		require.NoError(t, err)
+		err = helper.ClearAuthContext(rr, req)
+		require.NoError(t, err)
+		http.Redirect(rr, req, clientRefusalURL, http.StatusFound)
+
+		res := rr.Result()
+		counts := map[string]int{}
+		for _, c := range res.Cookies() {
+			counts[c.Name]++
+		}
+		// Both writes are on the wire, rather than the second having replaced the first in the
+		// header map. The clearing write fits in one chunk, so it re-sets only the master cookie
+		// and chunk 0; the stale higher chunks are ignored because the master's ChunkCount bounds
+		// the reassembly.
+		assert.Equal(t, 2, counts[realStoreSessionName])
+		assert.Equal(t, 2, counts[realStoreSessionName+"-chunk-0"])
+
+		replayed := replayThroughJar(t, res, nil)
+		_, err = helper.GetAuthContext(replayed)
+		assert.ErrorIs(t, err, customerrors.ErrNoAuthContext)
+		requireSessionDecoded(t, store, replayed)
+	})
+
+	t.Run("RealStoreClearThenSaveLastWins", func(t *testing.T) {
+		// Control for the case above. Without it, that case passes just as well if the jar simply
+		// discards everything when a cookie name repeats, which would make it evidence of nothing.
+		// Here the later write is the save, so the jar must keep the context.
+		//
+		// No requireSessionDecoded here either: keeping the context requires a successful decode.
+		helper, _ := newRealStoreAuthHelper(t)
+
+		req := httptest.NewRequest(http.MethodGet, realStoreBaseURL+"/auth/authorize?client_id=test-client", nil)
+		rr := httptest.NewRecorder()
+
+		err := helper.ClearAuthContext(rr, req)
+		require.NoError(t, err)
+		err = helper.SaveAuthContext(rr, req, multiChunkAuthContext())
+		require.NoError(t, err)
+		http.Redirect(rr, req, clientRefusalURL, http.StatusFound)
+
+		authContext, err := helper.GetAuthContext(replayThroughJar(t, rr.Result(), nil))
+		require.NoError(t, err)
+		assert.Equal(t, oauth.AuthStateReadyToIssueCode, authContext.AuthState)
 	})
 }


### PR DESCRIPTION
Fixes #141.

## What this fixes

`ClearAuthContext` ran **after** the client's response had already been committed at seven call sites
in the authserver handlers. The session store is `sessionstore.ChunkedCookieStore`, cookie only, so
the deletion is persisted through a `Set-Cookie` and nothing else. A header written after the status
line never reaches the wire, so the clear was dropped and the browser kept a usable auth context for a
ceremony the server had just refused.

Seven sites, but **22 refusal paths**: two of the seven are closures with 5 and 12 callers each.

| Site | Retained state | Paths | What a replay could do |
|---|---|---|---|
| `HandleAuthorizeGet`'s refusal closure | `initial` | 5 | inert, no handler accepts it |
| `handlePromptNone`'s redirect closure | `initial` | 12 | inert |
| `/auth/completed`, disabled user | `authentication_completed` | 1 | re-refuses, but re-bumps the session and re-emits the audit event |
| `/auth/completed`, no authorized scopes | `authentication_completed` | 1 | re-refuses |
| `/auth/consent`, nothing consented | `requires_consent` | 1 | renders consent again; the user may approve, so the client gets `access_denied` **and then a code** |
| `/auth/consent`, cancelled | `requires_consent` | 1 | same |
| `/auth/issue`, `id_token_hint` mismatch | `ready_to_issue_code` | 1 | the state that mints codes; only the sub comparison stands between a replay and a code |

No bypass is claimed, and the issue does not claim one either. Every replay re-runs the check that
refused in the first place, and those checks are deterministic on values fixed in the cookie. What
this closes is the retained state itself: the sharpest path is the `requires_consent` pair, where a
relying party could receive two responses for one authorization request.

Fixed, a replay lands on the account profile instead, which is what the shared no-context branch
already does.

## How it works

One statement moves at each site, and the shape is identical at all of them:

```go
err := authHelper.ClearAuthContext(w, r)   // was below the redirect
if err != nil { /* answer the client with server_error, see below */ }
err = redirToClientWithError(w, r, templateFS, ...)
```

This is safe because **`redirToClientWithError` reads nothing from the session**. It takes the error
code, description, response mode, redirect URI, state and response type as explicit parameters, and
every caller already holds those in memory. Clearing the cookie first cannot change what the client is
told, in any response mode.

Three other things changed with it:

- **A failed clear now answers the client** with `error=server_error` rather than a bare HTTP 500 that
  the client never sees, at all seven sites plus the failure branch of the one site whose ordering was
  already correct. OIDC Core 1.0 3.1.2.2 with 3.1.2.6 requires an error response for a redirect URI
  validated upstream, which all eight are, and RFC 6749 4.1.2.1 mints `server_error` for exactly this
  condition. This was escalated and decided by the repository owner; the reasoning and what reversing
  it costs are in the first closing comment below.
- **Four missing `return`s** were added. After the reorder the trailing branch is last in its block at
  all four, so they are defensive rather than load-bearing, but they leave all seven sites in one
  shape.
- **`redirToClientWithError` buffers its `form_post` render.** It wrote straight to the
  `ResponseWriter`, so a template that parsed and then failed mid-render committed a partial 200 and
  the caller's `InternalServerError` could no longer change the status: the last-resort 500 was not a
  last resort. `form_post.html` is operator supplied whenever `GOIABADA_AUTHSERVER_TEMPLATEDIR` is
  set, so a custom template makes this reachable. Found by the reviewer at stage 5.

The `id_token_hint` site also gets its OIDC citation corrected. The "MUST NOT reply with an ID Token
or Access Token for a different user" sentence is in Core 1.0 **3.1.2.2**, not 3.1.2.1.

**No interface, schema, migration, wire format or persisted shape changes**, and no user-facing
documentation moves, because no observable protocol behaviour does except the failure branch above.

## What landed, stage by stage

| Stage | Commit | What |
|---|---|---|
| 1 | `ac4ffac` | Pin the premise: three subtests in `TestClearAuthContext` driving a real `ChunkedCookieStore` through a real `net/http/cookiejar`. The existing test was entirely mock-backed and never observed a `Set-Cookie`, which is how the defect survived. |
| 2 | `b52850f` | `handler_authorize.go`, both closures, 17 of the 22 paths |
| 3 | `81924bf` | `handler_auth_completed.go`, the disabled-user and no-scopes refusals |
| 4 | `e80da8e` | `handler_consent.go`, both deny branches |
| 5 | `da1d6c8` | `handler_auth_issue.go`, the `id_token_hint` mismatch and the `prompt=none` failure branch, plus the buffered `form_post` repair |

## Tests

`./run-tests.sh --type all` on the final tree: **9347 passing, 0 fail, 4 skip**, 13m04s.

| Tier | Passing | Engines |
|---|---|---|
| Unit | 2923 | three modules |
| Data | 1564, 4 skip | sqlite, mysql, postgres, mssql |
| Integration | 4860 | sqlite, mysql, postgres, mssql |

The 4 skips are pre-existing engine-capability ones: sqlite holds a single connection, so two
contention tests cannot create overlap on it.

What the new coverage actually observes, at three seams:

1. **The committed response.** Each site gets a case that stubs `ClearAuthContext` to write a sentinel
   `Set-Cookie`, then asserts on `rr.Result().Header` rather than `rr.Header()`. That distinction is
   the whole point: handler and stub share one live header map, so `rr.Header()` shows the sentinel
   under either ordering, while `rr.Result()` reads the snapshot taken when the status line was
   written. Plus one case per site asserting the client still gets `server_error` when the clear fails.
2. **The real store.** `TestClearAuthContext` now proves a clear written before the commit reaches a
   browser, one written after does not, and that when a response carries two session writes the later
   wins. This is the only permanent test where a real `Set-Cookie` is written and read back.
3. **The ceremony end to end.** Four integration replays on the same cookie jar, asserting a refused
   ceremony now lands on the profile redirect instead of re-refusing or re-rendering consent.

Every reordering was mutation-tested: reverting any one site fails its own cases and leaves the others
green, and reverting the `id_token_hint` site also fails its integration replay with the browser
reaching the retained `ready_to_issue_code` context.

## Read first

Two comments below:

- **Deferred decisions** — there are none, and the one escalated decision is restated with what
  reversing it costs. It also flags that the escalation is still sitting unanswered-looking on issue
  #141 itself, since it was raised before this pull request existed.
- **Follow-ups** — two, both verified and ready to file, neither of them work this change owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
