### PR TITLE
CI/CD v2 stage 6: stop version-manager.sh writing workflows, add the drift guard

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -170,6 +170,29 @@ jobs:
           done
           exit $rc
 
+      # The remaining drift risk once the workflows read versions.yaml at run
+      # time: someone edits versions.yaml and forgets to run `update`, leaving
+      # the Dockerfiles, the four go.mod files and the template CDN pins stale
+      # while CI uses the new value.
+      #
+      # Running `update` here and requiring a clean diff catches any stale
+      # target anywhere, in any number of occurrences. That is strictly stronger
+      # than asserting each expected literal is present somewhere, which was the
+      # earlier proposal: `grep -qF` only asks whether a literal appears at all,
+      # and the devcontainer Dockerfile contains the Go archive name three
+      # times, so two stale copies and one correct one would have passed.
+      #
+      # Safe to mutate the checkout: `update` is pure sed and deterministic, and
+      # the CI working tree is disposable.
+      - name: versions.yaml is applied
+        run: |
+          set -euo pipefail
+          ( cd src/authserver && ./version-manager.sh update >/dev/null )
+          if ! git diff --exit-code; then
+            echo "::error::versions.yaml was changed without running ./version-manager.sh update — commit the regenerated files"
+            exit 1
+          fi
+
   vulnerabilities:
     name: Vulnerabilities
     needs: versions

--- a/src/authserver/version-manager.sh
+++ b/src/authserver/version-manager.sh
@@ -473,25 +473,6 @@ cmd_update() {
     local fail_count=0
 
     # -------------------------------------------------------------------------
-    # GitHub Actions Workflows
-    # -------------------------------------------------------------------------
-    echo -e "\n${BOLD}GitHub Actions Workflows${NC}"
-
-    for workflow in "$BASE_DIR/.github/workflows/build-binaries.yml" \
-                    "$BASE_DIR/.github/workflows/build-setup-binaries.yml"; do
-        if [ -f "$workflow" ]; then
-            # Pattern: go-version: 'X.Y.Z' -> go-version: 'NEW_VERSION'
-            if update_file "$workflow" \
-                "s|go-version: '[0-9.]*'|go-version: '${GO_VERSION}'|g" \
-                "Go version"; then
-                ((success_count++))
-            else
-                ((fail_count++))
-            fi
-        fi
-    done
-
-    # -------------------------------------------------------------------------
     # Product version: not handled here
     # -------------------------------------------------------------------------
     # The build scripts' VERSION= lines, the setup tool's Makefile, its


### PR DESCRIPTION
Stage 6 (5.7.3, 5.7.4). Small, because the workflows read `versions.yaml` at run time rather than having values copied into them — so there's no target map, no occurrence counts, no marker comments and no new verifier.

## What goes

`cmd_update` loses its `GitHub Actions Workflows` section outright. It wrote `go-version:` into `build-binaries.yml` and `build-setup-binaries.yml`, both of which stage 7 deletes. Nothing replaces it: `check.yml` and `release.yml` read `tools.go` from `versions.yaml` when they run, so the number lives in exactly one place and **cannot** drift.

`version-manager.sh` now touches nothing under `.github/`.

## What arrives

That leaves one real risk: someone edits `versions.yaml` and forgets to run `update`, leaving the Dockerfiles, the four `go.mod` files and the template CDN pins stale while CI uses the new value. `check.yml`'s `Lint` job now runs `update` and requires a clean `git diff`.

This is **strictly stronger** than the `verify_versions` function proposed in an earlier revision and deleted unimplemented. That asserted each expected literal appears *somewhere*, which `grep -qF` cannot distinguish from partial drift — and the devcontainer Dockerfile contains the Go archive name **three times**, so two stale copies and one correct one would have passed. Requiring a clean diff catches any stale target anywhere, in any number of occurrences, in six lines of YAML instead of twenty of shell.

Safe to mutate the checkout: `update` is pure `sed` and deterministic, and the CI working tree is disposable.

**Residual gap, stated honestly:** if a `sed` pattern goes stale because the *surrounding syntax* changed, `update` writes nothing, the diff is clean, and an unmanaged version string sits in the file. That's narrower than the failure being fixed and requires someone to restructure a Dockerfile line.

## Verified locally, on a clean tree

1. `update` is idempotent — no diff on an unchanged `versions.yaml`
2. A real `tools.go` bump reaches the Dockerfiles and four `go.mod` files and **no** `.github/` path — where before this change it wrote two workflow files (confirmed by running it both ways)
3. The guard **fires** with exit 1 on a commit that bumps `versions.yaml` without running `update`, naming every stale file

🤖 Generated with [Claude Code](https://claude.com/claude-code)