### PR TITLE
CI/CD v2 stage 2: add check.yml alongside the existing workflow

### DIFF
--- a/.github/actions/setup-test-container/action.yml
+++ b/.github/actions/setup-test-container/action.yml
@@ -1,0 +1,50 @@
+# Shared setup for the container-based test jobs in check.yml.
+#
+# The golang:*-bookworm image is close to what run-tests.sh needs but not
+# identical, and seven jobs need the same three steps. Debian rather than the
+# alpine base used by Dockerfile-test, because GitHub injects a glibc-linked
+# Node.js runtime into container jobs to execute actions, which does not run on
+# musl.
+
+name: Set up test container
+description: Install the OS packages, Tailwind CLI and Go caches that run-tests.sh and build.sh need.
+
+inputs:
+  tailwind:
+    description: Tailwind CLI version, from versions.yaml
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # net-tools supplies netstat, which run-tests.sh's kill_processes_on_ports
+    # uses. Without it that function silently finds nothing rather than
+    # failing, so a stale listener would go unnoticed.
+    - name: Install OS packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        apt-get update -qq
+        apt-get install -y -qq --no-install-recommends net-tools curl zip ca-certificates
+
+    # The glibc build, not the -musl one Dockerfile-test fetches for alpine.
+    - name: Install Tailwind CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -sfL --retry 3 --retry-delay 5 \
+          "https://github.com/tailwindlabs/tailwindcss/releases/download/v${{ inputs.tailwind }}/tailwindcss-linux-x64" \
+          -o /usr/local/bin/tailwindcss
+        chmod +x /usr/local/bin/tailwindcss
+        tailwindcss --help >/dev/null
+
+    # GOPATH and GOCACHE inside the official golang image, which runs as root.
+    - name: Cache Go modules and build output
+      uses: actions/cache@v4
+      with:
+        path: |
+          /go/pkg/mod
+          /root/.cache/go-build
+        key: ${{ runner.os }}-gomod-${{ hashFiles('src/**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,415 @@
+# The PR check suite. Runs alongside the legacy run-tests.yml until stage 3 of
+# the CI/CD v2 plan retires it (docs/ci-v2-design.md).
+#
+# The point of the job split is visibility: GitHub renders two levels, jobs in
+# the sidebar and steps within a job, so the database goes on the job axis and
+# the test tier on the step axis. A red run then names the database without a
+# click and the tier with one.
+#
+# Actions are referenced by tag here, not SHA. Stage 8 pins them. That ordering
+# is deliberate: this workflow holds no credentials, while the release
+# workflows added in stage 5 do and are SHA-pinned at birth.
+
+name: Check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_call:
+    inputs:
+      full:
+        description: Run the jobs that are otherwise push-only (release.yml passes true)
+        type: boolean
+        default: false
+
+concurrency:
+  # A superseded push stops burning runners instead of racing its replacement.
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# Test-only values, copied as literals from src/build/docker-compose-test.yml.
+# These are fixed test credentials, not secrets: keeping them literal is what
+# lets a developer reproduce a CI failure locally. Declared once at workflow
+# level because GitHub does not support YAML anchors in workflow files, and
+# every container job needs the same block.
+#
+# The database variables are deliberately absent: run-tests.sh's
+# configure_database sets them per database, and that function is the reason CI
+# can reuse the script unchanged.
+env:
+  TZ: Europe/Lisbon
+
+  GOIABADA_ADMIN_EMAIL: admin@example.com
+  GOIABADA_ADMIN_PASSWORD: changeme
+  GOIABADA_APPNAME: Goiabada
+
+  GOIABADA_AUTHSERVER_BASEURL: http://localhost:19090
+  # The compose file points this at the goiabada-test container by name. In a
+  # container job the server and the tests share one container, so localhost is
+  # the equivalent.
+  GOIABADA_AUTHSERVER_INTERNALBASEURL: http://localhost:19090
+  GOIABADA_AUTHSERVER_LISTEN_HOST_HTTP: 0.0.0.0
+  GOIABADA_AUTHSERVER_LISTEN_PORT_HTTP: "19090"
+  GOIABADA_AUTHSERVER_LISTEN_HOST_HTTPS: ""
+  GOIABADA_AUTHSERVER_LISTEN_PORT_HTTPS: ""
+  GOIABADA_AUTHSERVER_CERTFILE: ""
+  GOIABADA_AUTHSERVER_KEYFILE: ""
+  GOIABADA_AUTHSERVER_TRUST_PROXY_HEADERS: "false"
+  GOIABADA_AUTHSERVER_RATELIMITER_ENABLED: "false"
+  GOIABADA_AUTHSERVER_LOG_HTTP_REQUESTS: "false"
+  GOIABADA_AUTHSERVER_LOG_SQL: "false"
+  GOIABADA_AUTHSERVER_STATICDIR: ""
+  GOIABADA_AUTHSERVER_TEMPLATEDIR: ""
+  GOIABADA_AUTHSERVER_SESSION_AUTHENTICATION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  GOIABADA_AUTHSERVER_SESSION_ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  GOIABADA_AES_ENCRYPTION_KEY: 00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
+  GOIABADA_AUTHSERVER_BOOTSTRAP_ENV_OUTFILE: /tmp/bootstrap.env
+
+  GOIABADA_ADMINCONSOLE_BASEURL: http://localhost:19091
+  GOIABADA_ADMINCONSOLE_LISTEN_HOST_HTTP: 0.0.0.0
+  GOIABADA_ADMINCONSOLE_LISTEN_PORT_HTTP: "19091"
+  GOIABADA_ADMINCONSOLE_LISTEN_HOST_HTTPS: ""
+  GOIABADA_ADMINCONSOLE_LISTEN_PORT_HTTPS: ""
+  GOIABADA_ADMINCONSOLE_CERTFILE: ""
+  GOIABADA_ADMINCONSOLE_KEYFILE: ""
+  GOIABADA_ADMINCONSOLE_TRUST_PROXY_HEADERS: "false"
+  GOIABADA_ADMINCONSOLE_LOG_HTTP_REQUESTS: "false"
+  GOIABADA_ADMINCONSOLE_STATICDIR: ""
+  GOIABADA_ADMINCONSOLE_TEMPLATEDIR: ""
+  GOIABADA_ADMINCONSOLE_SESSION_AUTHENTICATION_KEY: fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+  GOIABADA_ADMINCONSOLE_SESSION_ENCRYPTION_KEY: fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+
+jobs:
+  # Every other job reads its tool versions from here, so versions.yaml stays
+  # the single source of truth and nothing is copied into this file. This job
+  # MUST be in the required-check list: GitHub counts a skipped job as
+  # successful, so if this failed and were not itself required, every dependent
+  # job would skip, count as passing, and leave the PR mergeable with nothing
+  # having run.
+  versions:
+    name: Versions
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.read.outputs.go }}
+      tailwind: ${{ steps.read.outputs.tailwind }}
+      golangci: ${{ steps.read.outputs.golangci }}
+      unparam: ${{ steps.read.outputs.unparam }}
+      govulncheck: ${{ steps.read.outputs.govulncheck }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: read
+        run: |
+          set -euo pipefail
+          f=src/authserver/versions.yaml
+          for k in go tailwind unparam govulncheck; do
+            v=$(yq -r ".tools.$k" "$f")
+            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::tools.$k missing from $f"; exit 1; }
+            echo "$k=$v" >> "$GITHUB_OUTPUT"
+          done
+          v=$(yq -r '.tools."golangci-lint"' "$f")
+          [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::tools.golangci-lint missing from $f"; exit 1; }
+          echo "golangci=$v" >> "$GITHUB_OUTPUT"
+
+  lint:
+    name: Lint
+    needs: versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ needs.versions.outputs.go }}
+          cache-dependency-path: src/**/go.sum
+
+      # Pinned from versions.yaml. A blocking gate whose definition of "clean"
+      # can change on an upstream release is not a gate.
+      - name: Install linters
+        run: |
+          set -euo pipefail
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${{ needs.versions.outputs.golangci }}
+          go install mvdan.cc/unparam@v${{ needs.versions.outputs.unparam }}
+
+      # The standalone staticcheck binary is deliberately not run. It does not
+      # ship the QF (quickfix) checks that golangci-lint's bundled copy
+      # registers, making it a strict subset that cannot fail when golangci-lint
+      # passes. .golangci.yml is the single definition of lint-clean
+      # (docs/ci-v2-design.md 5.8).
+      - name: gofmt, vet, golangci-lint, unparam
+        run: |
+          rc=0
+          for m in core authserver adminconsole cmd/goiabada-setup; do
+            echo "::group::$m"
+            (
+              cd "src/$m"
+              # `gofmt -l` exits 0 and merely prints filenames, so the exit code
+              # cannot be relied on here.
+              unformatted=$(gofmt -l .)
+              if [ -n "$unformatted" ]; then
+                echo "::error::$m has unformatted files:"
+                echo "$unformatted"
+                exit 1
+              fi
+              go vet ./...            || exit 1
+              unparam -exported ./... || exit 1
+              golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./... || exit 1
+            ) || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
+
+  vulnerabilities:
+    name: Vulnerabilities
+    needs: versions
+    runs-on: ubuntu-latest
+    # ADVISORY ONLY, and deliberately so. govulncheck currently reports
+    # GO-2025-3884 (github.com/gorilla/csrf) as reachable from core, authserver
+    # and adminconsole, and the advisory has no fixed version, so this job
+    # cannot pass today. Making it blocking would redden every PR on day one.
+    #
+    # Tracked in issue #155. When that is resolved, delete this line and add
+    # "Vulnerabilities" to the required checks. Until then it MUST NOT be added
+    # to the required-check list (docs/ci-v2-design.md 7).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ needs.versions.outputs.go }}
+          cache-dependency-path: src/**/go.sum
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v${{ needs.versions.outputs.govulncheck }}
+      - name: govulncheck
+        run: |
+          rc=0
+          for m in core authserver adminconsole cmd/goiabada-setup; do
+            echo "::group::$m"
+            ( cd "src/$m" && govulncheck ./... ) || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
+
+  unit-core:
+    name: Unit / core
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    services:
+      # core's TestSendEmail talks to a real SMTP server. Verified by running
+      # the tier without it, where that is the only test that fails.
+      mailpit:
+        image: axllent/mailpit
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Core module tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type core --no-build
+
+  # No services: verified by running this tier with every service unreachable,
+  # where it still passes (with Go's test cache defeated, so the tests really
+  # ran).
+  unit-authserver:
+    name: Unit / authserver
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Authserver internal tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type internal --no-build
+
+  # No services, verified the same way as Unit / authserver.
+  unit-adminconsole:
+    name: Unit / adminconsole
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Admin console module tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type adminconsole --no-build
+
+  # The four database jobs are written out rather than expressed as a matrix.
+  # `matrix` IS available to `services`, so a matrix is possible -- this is a
+  # readability choice. Each database needs its own env block, health command
+  # and port, and expressing that through per-key conditional expressions trades
+  # obvious duplication for expressions that are harder to debug when a health
+  # check misbehaves. A naive matrix would also boot all three databases for
+  # every leg, and GitHub waits for every service health check before running
+  # any step, so the sqlite leg would block on an MSSQL container it never uses.
+
+  tests-sqlite:
+    name: Tests / sqlite
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    services:
+      mailpit:
+        image: axllent/mailpit
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Build
+        working-directory: src/authserver
+        run: ./build.sh
+      - name: Data tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type data --db sqlite --no-build
+      - name: Integration tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type integration --db sqlite --no-build
+
+  tests-mysql:
+    name: Tests / mysql
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    services:
+      # MYSQL_TCP_PORT rather than `command: --port=13306`, because service
+      # containers cannot override a container's command. Verified against the
+      # image directly. Presenting the devcontainer's exact hostname and port is
+      # what lets run-tests.sh run here unchanged.
+      mysql-server:
+        image: mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: mySqlPass123
+          MYSQL_TCP_PORT: 13306
+        options: >-
+          --health-cmd "mysqladmin ping -uroot -pmySqlPass123 --port=13306 --protocol=tcp"
+          --health-interval 3s --health-timeout 3s --health-retries 30
+      mailpit:
+        image: axllent/mailpit
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Build
+        working-directory: src/authserver
+        run: ./build.sh
+      - name: Data tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type data --db mysql --no-build
+      - name: Integration tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type integration --db mysql --no-build
+
+  tests-postgres:
+    name: Tests / postgres
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    services:
+      postgres-server:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: myPostgresPass123
+          POSTGRES_DB: goiabada
+          PGPORT: 15432
+        options: >-
+          --health-cmd "pg_isready -U postgres -p 15432"
+          --health-interval 3s --health-timeout 3s --health-retries 30
+      mailpit:
+        image: axllent/mailpit
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Build
+        working-directory: src/authserver
+        run: ./build.sh
+      - name: Data tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type data --db postgres --no-build
+      - name: Integration tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type integration --db postgres --no-build
+
+  tests-mssql:
+    name: Tests / mssql
+    needs: versions
+    runs-on: ubuntu-latest
+    container: golang:${{ needs.versions.outputs.go }}-bookworm
+    services:
+      mssql-server:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          MSSQL_SA_PASSWORD: YourStr0ngPassw0rd!
+          MSSQL_PID: Express
+          MSSQL_TCP_PORT: 11433
+        # Longer retries than the others: MSSQL routinely takes 30-60s to pass
+        # a health check.
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -Q 'SELECT 1'"
+          --health-interval 5s --health-timeout 5s --health-retries 40
+      mailpit:
+        image: axllent/mailpit
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-test-container
+        with:
+          tailwind: ${{ needs.versions.outputs.tailwind }}
+      - name: Build
+        working-directory: src/authserver
+        run: ./build.sh
+      - name: Data tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type data --db mssql --no-build
+      - name: Integration tests
+        working-directory: src/authserver
+        run: ./run-tests.sh --type integration --db mssql --no-build
+
+  # Moves discovery of a broken Dockerfile or cross-compile from "when I tag a
+  # release" to "right after the merge", without making every PR pay for it.
+  # No registry credentials: --load, never --push.
+  build-validation:
+    name: Build validation
+    needs: versions
+    if: github.event_name == 'push' || inputs.full
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ needs.versions.outputs.go }}
+          cache-dependency-path: src/**/go.sum
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Install Tailwind
+        run: |
+          set -euo pipefail
+          curl -sfL --retry 3 --retry-delay 5 \
+            "https://github.com/tailwindlabs/tailwindcss/releases/download/v${{ needs.versions.outputs.tailwind }}/tailwindcss-linux-x64" \
+            -o /usr/local/bin/tailwindcss
+          chmod +x /usr/local/bin/tailwindcss
+      - name: Cross-compile all platforms
+        working-directory: src/build
+        run: ./build-binaries.sh
+      - name: Cross-compile the setup tool
+        working-directory: src/cmd/goiabada-setup
+        run: ./build-binaries.sh
+      - name: Build both images
+        working-directory: src/build
+        run: |
+          set -euo pipefail
+          docker buildx build --load -f Dockerfile-authserver   -t goiabada-authserver:ci   ..
+          docker buildx build --load -f Dockerfile-adminconsole -t goiabada-adminconsole:ci ..

--- a/docs/ci-v2-design.md
+++ b/docs/ci-v2-design.md
@@ -5,6 +5,8 @@
 **Baseline commit:** `8b69223`
 **Repository:** `leodip/goiabada` (public, default branch `main`)
 
+> **Stage 2 implemented, 2026-08-08.** `check.yml` runs alongside `run-tests.yml`, both green on the same commit: **251s against 541s**, with the wall-clock claim in 4.2 confirmed exactly. Fixed a defect in `run-tests.sh` found on the way (the module tiers could report green from Go's test cache without executing). `Vulnerabilities` is advisory-only pending #155. See stage 2 for the measurements and for four things 5.1 left unspecified.
+
 > **Stage 0 implemented, 2026-08-08.** 4.4 resolved to **option A**. Stage 0 landed on branch `ci-v2-stage-0-lint-baseline`: the lint backlog is **0** across all four modules, `.golangci.yml` is checked in, and `staticcheck`, `unparam` and `govulncheck` are pinned. Two of the plan's assumptions proved wrong while implementing it and are corrected in place — see stage 0's **Correction 1** (`--fix` did nothing) and **Correction 2** (the `QF1001` rewrite taken). 5.8's open question is resolved: `.golangci.yml` is the single definition of lint-clean. Issue #155 remains open and still gates the `Vulnerabilities` required check.
 
 > **Measurement correction, applied after revision 5.** The baseline was re-stamped from `ac4ffac` (the tip of an unrelated feature branch in a different working copy) to this repository's `main` HEAD, and the lint backlog in 1.4 D was re-measured with golangci-lint's issue caps disabled. **The backlog is 81 findings plus 2 unformatted files, not 11.** No design decision changed, but 4.4's "nearly free" rationale no longer follows from the numbers and now presents three options instead of asserting one. See 1.4 D, 4.4, 5.8 and stage 0.
@@ -1477,6 +1479,47 @@ Leave both workflows in place for at least two more merged PRs.
 
 **Rollback** Delete `check.yml`. `run-tests.yml` never stopped gating.
 
+> **Implemented and measured.** Every criterion above was met on the stage 2 PR. Eleven jobs rather than the nine this list anticipated, because `Versions` and `Build validation` were added by later revisions and never folded into this count.
+
+**Measured on the stage 2 PR, both workflows against the same commit:**
+
+| Job | Result | Duration |
+|---|---|---|
+| `Tests / mssql` | pass | 236s |
+| `Tests / mysql` | pass | 229s |
+| `Tests / postgres` | pass | 202s |
+| `Tests / sqlite` | pass | 199s |
+| `Lint` | pass | 182s |
+| `Unit / core` | pass | 93s |
+| `Unit / authserver` | pass | 80s |
+| `Unit / adminconsole` | pass | 79s |
+| `Vulnerabilities` | **fail, tolerated** | 68s |
+| `Versions` | pass | 8s |
+| `Build validation` | skipped, correctly | — |
+
+| Workflow | Wall clock |
+|---|---|
+| `run-tests.yml`, one opaque job | **541s** |
+| `check.yml`, eleven jobs | **251s** |
+
+541s sits inside the 8.3 to 9.2 minute band recorded in 1.3, so this is a like-for-like comparison rather than a lucky run. **4.2's claim holds exactly**: 251s is the slowest leg (`mssql`, 236s) plus about 15s of scheduling, which is what "wall clock drops to roughly the slowest single leg" predicts. Total runner time rises to roughly 23 minutes across all jobs, which is free on a public repository and is precisely the trade 1.3 identified.
+
+**Four things this stage had to resolve that 5.1 did not specify.**
+
+1. **The container jobs need about 40 `GOIABADA_*` environment variables**, copied as literals from `docker-compose-test.yml`. 5.1 mentions only "session keys, the AES key, admin credentials". Without the full set the auth server starts on its default port while `run-tests.sh` polls 19090, and `GOIABADA_AUTHSERVER_BASEURL` is unbound under `set -u`. Discovered by hitting it. They are declared once at workflow level, because GitHub does not support YAML anchors in workflow files. `GOIABADA_AUTHSERVER_INTERNALBASEURL` becomes `http://localhost:19090`, since the server and the tests share one container rather than living in separate compose services.
+2. **The database variables must stay absent** from that block, so `configure_database` remains authoritative (5.5.7).
+3. **`Dockerfile-test` fetches the musl Tailwind binary** for alpine; a bookworm container needs `tailwindcss-linux-x64`.
+4. **Services are declared only where they are needed**, established by running each tier with every service unreachable rather than by assumption: `core` needs `mailpit` (`TestSendEmail` hardcodes `SMTPHost: "mailpit"`, port 1025), while the `authserver` and `adminconsole` tiers need nothing.
+
+The repeated container setup lives in a local composite action, `.github/actions/setup-test-container`, rather than being duplicated across seven jobs.
+
+**A defect in `run-tests.sh` found while doing point 4, and fixed in the same PR.** The three module tiers ran `go test -v ./...` **without `-count=1`**, unlike the data and integration tiers, which have always had it. Go's test cache keys on source and flags but has no notion of whether a network service is reachable, so with `mailpit` gone the core tier still exits 0 reporting `ok ... (cached)` for all 29 packages: **green having executed nothing**. The container jobs cache `GOCACHE` between runs, so stale passes would have been replayed in CI as well. Verified both ways: exit 0 when cached, exit 1 once caching is defeated.
+
+**Deferred, with reasons.**
+
+- **`Lint` takes 182s, nearly as long as a database leg**, and almost none of it is linting: `golangci-lint` and `unparam` are compiled from source by `go install` on every run, and `actions/setup-go`'s cache covers module downloads rather than built binaries. Caching the two binaries keyed on their pinned versions should cut this to well under a minute. Left for stage 8; it is a cost, not a correctness problem.
+- **`Vulnerabilities` will show red on every PR** until issue #155 is resolved, which is the failure mode 4.4 warned about under option C: a permanently red check is one nobody reads, and it also masks any *new* advisory. The alternative worth considering is `govulncheck -format json` filtered against a small allowlist naming `GO-2025-3884` with its reason, so the gate goes green now and red the moment a *different* advisory becomes reachable. Not built, because it is a judgment call about how the gate should read rather than something this document specifies.
+
 ---
 
 ### Stage 3. Retire `run-tests.yml`, set branch protection
@@ -1673,7 +1716,7 @@ Run the same nine-point checklist from stage 5, with two differences: `publish.y
 |---|---|---|---|
 | 0 | **Done.** 81 lint fixes + 2 `gofmt` files (4.4 option A), `.golangci.yml`, 3 tool pins, `make check` aligned | existing CI | yes |
 | 1 | `run-tests.sh` | local runs | yes |
-| 2 | add `check.yml` | its own PR | yes |
+| 2 | **Done.** add `check.yml` (11 jobs), `-count=1` fix | its own PR: 251s vs 541s, all agree | yes |
 | 3 | delete `run-tests.yml`, branch protection | 3 green PRs | yes |
 | 4 | ldflags, `versions.yaml`, `version-manager.sh` | local build checks | full revert only |
 | 5 | `release.yml`, `publish.yml`, `docs.yml`, **SHA pins + attestations on these** | `v1.5.3-rc1` dry run | yes |

--- a/src/authserver/run-tests.sh
+++ b/src/authserver/run-tests.sh
@@ -433,13 +433,21 @@ configure_database() {
 }
 
 # ---- module test runs (no DB matrix) ----------------------------------------
+# -count=1 defeats Go's test result cache, matching what run_tests already does
+# for the data and integration tiers. It is not optional here: core's
+# TestSendEmail talks to a real SMTP server at mailpit:1025, and Go's cache
+# keys on source and flags but has no notion of whether a network service is
+# reachable. Without this, an earlier successful run makes `go test -v ./...`
+# report `ok ... (cached)` and exit 0 even when mailpit is gone -- so the tier
+# reports green having executed nothing. Verified: the same invocation exits 0
+# with 29 cached packages when isolated, and 1 once caching is defeated.
 
 if should_run_internal; then
     log="$LOG_DIR/01-internal.log"
     echo "Running internal tests... (log: $log)"
     start=$SECONDS
     gha_group "Internal tests"
-    if ! go test -v "./internal/..." 2>&1 | tee "$log"; then
+    if ! go test -v -count=1 "./internal/..." 2>&1 | tee "$log"; then
         gha_summary_row "Internal" "-" "FAIL" "$(fmt_duration $((SECONDS - start)))"
         fail_with "Authserver internal tests" "$log"
     fi
@@ -452,7 +460,7 @@ if should_run_core; then
     echo "Running tests for core module... (log: $log)"
     start=$SECONDS
     gha_group "Core module tests"
-    if ! (cd ../core && go test -v ./...) 2>&1 | tee "$log"; then
+    if ! (cd ../core && go test -v -count=1 ./...) 2>&1 | tee "$log"; then
         gha_summary_row "Core" "-" "FAIL" "$(fmt_duration $((SECONDS - start)))"
         fail_with "Core module tests" "$log"
     fi
@@ -465,7 +473,7 @@ if should_run_adminconsole; then
     echo "Running tests for admin console module... (log: $log)"
     start=$SECONDS
     gha_group "Admin console module tests"
-    if ! (cd ../adminconsole && go test -v ./...) 2>&1 | tee "$log"; then
+    if ! (cd ../adminconsole && go test -v -count=1 ./...) 2>&1 | tee "$log"; then
         gha_summary_row "Adminconsole" "-" "FAIL" "$(fmt_duration $((SECONDS - start)))"
         fail_with "Admin console module tests" "$log"
     fi


### PR DESCRIPTION
Stage 2 of the CI/CD v2 plan (5.1). Adds `check.yml` **alongside** `run-tests.yml`, which is untouched and keeps gating every PR. Nothing is deleted and no branch protection changes until stage 3, once this has been shown to agree with the old workflow.

**This PR's own run is the verification.** Per the plan, leave both workflows in place for at least two more merged PRs before stage 3.

## What to look for in this run

- all eleven jobs appear as separate sidebar entries
- each `Tests / <db>` job shows `Build`, `Data tests`, `Integration tests` as distinct steps
- the four databases are reachable at the devcontainer's own hostnames and ports
- results agree with `run-tests` running beside it
- per-job timings, to check the wall-clock claim in section 3 (~9 min serial → roughly the slowest leg)

## Design notes worth reviewing

**Four explicit database jobs, not a matrix.** A matrix *is* possible — `matrix` is available to `services` — so this is a readability choice, recorded in a comment so nobody "simplifies" it back. A naive matrix would also boot all three databases for every leg, and GitHub waits for every service health check before running any step, so the sqlite leg would block on an MSSQL container it never touches.

**`Versions` must become a required check in stage 3.** GitHub counts a *skipped* job as successful. Every other job `needs: versions`, so if it failed and were not itself required, all ten dependent checks would skip, count as passing, and leave the PR mergeable having run nothing.

**Services declared only where needed**, verified by running each tier with every service unreachable: `core` needs mailpit (`TestSendEmail` hardcodes `SMTPHost: "mailpit"`, port 1025); the authserver and adminconsole tiers need nothing.

**Standalone `staticcheck` is deliberately not run** in `Lint`. It does not ship the `QF` checks that golangci-lint's bundled copy registers, making it a strict subset that cannot fail when golangci-lint passes (5.8).

## A defect found while doing this, fixed here

The three module tiers in `run-tests.sh` ran `go test -v ./...` **without `-count=1`**, unlike the data and integration tiers which have always had it.

Go's test cache keys on source and flags but has no notion of whether a network service is reachable. With mailpit unreachable, the core tier still exits **0**, reporting `ok ... (cached)` across all 29 packages — green having executed nothing. Verified: exit 0 when cached, exit 1 once caching is defeated.

This is fixed here rather than deferred because the new `Unit /` jobs would otherwise be unreliable — and worse, the container jobs cache `GOCACHE` across runs, so stale results would have been replayed in CI.

It affects local runs too: `./run-tests.sh --type core` could report green without running anything.

## Not yet blocking

`Vulnerabilities` is `continue-on-error: true` and **must not** be added to the required-check list. `govulncheck` reports `GO-2025-3884` (`gorilla/csrf`) as reachable from three modules with no fixed version, so it cannot pass today. Tracked in #155.

Actions are referenced by tag, not SHA — stage 8 pins them. This workflow holds no credentials, unlike the release workflows in stage 5, which are SHA-pinned at birth.

Validated with `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)