### PR TITLE
fix(ci): never cancel a check run on push to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,9 +25,17 @@ on:
         default: false
 
 concurrency:
-  # A superseded push stops burning runners instead of racing its replacement.
   group: check-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs, so pushing again to a branch stops burning
+  # runners on the previous commit. Never cancel a push to main.
+  #
+  # This was `true` unconditionally, which was wrong: `Build validation` runs
+  # ONLY on push (4.5), and it is the sole job that exercises the release path
+  # -- five cross-compiles plus both Docker images. Merging two PRs in quick
+  # succession cancelled the first one's run, so a commit landed on main having
+  # never had its build path validated, which is precisely what that job exists
+  # to prevent. Observed on 4dd17c8.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
`cancel-in-progress: true` applied to every trigger. But `Build validation` runs **only on push** (4.5), and it is the sole job that exercises the release path — five cross-compiles plus both Docker images.

So merging two PRs in quick succession cancelled the first merge's run, and that commit landed on `main` having **never had its build path validated** — precisely what the job exists to prevent.

Observed for real: `4dd17c8` (stage 2's merge) was cancelled by the merge that produced `e02a56c` (stage 4).

§5.1's rationale for the setting is about superseded *PR* pushes — "superseded PR pushes stop burning runners". Scoping it to `pull_request` keeps that benefit and lets pushes to `main` always finish.

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Validated with `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)