### PR TITLE
CI/CD v2 stage 4: the git tag owns the product version

### DIFF
--- a/src/authserver/version-manager.sh
+++ b/src/authserver/version-manager.sh
@@ -16,11 +16,22 @@
 #   generate - Regenerate committed data files (timezones, countries)
 #   all     - Run all commands in sequence (check → update → deps)
 #
-# Workflow:
+# Scope: this script manages TOOLCHAIN and CDN pins (Go, Tailwind,
+# golangci-lint, mockery, staticcheck, unparam, govulncheck, daisyUI,
+# humanize-duration). It does NOT manage the product version.
+#
+# Workflow, for bumping a tool or CDN pin:
 #   1. Edit versions.yaml to set desired versions
 #   2. Run: ./version-manager.sh update
 #   3. Review changes: git diff
 #   4. Run tests and build
+#
+# Releasing the product is a separate activity and needs none of this:
+#   git tag vX.Y.Z && git push origin vX.Y.Z
+#
+# The version compiled into the binaries, the Docker image tags and the image
+# tags written into the setup wizard's generated manifests all derive from that
+# one tag via ldflags, so they cannot disagree with each other.
 #
 # Requirements:
 #   - yq (YAML parser) - installed in devcontainer
@@ -107,7 +118,7 @@ check_internet() {
 # =============================================================================
 
 # Read a version from versions.yaml
-# Usage: get_version "project.goiabada" -> "1.4.4"
+# Usage: get_version "tools.go" -> "1.26.5"
 get_version() {
     local key="$1"
     yq -r ".$key" "$VERSIONS_FILE"
@@ -116,13 +127,10 @@ get_version() {
 # Get all versions as key=value pairs for display
 get_all_versions() {
     yq -r '
-        .project | to_entries | .[] | "project." + .key + "=" + .value,
         .tools | to_entries | .[] | "tools." + .key + "=" + .value,
         .cdn | to_entries | .[] | "cdn." + .key + "=" + .value
     ' "$VERSIONS_FILE" 2>/dev/null || {
         # Fallback: read each key individually
-        echo "project.goiabada=$(get_version 'project.goiabada')"
-        echo "project.goiabada-setup=$(get_version 'project.goiabada-setup')"
         echo "tools.go=$(get_version 'tools.go')"
         echo "tools.tailwind=$(get_version 'tools.tailwind')"
         echo "tools.golangci-lint=$(get_version 'tools.golangci-lint')"
@@ -236,10 +244,12 @@ cmd_show() {
     printf "%-25s %s\n" "Key" "Version"
     printf "%-25s %s\n" "---" "-------"
 
-    # Project versions
-    echo -e "\n${BOLD}Project:${NC}"
-    printf "  %-23s ${GREEN}%s${NC}\n" "goiabada" "$(get_version 'project.goiabada')"
-    printf "  %-23s ${GREEN}%s${NC}\n" "goiabada-setup" "$(get_version 'project.goiabada-setup')"
+    # Product version, which this file does not own. Reported from git so that
+    # `show` remains the one place that answers "what versions is this project
+    # on", even though the answer now comes from two different sources.
+    echo -e "\n${BOLD}Product (from git tags, not this file):${NC}"
+    printf "  %-23s ${GREEN}%s${NC}\n" "latest tag" "$(git describe --tags --abbrev=0 2>/dev/null || echo 'none')"
+    printf "  %-23s ${GREEN}%s${NC}\n" "working tree" "$(git describe --tags --dirty 2>/dev/null || echo 'unknown')"
 
     # Tool versions
     echo -e "\n${BOLD}Tools:${NC}"
@@ -449,8 +459,6 @@ cmd_update() {
     print_header "Updating Version Strings in Project Files"
 
     # Load all versions from YAML
-    local GOIABADA_VERSION=$(get_version 'project.goiabada')
-    local SETUP_VERSION=$(get_version 'project.goiabada-setup')
     local GO_VERSION=$(get_version 'tools.go')
     local TAILWIND_VERSION=$(get_version 'tools.tailwind')
     local GOLANGCI_VERSION=$(get_version 'tools.golangci-lint')
@@ -484,78 +492,15 @@ cmd_update() {
     done
 
     # -------------------------------------------------------------------------
-    # Build Scripts (Goiabada Version)
+    # Product version: not handled here
     # -------------------------------------------------------------------------
-    echo -e "\n${BOLD}Build Scripts${NC}"
-
-    for script in "$BASE_DIR/src/build/build-binaries.sh" \
-                  "$BASE_DIR/src/build/build-docker-images.sh"; do
-        if [ -f "$script" ]; then
-            # Pattern: VERSION="X.Y.Z" or VERSION="X.Y.Z-suffix"
-            if update_file "$script" \
-                "s|VERSION=\"[0-9.]*\(-[a-zA-Z0-9]*\)\?\"|VERSION=\"${GOIABADA_VERSION}\"|g" \
-                "Goiabada version"; then
-                ((success_count++))
-            else
-                ((fail_count++))
-            fi
-        fi
-    done
-
-    # -------------------------------------------------------------------------
-    # goiabada-setup Tool
-    # -------------------------------------------------------------------------
-    echo -e "\n${BOLD}Goiabada Setup Tool${NC}"
-
-    # Makefile: VERSION ?= X.Y.Z
-    if [ -f "$BASE_DIR/src/cmd/goiabada-setup/Makefile" ]; then
-        if update_file "$BASE_DIR/src/cmd/goiabada-setup/Makefile" \
-            "s|VERSION ?= [0-9.]*|VERSION ?= ${SETUP_VERSION}|g" \
-            "Makefile version"; then
-            ((success_count++))
-        else
-            ((fail_count++))
-        fi
-    fi
-
-    # main.go: const version = "X.Y.Z"
-    if [ -f "$BASE_DIR/src/cmd/goiabada-setup/main.go" ]; then
-        if update_file "$BASE_DIR/src/cmd/goiabada-setup/main.go" \
-            "s|const version = \"[0-9.]*\"|const version = \"${SETUP_VERSION}\"|g" \
-            "version constant"; then
-            ((success_count++))
-        else
-            ((fail_count++))
-        fi
-
-        # Docker image references: leodip/goiabada:authserver-X.Y.Z(-suffix)
-        if update_file "$BASE_DIR/src/cmd/goiabada-setup/main.go" \
-            "s|leodip/goiabada:authserver-[0-9.]*\(-[a-zA-Z0-9]*\)\?|leodip/goiabada:authserver-${GOIABADA_VERSION}|g" \
-            "authserver image"; then
-            ((success_count++))
-        else
-            ((fail_count++))
-        fi
-
-        if update_file "$BASE_DIR/src/cmd/goiabada-setup/main.go" \
-            "s|leodip/goiabada:adminconsole-[0-9.]*\(-[a-zA-Z0-9]*\)\?|leodip/goiabada:adminconsole-${GOIABADA_VERSION}|g" \
-            "adminconsole image"; then
-            ((success_count++))
-        else
-            ((fail_count++))
-        fi
-    fi
-
-    # build-binaries.sh: VERSION="X.Y.Z"
-    if [ -f "$BASE_DIR/src/cmd/goiabada-setup/build-binaries.sh" ]; then
-        if update_file "$BASE_DIR/src/cmd/goiabada-setup/build-binaries.sh" \
-            "s|VERSION=\"[0-9.]*\"|VERSION=\"${SETUP_VERSION}\"|g" \
-            "build script version"; then
-            ((success_count++))
-        else
-            ((fail_count++))
-        fi
-    fi
+    # The build scripts' VERSION= lines, the setup tool's Makefile, its
+    # `const version` and the four leodip/goiabada image tags in its main.go
+    # used to be generated from project.goiabada and project.goiabada-setup.
+    # All of them now come from the git tag via ldflags at build time, so there
+    # is nothing to write: the tag and the version compiled into the binaries
+    # cannot disagree, rather than agreeing only because the release procedure
+    # was followed in the right order.
 
     # -------------------------------------------------------------------------
     # DevContainer Dockerfile
@@ -915,11 +860,17 @@ show_help() {
     echo "  generate Regenerate committed data files (timezones, countries)"
     echo "  all     Run all commands in sequence"
     echo ""
-    echo "Workflow:"
+    echo "Scope: toolchain and CDN pins only. The product version comes from"
+    echo "the git tag, not from versions.yaml."
+    echo ""
+    echo "Workflow, for bumping a tool or CDN pin:"
     echo "  1. Edit versions.yaml to set desired versions"
     echo "  2. Run: $0 update"
     echo "  3. Review changes: git diff"
     echo "  4. Run tests and build"
+    echo ""
+    echo "To release:"
+    echo "  git tag vX.Y.Z && git push origin vX.Y.Z"
     echo ""
     echo "Examples:"
     echo "  $0 show          # See current versions"

--- a/src/authserver/versions.yaml
+++ b/src/authserver/versions.yaml
@@ -1,23 +1,18 @@
 # =============================================================================
 # Goiabada Version Definitions
 # =============================================================================
-# This file is the single source of truth for all version numbers in the project.
-# Edit this file, then run: ./version-manager.sh update
+# This file owns the TOOLCHAIN and CDN pins. Edit it, then run:
+#   ./version-manager.sh update
+#
+# It does NOT own the product version. That comes from the git tag and is
+# injected at build time via ldflags, so the tag and the version compiled into
+# the binaries cannot disagree. Releasing is:
+#   git tag vX.Y.Z && git push origin vX.Y.Z
 #
 # Structure:
-#   project:  - Goiabada application versions
 #   tools:    - Build and development tool versions
 #   cdn:      - Frontend CDN dependency versions
 # =============================================================================
-
-# -----------------------------------------------------------------------------
-# Project Versions
-# -----------------------------------------------------------------------------
-# goiabada:       Main application version (authserver + adminconsole Docker images)
-# goiabada-setup: CLI setup tool version
-project:
-  goiabada: "1.5.2"
-  goiabada-setup: "1.0.0"
 
 # -----------------------------------------------------------------------------
 # Tool Versions

--- a/src/build/build-binaries.sh
+++ b/src/build/build-binaries.sh
@@ -1,65 +1,97 @@
 #!/bin/bash
-VERSION="1.5.2"
+# Cross-compiles authserver + adminconsole for every supported platform and
+# packages each pair as a zip.
+#
+# The version is no longer edited into this file. It comes from the caller,
+# which in a release is the git tag (see docs/ci-v2-design.md 4.1). A plain
+# local run produces "dev".
+#
+# set -euo pipefail matters more here than it looks: without it, build_platform
+# ran cd, go build and zip with no status checks, the loop continued across all
+# five platforms regardless, and the script ended on an echo. A failed
+# cross-compile therefore exited 0 with a success message, and whatever
+# happened to be on disk -- including a previous run's zips -- got uploaded.
+set -euo pipefail
+
+VERSION="${GOIABADA_VERSION:-dev}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:?--version needs a value}"; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
 BUILD_DATE=$(date +%Y-%m-%d)
 GIT_COMMIT=$(git rev-parse --short HEAD)
+
+# Absolute paths, because build_platform used to walk relative to wherever the
+# previous iteration happened to leave the working directory. That worked, but
+# only by coincidence, and under `set -e` a single unexpected cd would abort the
+# run rather than silently building the wrong thing.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$SCRIPT_DIR"
 
 echo "Version: $VERSION"
 echo "Build date: $BUILD_DATE"
 echo "Git commit: $GIT_COMMIT"
 echo "Current directory: $(pwd)"
 
+LDFLAGS='-X "github.com/leodip/goiabada/core/constants.Version='${VERSION}'" -X "github.com/leodip/goiabada/core/constants.BuildDate='${BUILD_DATE}'" -X "github.com/leodip/goiabada/core/constants.GitCommit='${GIT_COMMIT}'"'
+
 # Function to build both applications for a specific platform
 build_platform() {
     local os=$1
     local arch=$2
     local extension=$3  # Empty for Unix, .exe for Windows
-    
+
     echo "Building for $os $arch..."
-    
-    # Build authserver
+
     echo "Building authserver..."
-    cd ../authserver
-    GOOS=$os GOARCH=$arch go build -v -tags=production \
-        -ldflags '-X "github.com/leodip/goiabada/core/constants.Version='${VERSION}'" -X "github.com/leodip/goiabada/core/constants.BuildDate='${BUILD_DATE}'" -X "github.com/leodip/goiabada/core/constants.GitCommit='${GIT_COMMIT}'"' \
-        -o ../build/goiabada-authserver${extension} \
-        ./cmd/goiabada-authserver/main.go
-    
-    # Build adminconsole
+    ( cd "$SRC_DIR/authserver" && GOOS=$os GOARCH=$arch go build -v -tags=production \
+        -ldflags "$LDFLAGS" \
+        -o "$BUILD_DIR/goiabada-authserver${extension}" \
+        ./cmd/goiabada-authserver/main.go )
+
     echo "Building adminconsole..."
-    cd ../adminconsole
-    GOOS=$os GOARCH=$arch go build -v -tags=production \
-        -ldflags '-X "github.com/leodip/goiabada/core/constants.Version='${VERSION}'" -X "github.com/leodip/goiabada/core/constants.BuildDate='${BUILD_DATE}'" -X "github.com/leodip/goiabada/core/constants.GitCommit='${GIT_COMMIT}'"' \
-        -o ../build/goiabada-adminconsole${extension} \
-        ./cmd/goiabada-adminconsole/main.go
-    
-    # Create ZIP with both binaries
-    cd ../build
+    ( cd "$SRC_DIR/adminconsole" && GOOS=$os GOARCH=$arch go build -v -tags=production \
+        -ldflags "$LDFLAGS" \
+        -o "$BUILD_DIR/goiabada-adminconsole${extension}" \
+        ./cmd/goiabada-adminconsole/main.go )
+
     echo "Creating ZIP package for $os $arch..."
-    zip -v "goiabada-${VERSION}-${os}-${arch}.zip" \
+    ( cd "$BUILD_DIR" && zip -v "goiabada-${VERSION}-${os}-${arch}.zip" \
         "goiabada-authserver${extension}" \
-        "goiabada-adminconsole${extension}"
-    
-    # Clean up binaries
-    rm "goiabada-authserver${extension}" "goiabada-adminconsole${extension}"
+        "goiabada-adminconsole${extension}" )
+
+    rm "$BUILD_DIR/goiabada-authserver${extension}" "$BUILD_DIR/goiabada-adminconsole${extension}"
 }
 
 # Verify go.mod files exist
-if [ ! -f "../authserver/go.mod" ] || [ ! -f "../adminconsole/go.mod" ]; then
+if [ ! -f "$SRC_DIR/authserver/go.mod" ] || [ ! -f "$SRC_DIR/adminconsole/go.mod" ]; then
     echo "Error: Could not find go.mod files. Cannot proceed with build."
     exit 1
 fi
 echo "Found go.mod files"
 
+# `export`, not `go env -w`. The latter writes CGO_ENABLED into the user's
+# global Go configuration (~/.config/go/env), which persists well beyond this
+# build and affects every other Go project on the machine. It also fails
+# outright where that directory does not exist, which under `set -e` now aborts
+# the build rather than being silently ignored. Scope it to this process
+# instead, matching what the setup tool's build script already does.
 echo "Setting CGO_ENABLED=0..."
-go env -w CGO_ENABLED=0
+export CGO_ENABLED=0
 
 echo "Downloading dependencies for authserver..."
-cd ../authserver
-go mod download -x
+( cd "$SRC_DIR/authserver" && go mod download -x )
 
 echo "Downloading dependencies for adminconsole..."
-cd ../adminconsole
-go mod download -x
+( cd "$SRC_DIR/adminconsole" && go mod download -x )
+
+# Start clean, so nothing stale can survive into a release upload.
+rm -f "$BUILD_DIR"/goiabada-*.zip
 
 # Build for each platform
 build_platform "linux" "amd64" ""
@@ -68,5 +100,17 @@ build_platform "darwin" "amd64" ""
 build_platform "darwin" "arm64" ""
 build_platform "windows" "amd64" ".exe"
 
+# Explicit manifest of the expected artifacts. `set -e` catches a failing
+# command; it does not catch a build that produced nothing.
+EXPECTED=(
+    "goiabada-${VERSION}-linux-amd64.zip"   "goiabada-${VERSION}-linux-arm64.zip"
+    "goiabada-${VERSION}-darwin-amd64.zip"  "goiabada-${VERSION}-darwin-arm64.zip"
+    "goiabada-${VERSION}-windows-amd64.zip"
+)
+for f in "${EXPECTED[@]}"; do
+    [ -s "$BUILD_DIR/$f" ] || { echo "missing or empty artifact: $f" >&2; exit 1; }
+done
+
 echo "Build process completed successfully!"
 echo "All binaries have been zipped and cleaned up."
+ls -la "$BUILD_DIR"/goiabada-*.zip

--- a/src/build/build-docker-images.sh
+++ b/src/build/build-docker-images.sh
@@ -2,12 +2,16 @@
 set -euo pipefail  # Exit on error, undefined variables, pipe failures
 
 # Configuration
-VERSION="1.5.2"
+#
+# The version is no longer edited into this file. It comes from the caller,
+# which in a release is the git tag (see docs/ci-v2-design.md 4.1).
+VERSION="${GOIABADA_VERSION:-dev}"
 BUILD_DATE=$(date +%Y-%m-%d)
 GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 # Determine if this is a pre-release version (contains -alpha, -beta, -rc, etc.)
-# Pre-release versions should NOT be tagged as "latest"
+# Kept for reporting, and reinforced at the release level: `latest` is no longer
+# this script's business at all (see below).
 IS_PRERELEASE=false
 if [[ "$VERSION" == *-* ]]; then
     IS_PRERELEASE=true
@@ -21,10 +25,27 @@ PLATFORMS="linux/amd64,linux/arm64"
 # Builder name
 BUILDER_NAME="goiabada-multiarch"
 
-# Parse arguments
+# Parse arguments.
+#
+# Proper long-option parsing rather than positional $1. An earlier proposal to
+# read the version from $1 collided with the --push check that used to live
+# here: `build-docker-images.sh --push` would have set VERSION=--push and
+# published images tagged `authserver---push`, which is a legal Docker tag, so
+# it would have succeeded. The *) arm turns a future typo into a failure
+# instead of a silently ignored argument.
 PUSH=false
-if [[ "${1:-}" == "--push" ]]; then
-    PUSH=true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:?--version needs a value}"; shift 2 ;;
+        --push)    PUSH=true; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Recompute after parsing, since --version may have changed it.
+IS_PRERELEASE=false
+if [[ "$VERSION" == *-* ]]; then
+    IS_PRERELEASE=true
 fi
 
 # Validate Docker is available
@@ -38,10 +59,11 @@ echo "Version: $VERSION"
 echo "Build date: $BUILD_DATE"
 echo "Git commit: $GIT_COMMIT"
 if [[ "$IS_PRERELEASE" == true ]]; then
-    echo "Pre-release: yes (will NOT tag as 'latest')"
+    echo "Pre-release: yes"
 else
-    echo "Pre-release: no (will tag as 'latest')"
+    echo "Pre-release: no"
 fi
+echo "Tags: version only ('latest' is moved by publish.yml on release)"
 if [[ "$PUSH" == true ]]; then
     echo "Mode: Multi-platform build and push"
     echo "Platforms: $PLATFORMS"
@@ -79,10 +101,11 @@ if [[ "$PUSH" == true ]]; then
 
     # Build and push authserver (multi-platform)
     echo "=== Building and pushing authserver image (multi-platform) ==="
+    # Version tag only. The `latest` tags are no longer produced here: they are
+    # moved by publish.yml when a release is deliberately published, so that the
+    # tag every unpinned deployment follows changes at that moment rather than
+    # whenever CI happens to go green (docs/ci-v2-design.md 4.6).
     AUTHSERVER_TAGS="-t leodip/goiabada:authserver-$VERSION"
-    if [[ "$IS_PRERELEASE" == false ]]; then
-        AUTHSERVER_TAGS="$AUTHSERVER_TAGS -t leodip/goiabada:authserver-latest"
-    fi
     docker buildx build --progress=plain \
       --platform "$PLATFORMS" \
       -f ./build/Dockerfile-authserver \
@@ -98,9 +121,6 @@ if [[ "$PUSH" == true ]]; then
     # Build and push adminconsole (multi-platform)
     echo "=== Building and pushing adminconsole image (multi-platform) ==="
     ADMINCONSOLE_TAGS="-t leodip/goiabada:adminconsole-$VERSION"
-    if [[ "$IS_PRERELEASE" == false ]]; then
-        ADMINCONSOLE_TAGS="$ADMINCONSOLE_TAGS -t leodip/goiabada:adminconsole-latest"
-    fi
     docker buildx build --progress=plain \
       --platform "$PLATFORMS" \
       -f ./build/Dockerfile-adminconsole \
@@ -122,10 +142,11 @@ if [[ "$PUSH" == true ]]; then
 else
     # Build authserver (local only, single platform)
     echo "=== Building authserver image (local) ==="
+    # Version tag only. The `latest` tags are no longer produced here: they are
+    # moved by publish.yml when a release is deliberately published, so that the
+    # tag every unpinned deployment follows changes at that moment rather than
+    # whenever CI happens to go green (docs/ci-v2-design.md 4.6).
     AUTHSERVER_TAGS="-t leodip/goiabada:authserver-$VERSION"
-    if [[ "$IS_PRERELEASE" == false ]]; then
-        AUTHSERVER_TAGS="$AUTHSERVER_TAGS -t leodip/goiabada:authserver-latest"
-    fi
     docker buildx build --progress=plain \
       --platform linux/amd64 \
       -f ./build/Dockerfile-authserver \
@@ -141,9 +162,6 @@ else
     # Build adminconsole (local only, single platform)
     echo "=== Building adminconsole image (local) ==="
     ADMINCONSOLE_TAGS="-t leodip/goiabada:adminconsole-$VERSION"
-    if [[ "$IS_PRERELEASE" == false ]]; then
-        ADMINCONSOLE_TAGS="$ADMINCONSOLE_TAGS -t leodip/goiabada:adminconsole-latest"
-    fi
     docker buildx build --progress=plain \
       --platform linux/amd64 \
       -f ./build/Dockerfile-adminconsole \

--- a/src/cmd/goiabada-setup/Makefile
+++ b/src/cmd/goiabada-setup/Makefile
@@ -1,7 +1,9 @@
 # Goiabada Setup CLI - Build Makefile
 # Builds cross-platform binaries for Linux, macOS, and Windows
 
-VERSION ?= 1.0.0
+# The product version comes from the git tag at release time, not from this
+# file. A local `make` build is honestly marked "dev".
+VERSION ?= $(or $(GOIABADA_VERSION),dev)
 BUILD_DIR = ./build
 BINARY_NAME = goiabada-setup
 

--- a/src/cmd/goiabada-setup/build-binaries.sh
+++ b/src/cmd/goiabada-setup/build-binaries.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
-VERSION="1.0.0"
+# Cross-compiles goiabada-setup for every supported platform.
+#
+# The version is no longer edited into this file. It comes from the caller,
+# which in a release is the git tag (see docs/ci-v2-design.md 4.1). A plain
+# local run produces "dev", which is the honest answer for a source build.
+set -euo pipefail
+
+VERSION="${GOIABADA_VERSION:-dev}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:?--version needs a value}"; shift 2 ;;
+        # Turns a future typo into a failure rather than a silently ignored
+        # argument.
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
 
 echo "Version: $VERSION"
 echo "Current directory: $(pwd)"
+
+BUILD_DIR=./build
 
 # Function to build for a specific platform
 build_platform() {
@@ -12,9 +30,13 @@ build_platform() {
 
     echo "Building goiabada-setup for $os $arch..."
 
+    # imageTag gets the same value as version: the wizard writes deployment
+    # manifests for users, and the images it points them at must be the ones
+    # that shipped in this release. Both derive from one tag, so they cannot
+    # disagree.
     GOOS=$os GOARCH=$arch go build -v \
-        -ldflags "-s -w" \
-        -o "./build/goiabada-setup-${os}-${arch}${extension}" \
+        -ldflags "-s -w -X main.version=${VERSION} -X main.imageTag=${VERSION}" \
+        -o "${BUILD_DIR}/goiabada-setup-${os}-${arch}${extension}" \
         ./main.go
 }
 
@@ -30,8 +52,10 @@ export CGO_ENABLED=0
 echo "Downloading dependencies..."
 go mod download -x
 
-# Create build directory
-mkdir -p ./build
+# Start clean, so a failed build cannot leave a previous run's binary on disk
+# for the release job to pick up and upload.
+mkdir -p "$BUILD_DIR"
+rm -f "$BUILD_DIR"/goiabada-setup-*
 
 # Build for each platform
 build_platform "linux" "amd64" ""
@@ -40,7 +64,19 @@ build_platform "darwin" "amd64" ""
 build_platform "darwin" "arm64" ""
 build_platform "windows" "amd64" ".exe"
 
+# Explicit manifest of what must exist. `set -e` catches a failing go build,
+# but not a build that silently produced nothing, and the filenames are
+# load-bearing: the docs link to /releases/latest/download/<these names>.
+EXPECTED=(
+    "goiabada-setup-linux-amd64"   "goiabada-setup-linux-arm64"
+    "goiabada-setup-darwin-amd64"  "goiabada-setup-darwin-arm64"
+    "goiabada-setup-windows-amd64.exe"
+)
+for f in "${EXPECTED[@]}"; do
+    [ -s "${BUILD_DIR}/${f}" ] || { echo "missing or empty artifact: $f" >&2; exit 1; }
+done
+
 echo ""
 echo "Build process completed successfully!"
 echo "Artifacts:"
-ls -la ./build/
+ls -la "$BUILD_DIR"/

--- a/src/cmd/goiabada-setup/main.go
+++ b/src/cmd/goiabada-setup/main.go
@@ -20,7 +20,18 @@ import (
 	_ "github.com/microsoft/go-mssqldb"
 )
 
-const version = "1.0.0"
+// Injected at build time via -ldflags by build-binaries.sh, which takes the
+// value from the git tag. They are vars rather than consts precisely so the
+// linker can set them.
+//
+// The defaults are what a source build gets. "dev" identifies an unreleased
+// binary, and "latest" is the right image tag for someone running the wizard
+// from a checkout: it resolves to the current release rather than to whichever
+// version happened to be hardcoded when the file was last edited.
+var (
+	version  = "dev"
+	imageTag = "latest"
+)
 
 // ANSI color codes
 var (
@@ -1579,7 +1590,7 @@ func generateAuthServerService(config *Config) string {
 	authInternalURL := "http://goiabada-authserver:9090"
 
 	sb.WriteString("  goiabada-authserver:\n")
-	sb.WriteString("    image: leodip/goiabada:authserver-1.5.2\n")
+	fmt.Fprintf(&sb, "    image: leodip/goiabada:authserver-%s\n", imageTag)
 	sb.WriteString("    restart: unless-stopped\n")
 
 	if config.DBType != "sqlite" {
@@ -1686,7 +1697,7 @@ func generateAdminConsoleService(config *Config) string {
 	authInternalURL := "http://goiabada-authserver:9090"
 
 	sb.WriteString("  goiabada-adminconsole:\n")
-	sb.WriteString("    image: leodip/goiabada:adminconsole-1.5.2\n")
+	fmt.Fprintf(&sb, "    image: leodip/goiabada:adminconsole-%s\n", imageTag)
 	sb.WriteString("    restart: unless-stopped\n")
 	sb.WriteString("    depends_on:\n")
 	sb.WriteString("      goiabada-authserver:\n")
@@ -1892,7 +1903,7 @@ func generateKubernetesManifests(config *Config) string {
 	sb.WriteString("    spec:\n")
 	sb.WriteString("      containers:\n")
 	sb.WriteString("      - name: authserver\n")
-	sb.WriteString("        image: leodip/goiabada:authserver-1.5.2\n")
+	fmt.Fprintf(&sb, "        image: leodip/goiabada:authserver-%s\n", imageTag)
 	sb.WriteString("        ports:\n")
 	sb.WriteString("        - containerPort: 9090\n")
 	sb.WriteString("        envFrom:\n")
@@ -1969,7 +1980,7 @@ func generateKubernetesManifests(config *Config) string {
 	sb.WriteString("    spec:\n")
 	sb.WriteString("      containers:\n")
 	sb.WriteString("      - name: adminconsole\n")
-	sb.WriteString("        image: leodip/goiabada:adminconsole-1.5.2\n")
+	fmt.Fprintf(&sb, "        image: leodip/goiabada:adminconsole-%s\n", imageTag)
 	sb.WriteString("        ports:\n")
 	sb.WriteString("        - containerPort: 9091\n")
 	sb.WriteString("        envFrom:\n")


### PR DESCRIPTION
Stage 4 of the CI/CD v2 plan (4.1). Everything that changes **who owns the product version** lands together, so no intermediate commit has two owners. The doc marks this stage **"full revert only"** — worth reviewing rather than fast-merging.

## The split

`versions.yaml` loses its `project:` block and keeps owning toolchain and CDN pins. These are two different activities at two different times: bumping Tailwind or mockery is *maintenance* that wants a human reviewing a diff; cutting a release should just assert "ship what is on main right now". Merging them is why releasing currently means editing six generated files before the tag exists.

Releasing becomes:

```
git tag v1.6.0 && git push origin v1.6.0
```

## Why this matters beyond convenience

`goiabada-setup` writes docker-compose and k8s manifests **for users**, with the image tag baked into the generated string. Tagging `v1.6.0` on a commit whose `main.go` still read `1.5.2` produced a wizard handing users manifests pointing at the *previous* release — silently. That's constraint E's sharp edge.

Both the binary's `--version` and the four image tags it writes now derive from the same tag via `ldflags`, so they are structurally incapable of disagreeing. A source build reports `dev` and pins `:latest`, which is the right answer for a checkout rather than a misleading number.

## The `$1` collision, worth a look

`build-docker-images.sh` already reserved `$1` for `--push`. Reading the version from `$1` too would have made `build-docker-images.sh --push` set `VERSION=--push` and publish images tagged `authserver---push` — a legal Docker tag, so it would have **succeeded**. It now takes proper long options, and the `*)` arm turns a future typo into a failure rather than a silently ignored argument.

It also stops tagging `:latest` entirely; those tags move in `publish.yml` when a release is deliberately published (4.6).

## Silent-failure fixes

Neither binary script set `-e`. `build_platform` ran `cd`, `go build` and `zip` with no status checks, the loop continued across all five platforms regardless, and both scripts ended on an `echo` — so **a failed cross-compile exited 0 with a success message**, and whatever was on disk got uploaded, including a previous run's artifacts. Both now have `set -euo pipefail`, a clean of the output directory, and an explicit manifest check.

## Two things found while doing it

**`build-binaries.sh` walked between modules with relative `cd`**, correct only because each iteration happened to land back where the next one started. Under `set -e` that becomes fatal rather than silent, so paths are now absolute and each build runs in a subshell.

**It ran `go env -w CGO_ENABLED=0`**, which writes into the user's *global* Go configuration and affects every other Go project on the machine. It also fails outright where that directory doesn't exist, which under `set -e` aborts the build. Now a plain `export`, matching the setup tool's script.

## Verified locally

- `--version` reports `dev` by default, and the injected value with `ldflags`
- all four generated image tags follow `imageTag` (checked by rendering the manifests)
- the cross-compile produces five correctly named zips, and `go version -m` confirms the version, build date and commit are baked into the binaries
- `version-manager.sh update` is idempotent with zero `Unchanged` warnings — 22 writes, down from 29, exactly the 7 product-version writes removed
- `show` reports the product version from git; the setup module stays lint-clean

## Release freeze

From here until stage 5 merges, **do not dispatch the old build workflows** — they would now build with `VERSION=dev`. If a release is genuinely needed in this window, complete stage 5 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)