### PR TITLE
CI/CD v2 stage 5: release, publish and docs workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,75 @@
+# The documentation image. Decoupled from releases, so a typo fix ships when it
+# is merged rather than waiting for the next release or a remembered manual
+# dispatch. The path filter means Go-only PRs, the large majority, never pay for
+# it (docs/ci-v2-design.md 4.9).
+#
+# This workflow owns EVERY docs build. An earlier draft had publish.yml dispatch
+# it as well, which meant a stable release built and pushed the docs image
+# twice, concurrently, racing on the same tag.
+
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Docs
+    runs-on: ubuntu-latest
+    # Mandatory: the Docker credentials exist only in this environment.
+    environment: prod
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # The prerelease guard belongs on the TAG LIST, not on the job. A
+      # job-level `if` would skip the whole job for an rc, pushing nothing at
+      # all -- while the intent is that an rc still produces a versioned docs
+      # image (which is what makes an rc reviewable), just without moving what
+      # users read.
+      - name: Compute tags
+        id: tags
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          TAGS=()
+          case "$EVENT" in
+            push|workflow_dispatch)
+              TAGS+=("docs-latest")
+              ;;
+            release)
+              VERSION="${TAG_NAME#v}"
+              TAGS+=("docs-${VERSION}")
+              [ "$PRERELEASE" = "true" ] || TAGS+=("docs-latest")
+              ;;
+          esac
+          [ ${#TAGS[@]} -gt 0 ] || { echo "::error::no tags computed for event '$EVENT'"; exit 1; }
+
+          args=""
+          for t in "${TAGS[@]}"; do args="$args -t leodip/goiabada:$t"; done
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+          echo "Pushing: ${TAGS[*]}"
+
+      - name: Build and push
+        working-directory: site
+        run: |
+          set -euo pipefail
+          docker build ${{ steps.tags.outputs.args }} .
+          for t in $(echo "${{ steps.tags.outputs.args }}" | tr ' ' '\n' | grep -v '^-t$' | grep -v '^$'); do
+            docker push "$t"
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+# Phase two of the release. Publishing the draft is what moves `latest`, so the
+# tag every unpinned `docker compose` deployment follows changes at the moment
+# you consciously decide to release, not when CI happened to go green
+# (docs/ci-v2-design.md 4.6).
+#
+# Deleting the draft instead is a real abort: no user-visible tag ever moved.
+#
+# This workflow does NOT touch the docs. docs.yml owns every docs build,
+# listening for the same event; neither dispatches the other (5.4).
+
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  # REQUIRED for the GHCR push. Verified with `gh api`: this repository's
+  # default_workflow_permissions is `read`, so without this the imagetools push
+  # to ghcr.io fails.
+  packages: write
+
+jobs:
+  retag:
+    name: Retag latest
+    runs-on: ubuntu-latest
+    # An rc never moves `latest`.
+    if: ${{ !github.event.release.prerelease }}
+    # Mandatory: the Docker credentials exist only in this environment.
+    environment: prod
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # A manifest retag: server-side, no rebuild, no layer re-upload, and
+      # byte-identical to what was tested. Takes seconds.
+      - name: Move the latest tags
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          echo "Moving latest to $VERSION"
+          for img in authserver adminconsole; do
+            for reg in leodip/goiabada ghcr.io/leodip/goiabada; do
+              echo "==> $reg:$img-latest -> $reg:$img-$VERSION"
+              docker buildx imagetools create -t "$reg:$img-latest" "$reg:$img-$VERSION"
+            done
+          done
+
+      - name: Show the resulting digests
+        run: |
+          set -euo pipefail
+          for img in authserver adminconsole; do
+            docker buildx imagetools inspect "leodip/goiabada:$img-latest" | head -3
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,268 @@
+# Tag-driven release. Pushing v1.6.0 is the entire procedure; everything below
+# derives from that one tag, and it stops at a DRAFT so the notes can be written
+# before anything user-visible moves (docs/ci-v2-design.md 4.6).
+#
+# Actions are SHA-pinned here, not tag-pinned as in check.yml. This workflow
+# holds Docker Hub credentials, and a moving tag like @v3 means whoever controls
+# that tag chooses what executes next to those secrets.
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write       # create the draft release
+  packages: write       # push to GHCR; the repo default is read
+  id-token: write       # attestations
+  attestations: write
+
+concurrency:
+  # Two pushes of the same tag must not race each other to the registries.
+  group: release-${{ github.ref }}
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      prerelease: ${{ steps.v.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Required: with checkout's default depth of 1, a tag push fetches the
+          # tagged commit alone with no remote refs, so the "is it on main" check
+          # below would reject every tag, including correct ones. A guard that
+          # fails closed on all input is just an outage.
+          fetch-depth: 0
+
+      - id: v
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+
+          # Not the full SemVer grammar. It accepts leading zeros and empty
+          # prerelease identifiers, which would have to be typed deliberately.
+          # What it does enforce is the absence of '+': build metadata is legal
+          # in SemVer but INVALID in a Docker tag, so v1.6.0+build.3 would pass a
+          # naive check and then fail at push, or produce a mangled tag.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::tag '$TAG' must be v<major>.<minor>.<patch>[-prerelease], with no build metadata"
+            exit 1
+          fi
+
+          # Reject a tag pushed from a feature branch. merge-base is used rather
+          # than parsing `git branch -r --contains`, because it states the
+          # question directly and does not depend on which remote-tracking refs
+          # happen to exist.
+          git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo "::error::tag '$TAG' points at a commit that is not reachable from origin/main"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # A prerelease must be marked as one: /releases/latest/ skips
+          # prereleases, and the docs link to that URL for the setup binaries.
+          # Publishing an rc as a normal release would silently retarget every
+          # download link in the docs at a release candidate (constraint A).
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION prerelease=${VERSION#*-}"
+
+  # Duplicated from check.yml rather than shared: a reusable workflow cannot
+  # hand values to sibling jobs, and six lines of duplication is simpler than
+  # inventing a mechanism to avoid it.
+  versions:
+    name: Versions
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.read.outputs.go }}
+      tailwind: ${{ steps.read.outputs.tailwind }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - id: read
+        run: |
+          set -euo pipefail
+          f=src/authserver/versions.yaml
+          for k in go tailwind; do
+            v=$(yq -r ".tools.$k" "$f")
+            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::tools.$k missing from $f"; exit 1; }
+            echo "$k=$v" >> "$GITHUB_OUTPUT"
+          done
+
+  # The full matrix, re-run against the tagged commit. Roughly five minutes of
+  # redundancy when the commit already passed on main, and it buys the
+  # difference between "main was green at some point" and "this exact tag is
+  # green". Tags get pushed at the wrong commit.
+  checks:
+    name: Checks
+    needs: verify
+    uses: ./.github/workflows/check.yml
+    with:
+      full: true
+
+  binaries:
+    name: Binaries
+    # Depends on both, though Checks implies Verify transitively. Naming both
+    # makes the intent explicit and survives someone editing Checks.
+    needs: [verify, checks, versions]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ needs.versions.outputs.go }}
+          cache-dependency-path: src/**/go.sum
+
+      - name: Cross-compile authserver and adminconsole
+        working-directory: src/build
+        run: ./build-binaries.sh --version "${{ needs.verify.outputs.version }}"
+
+      - name: Cross-compile the setup tool
+        working-directory: src/cmd/goiabada-setup
+        run: ./build-binaries.sh --version "${{ needs.verify.outputs.version }}"
+
+      # One staging directory feeding the checksums, the attestation and the
+      # release upload, so all three describe an identical set.
+      - name: Stage artifacts and generate checksums
+        id: stage
+        run: |
+          set -euo pipefail
+          V="${{ needs.verify.outputs.version }}"
+          mkdir -p dist
+          cp src/build/goiabada-"$V"-*.zip dist/
+          # The setup binaries keep UNVERSIONED filenames: the docs link to
+          # /releases/latest/download/goiabada-setup-linux-amd64, and adding a
+          # version would break every download link (constraint A).
+          cp src/cmd/goiabada-setup/build/goiabada-setup-* dist/
+
+          EXPECTED=(
+            "goiabada-$V-linux-amd64.zip"  "goiabada-$V-linux-arm64.zip"
+            "goiabada-$V-darwin-amd64.zip" "goiabada-$V-darwin-arm64.zip"
+            "goiabada-$V-windows-amd64.zip"
+            "goiabada-setup-linux-amd64"   "goiabada-setup-linux-arm64"
+            "goiabada-setup-darwin-amd64"  "goiabada-setup-darwin-arm64"
+            "goiabada-setup-windows-amd64.exe"
+          )
+          for f in "${EXPECTED[@]}"; do
+            [ -s "dist/$f" ] || { echo "::error::missing or empty artifact: $f"; exit 1; }
+          done
+
+          # Only after the manifest check, so checksums.txt can never describe a
+          # partial set.
+          ( cd dist && sha256sum "${EXPECTED[@]}" > checksums.txt )
+
+          count=$(find dist -type f | wc -l)
+          [ "$count" -eq 11 ] || { echo "::error::expected 11 assets, found $count"; exit 1; }
+          ls -la dist/
+
+      - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3
+        with:
+          # No predicate-type: supplying it selects CUSTOM mode, which then
+          # requires predicate or predicate-path. Provenance is the default
+          # precisely when those are omitted.
+          subject-path: 'dist/*'
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-assets
+          path: dist/
+          # The default is `warn`, which is how an empty upload reaches a green
+          # job and then an empty release.
+          if-no-files-found: error
+
+  images:
+    name: Images
+    needs: [verify, checks, versions]
+    runs-on: ubuntu-latest
+    # Mandatory, not decorative. Repo-scope secrets are empty; DOCKER_USERNAME
+    # and DOCKER_PASSWORD exist only in this environment, and GitHub exposes
+    # environment secrets only to jobs that declare the environment.
+    environment: prod
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Version tags only. `latest` moves in publish.yml, when the release is
+      # deliberately published (4.6).
+      - name: Build and push multi-arch images
+        working-directory: src/build
+        env:
+          GOIABADA_REGISTRIES: leodip/goiabada ghcr.io/leodip/goiabada
+          GOIABADA_METADATA_DIR: ${{ runner.temp }}/meta
+        run: ./build-docker-images.sh --version "${{ needs.verify.outputs.version }}" --push
+
+      - name: Read pushed manifest digests
+        id: digests
+        run: |
+          set -euo pipefail
+          for img in authserver adminconsole; do
+            d=$(jq -r '."containerimage.digest"' "${{ runner.temp }}/meta/$img-meta.json")
+            [[ "$d" == sha256:* ]] || { echo "::error::no digest for $img"; exit 1; }
+            echo "$img=$d" >> "$GITHUB_OUTPUT"
+            echo "$img $d"
+          done
+
+      # Docker Hub only. subject-name binds an attestation to a fully qualified
+      # image name, so covering GHCR too would mean four calls rather than two.
+      # One buildx invocation pushed the same manifest to both, so the digests
+      # are identical by construction: GHCR is an unattested mirror whose
+      # contents anyone can verify against the Docker Hub reference.
+      - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3
+        with:
+          subject-name: docker.io/leodip/goiabada
+          subject-digest: ${{ steps.digests.outputs.authserver }}
+          push-to-registry: false
+      - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3
+        with:
+          subject-name: docker.io/leodip/goiabada
+          subject-digest: ${{ steps.digests.outputs.adminconsole }}
+          push-to-registry: false
+
+  draft:
+    name: Draft
+    # Both build jobs, so a partial release cannot produce a draft with missing
+    # assets.
+    needs: [verify, binaries, images]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-assets
+          path: dist
+
+      - name: Create the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          args=(--draft --title "Release $VERSION" --generate-notes)
+          # A prerelease MUST be flagged: /releases/latest/ skips prereleases and
+          # drafts, which is what keeps the docs' download links pointing at the
+          # last stable release (constraint A).
+          [ "$PRERELEASE" = "true" ] && args+=(--prerelease)
+          gh release create "v$VERSION" "${args[@]}" dist/*
+          echo "Draft created. Write the notes, then publish to move 'latest'."

--- a/src/build/build-docker-images.sh
+++ b/src/build/build-docker-images.sh
@@ -17,6 +17,36 @@ if [[ "$VERSION" == *-* ]]; then
     IS_PRERELEASE=true
 fi
 
+# Registries to tag. Space-separated, and defaulting to Docker Hub ALONE so the
+# script stays usable by anything not authenticated to GHCR -- including the
+# legacy workflow retained until stage 7, which logs into Docker Hub only.
+# release.yml sets both. One buildx invocation pushes to every listed registry
+# in a single pass, so a second registry costs no extra build time.
+IFS=' ' read -r -a REGISTRIES <<< "${GOIABADA_REGISTRIES:-leodip/goiabada}"
+
+# Where to write buildx's metadata JSON, which is the only way to get the pushed
+# manifest digest out of the build: buildx prints it to the log but exposes it
+# nowhere consumable, and actions/attest needs it to attest anything at all.
+METADATA_DIR="${GOIABADA_METADATA_DIR:-}"
+
+# Build the -t arguments for one image across every configured registry.
+tags_for() {
+    local image="$1"
+    local reg
+    for reg in "${REGISTRIES[@]}"; do
+        printf -- '-t %s:%s-%s ' "$reg" "$image" "$VERSION"
+    done
+}
+
+# --metadata-file argument, or nothing when no directory was requested.
+metadata_for() {
+    local image="$1"
+    if [ -n "$METADATA_DIR" ]; then
+        mkdir -p "$METADATA_DIR"
+        printf -- '--metadata-file %s/%s-meta.json ' "$METADATA_DIR" "$image"
+    fi
+}
+
 # Platforms to build for:
 # - linux/amd64: Standard x86_64 servers and PCs
 # - linux/arm64: ARM servers (AWS Graviton, Raspberry Pi 4/5, Apple Silicon via Rosetta)
@@ -105,11 +135,11 @@ if [[ "$PUSH" == true ]]; then
     # moved by publish.yml when a release is deliberately published, so that the
     # tag every unpinned deployment follows changes at that moment rather than
     # whenever CI happens to go green (docs/ci-v2-design.md 4.6).
-    AUTHSERVER_TAGS="-t leodip/goiabada:authserver-$VERSION"
     docker buildx build --progress=plain \
       --platform "$PLATFORMS" \
       -f ./build/Dockerfile-authserver \
-      $AUTHSERVER_TAGS \
+      $(tags_for authserver) \
+      $(metadata_for authserver) \
       --build-arg version=$VERSION \
       --build-arg buildDate=$BUILD_DATE \
       --build-arg gitCommit=$GIT_COMMIT \
@@ -120,11 +150,11 @@ if [[ "$PUSH" == true ]]; then
 
     # Build and push adminconsole (multi-platform)
     echo "=== Building and pushing adminconsole image (multi-platform) ==="
-    ADMINCONSOLE_TAGS="-t leodip/goiabada:adminconsole-$VERSION"
     docker buildx build --progress=plain \
       --platform "$PLATFORMS" \
       -f ./build/Dockerfile-adminconsole \
-      $ADMINCONSOLE_TAGS \
+      $(tags_for adminconsole) \
+      $(metadata_for adminconsole) \
       --build-arg version=$VERSION \
       --build-arg buildDate=$BUILD_DATE \
       --build-arg gitCommit=$GIT_COMMIT \
@@ -146,11 +176,10 @@ else
     # moved by publish.yml when a release is deliberately published, so that the
     # tag every unpinned deployment follows changes at that moment rather than
     # whenever CI happens to go green (docs/ci-v2-design.md 4.6).
-    AUTHSERVER_TAGS="-t leodip/goiabada:authserver-$VERSION"
     docker buildx build --progress=plain \
       --platform linux/amd64 \
       -f ./build/Dockerfile-authserver \
-      $AUTHSERVER_TAGS \
+      $(tags_for authserver) \
       --build-arg version=$VERSION \
       --build-arg buildDate=$BUILD_DATE \
       --build-arg gitCommit=$GIT_COMMIT \
@@ -161,11 +190,10 @@ else
 
     # Build adminconsole (local only, single platform)
     echo "=== Building adminconsole image (local) ==="
-    ADMINCONSOLE_TAGS="-t leodip/goiabada:adminconsole-$VERSION"
     docker buildx build --progress=plain \
       --platform linux/amd64 \
       -f ./build/Dockerfile-adminconsole \
-      $ADMINCONSOLE_TAGS \
+      $(tags_for adminconsole) \
       --build-arg version=$VERSION \
       --build-arg buildDate=$BUILD_DATE \
       --build-arg gitCommit=$GIT_COMMIT \


### PR DESCRIPTION
Stage 5 (5.2, 5.3, 5.4). Pushing a `v*` tag becomes the entire release procedure. The old build/publish workflows stay until stage 7.

**This lifts the release freeze** that stage 4 introduced — right now the legacy workflows would produce `dev`-versioned artifacts, so there is no working release path until this lands.

## The DAG is load-bearing

```
Verify ──→ Checks ──┬──→ Binaries ──┐
                    └──→ Images ────┴──→ Draft
```

GitHub runs jobs concurrently unless `needs:` says otherwise. Without these dependencies `Images` could push to both registries while the matrix was still running, or after it failed — and a release that publishes images for a commit whose tests then fail is worse than no automation, because registry tags cannot be un-pulled. `Images` is also the only job holding registry credentials, so a failure anywhere upstream means nothing was ever pushed.

## Verify

Rejects anything that isn't `v<major>.<minor>.<patch>[-prerelease]`, and rejects SemVer **build metadata** specifically: `+` is legal in SemVer but *invalid in a Docker tag*, so `v1.6.0+build.3` would pass a naive check and then fail at push, or produce a mangled tag.

It also rejects a tag whose commit isn't reachable from `origin/main`. That needs `fetch-depth: 0` — at checkout's default depth of 1 there are no remote refs, so the guard would reject **every** tag, including correct ones. A guard that fails closed on all input is just an outage.

## Two-phase, so `latest` moves deliberately

The tag push stops at a **draft** with all 11 assets. Publishing it fires `publish.yml`, which moves `latest` via an `imagetools` manifest retag — server-side, no rebuild, byte-identical to what was tested, seconds. Deleting the draft instead is a real abort: no user-visible tag ever moved. An rc never moves `latest`.

## Details worth reviewing

- **`dist/` staging** feeds the checksums, the attestation and the release upload, so all three describe an identical set. Checksums are generated *only after* an explicit manifest check, so `checksums.txt` can never describe a partial set.
- **Setup binaries keep unversioned filenames** — the docs link to `/releases/latest/download/goiabada-setup-linux-amd64` (constraint A).
- **`docs.yml`'s prerelease guard is on the tag list, not the job.** A job-level `if` would skip the whole job for an rc and push *nothing*, when the intent is that an rc still produces `docs-<version>` without moving what users read.
- **The registry list defaults to Docker Hub alone**, so the legacy workflow retained until stage 7 keeps working — it logs into Docker Hub only, and unconditionally tagging GHCR would break it.
- **`--metadata-file`** is the only consumable source of the pushed manifest digest. Without it `actions/attest` has nothing to attest, and it's easy to watch that step go green while covering nothing.
- **Actions are SHA-pinned here**, not deferred to stage 8: these are the first workflows holding Docker Hub credentials.
- **No `predicate-type`** on the attestations — supplying it selects *custom* mode, which then requires a predicate. Verified against the action's own `action.yml`: provenance is the default when omitted.

## Verification status

`actionlint` clean. The tag grammar and docs tag computation were exercised directly against the tables in 5.2/5.4:

| Tag | Verdict |
|---|---|
| `v1.6.0`, `v1.6.0-rc1`, `v1.6.0-rc.1` | accept |
| `v1.6.0+build.3`, `1.6.0`, `v1.6`, `v1.6.0-` | reject |

| Docs trigger | Tags |
|---|---|
| merge to main touching `site/**` | `docs-latest` |
| stable release | `docs-1.6.0`, `docs-latest` |
| prerelease | `docs-1.6.0-rc1` only |

**End-to-end verification needs a throwaway prerelease tag** (`v1.5.3-rc1`), which publishes real images to Docker Hub and GHCR and creates a draft release. That's reversible but public, so it's left as a deliberate decision rather than done unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)