### PR TITLE
CI/CD v2 stage 8: dependabot, SHA pins, linter caching

### DIFF
--- a/.github/actions/setup-test-container/action.yml
+++ b/.github/actions/setup-test-container/action.yml
@@ -40,7 +40,7 @@ runs:
 
     # GOPATH and GOCACHE inside the official golang image, which runs as root.
     - name: Cache Go modules and build output
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           /go/pkg/mod

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot keeps the pins from going stale. Unattended stale pins are worse
+# than moving tags: they look deliberate.
+#
+# Deliberately NOT covered here: the Go toolchain version, the Tailwind CLI,
+# mockery, staticcheck, unparam, govulncheck and the CDN script tags. Dependabot
+# cannot see any of them -- they are shell downloads, Dockerfile pins and script
+# tags in HTML rather than package manifests. Those stay
+# `./version-manager.sh check` territory. The two tools are complementary, not
+# overlapping (docs/ci-v2-design.md 5.9).
+
+version: 2
+
+updates:
+  # The SHA pins in the workflows. Without this they would be frozen forever,
+  # which is the failure mode pinning is accused of and this avoids.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+
+  # One entry per module: Dependabot does not discover Go workspaces
+  # recursively, and each go.mod is its own dependency graph.
+  - package-ecosystem: gomod
+    directory: /src/core
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: gomod
+    directory: /src/authserver
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: gomod
+    directory: /src/adminconsole
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: gomod
+    directory: /src/cmd/goiabada-setup
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,13 +158,22 @@ jobs:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${{ needs.versions.outputs.golangci }}
           go install mvdan.cc/unparam@v${{ needs.versions.outputs.unparam }}
 
-      # Fails loudly if the cache restored something unusable, rather than
-      # letting a later step fail with a confusing "command not found".
+      # Fails loudly if the cache restored something unusable or stale, rather
+      # than letting a later step fail with a confusing "command not found".
+      #
+      # `go version -m` reads the module version recorded in the binary, which
+      # is what actually proves the cached copy is the pinned one. unparam has
+      # no --version flag, and piping its usage output through `head` is a trap:
+      # head closes the pipe, unparam takes SIGPIPE, and under `pipefail` the
+      # step fails with exit 141 even though the tool is fine.
       - name: Confirm the linters are the pinned versions
         run: |
           set -euo pipefail
           golangci-lint --version
-          unparam -h 2>&1 | head -1
+          for tool in golangci-lint unparam; do
+            path=$(command -v "$tool") || { echo "::error::$tool not on PATH"; exit 1; }
+            go version -m "$path" | awk -v t="$tool" '$1 == "mod" { print t ": " $2 " " $3 }'
+          done
 
       # The standalone staticcheck binary is deliberately not run. It does not
       # ship the QF (quickfix) checks that golangci-lint's bundled copy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,7 @@ jobs:
       unparam: ${{ steps.read.outputs.unparam }}
       govulncheck: ${{ steps.read.outputs.govulncheck }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - id: read
         run: |
           set -euo pipefail
@@ -128,19 +128,43 @@ jobs:
     needs: versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ needs.versions.outputs.go }}
           cache-dependency-path: src/**/go.sum
 
+      # Both linters are compiled from source by `go install`, which dominated
+      # this job: 182s, almost none of it linting. setup-go's cache covers
+      # module downloads, not built binaries, so cache the binaries themselves.
+      #
+      # The key is the pinned versions, so a bump in versions.yaml misses the
+      # cache and rebuilds exactly once. That is also why this cannot serve a
+      # stale linter: the version is in the key, not merely in the install
+      # command.
+      - name: Cache linter binaries
+        id: linter-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/bin
+          key: linters-${{ runner.os }}-golangci${{ needs.versions.outputs.golangci }}-unparam${{ needs.versions.outputs.unparam }}
+
       # Pinned from versions.yaml. A blocking gate whose definition of "clean"
       # can change on an upstream release is not a gate.
       - name: Install linters
+        if: steps.linter-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${{ needs.versions.outputs.golangci }}
           go install mvdan.cc/unparam@v${{ needs.versions.outputs.unparam }}
+
+      # Fails loudly if the cache restored something unusable, rather than
+      # letting a later step fail with a confusing "command not found".
+      - name: Confirm the linters are the pinned versions
+        run: |
+          set -euo pipefail
+          golangci-lint --version
+          unparam -h 2>&1 | head -1
 
       # The standalone staticcheck binary is deliberately not run. It does not
       # ship the QF (quickfix) checks that golangci-lint's bundled copy
@@ -207,12 +231,20 @@ jobs:
     # to the required-check list (docs/ci-v2-design.md 7).
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ needs.versions.outputs.go }}
           cache-dependency-path: src/**/go.sum
+      - name: Cache govulncheck
+        id: govuln-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/bin
+          key: govulncheck-${{ runner.os }}-${{ needs.versions.outputs.govulncheck }}
+
       - name: Install govulncheck
+        if: steps.govuln-cache.outputs.cache-hit != 'true'
         run: go install golang.org/x/vuln/cmd/govulncheck@v${{ needs.versions.outputs.govulncheck }}
       - name: govulncheck
         run: |
@@ -235,7 +267,7 @@ jobs:
       mailpit:
         image: axllent/mailpit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -252,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     container: golang:${{ needs.versions.outputs.go }}-bookworm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -267,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     container: golang:${{ needs.versions.outputs.go }}-bookworm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -293,7 +325,7 @@ jobs:
       mailpit:
         image: axllent/mailpit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -328,7 +360,7 @@ jobs:
       mailpit:
         image: axllent/mailpit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -360,7 +392,7 @@ jobs:
       mailpit:
         image: axllent/mailpit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -395,7 +427,7 @@ jobs:
       mailpit:
         image: axllent/mailpit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup-test-container
         with:
           tailwind: ${{ needs.versions.outputs.tailwind }}
@@ -418,13 +450,13 @@ jobs:
     if: github.event_name == 'push' || inputs.full
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ needs.versions.outputs.go }}
           cache-dependency-path: src/**/go.sum
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Install Tailwind
         run: |
           set -euo pipefail

--- a/docs/ci-v2-design.md
+++ b/docs/ci-v2-design.md
@@ -1529,7 +1529,7 @@ The repeated container setup lives in a local composite action, `.github/actions
 
 **Deferred, with reasons.**
 
-- **`Lint` takes 182s, nearly as long as a database leg**, and almost none of it is linting: `golangci-lint` and `unparam` are compiled from source by `go install` on every run, and `actions/setup-go`'s cache covers module downloads rather than built binaries. Caching the two binaries keyed on their pinned versions should cut this to well under a minute. Left for stage 8; it is a cost, not a correctness problem.
+- **`Lint` takes 182s, nearly as long as a database leg**, and almost none of it is linting: `golangci-lint` and `unparam` are compiled from source by `go install` on every run, and `actions/setup-go`'s cache covers module downloads rather than built binaries. **Done in stage 8**: the binaries are cached under a key containing their pinned versions, so a bump in `versions.yaml` misses the cache and rebuilds exactly once, and the cache cannot serve a stale linter because the version is part of the key rather than only of the install command.
 - **`Vulnerabilities` will show red on every PR** until issue #155 is resolved, which is the failure mode 4.4 warned about under option C: a permanently red check is one nobody reads, and it also masks any *new* advisory. The alternative worth considering is `govulncheck -format json` filtered against a small allowlist naming `GO-2025-3884` with its reason, so the gate goes green now and red the moment a *different* advisory becomes reachable. Not built, because it is a judgment call about how the gate should read rather than something this document specifies.
 
 ---
@@ -1764,7 +1764,7 @@ Run the same nine-point checklist from stage 5, with two differences: `publish.y
 | 5 | **Done.** `release.yml`, `publish.yml`, `docs.yml`, SHA pins + attestations | `v1.5.3-rc1` dry run: 8/9 | yes |
 | 6 | **Done.** remove `version-manager.sh` workflow writes, add the CI drift step | idempotency + guard fires | yes |
 | 7 | **Done.** delete 4 old workflows | stage 5 verified | yes |
-| 8 | Dependabot, remaining SHA pins for `check.yml` | green PR | yes |
+| 8 | **Done.** Dependabot, SHA pins for `check.yml`, linter binary cache | green PR | yes |
 | 9 | first real release | full checklist | n/a |
 
 Stages 0 through 3 deliver the PR-visibility goal on their own and are independently valuable. Stages 4 through 7 deliver the one-command release. Stage 8 is follow-up hardening that can slip without blocking anything, now that the credential-bearing workflows are pinned at birth in stage 5.


### PR DESCRIPTION
Stage 8 — follow-up hardening. Nothing here blocks anything, which is why it comes last.

## Dependabot

Covers `github-actions` plus `gomod` for each of the four modules.

The actions entry is the important one: **it's what keeps the SHA pins from freezing forever**, which is the standard objection to pinning and the reason pinning *without* Dependabot is a trap.

It deliberately does **not** cover the Go toolchain, Tailwind CLI, mockery, staticcheck, unparam, govulncheck or the CDN script tags. Dependabot cannot see any of them — they're shell downloads, Dockerfile pins and script tags in HTML, not package manifests. Those stay `version-manager.sh check` territory. The two tools are complementary, not overlapping.

## SHA pins

`check.yml` and the composite action are now pinned by SHA with a trailing version comment.

The remaining unpinned references all live in workflows **already being deleted** — the four in #169 and `run-tests.yml` in stage 3 — so pinning them would be churn.

## Linter caching: the 182s problem

`Lint` took 182s, nearly as long as a database leg, and almost none of it was linting. `golangci-lint` and `unparam` are compiled from source by `go install` on every run, and `setup-go`'s cache covers module *downloads*, not built binaries.

Both are now cached under a key containing their pinned versions:

```
linters-${{ runner.os }}-golangci2.12.2-unparam0.0.0-2025...
```

Two properties worth noting:

- A bump in `versions.yaml` **misses the cache and rebuilds exactly once**.
- The cache **cannot serve a stale linter**, because the version is part of the key rather than only of the install command. That distinction is what makes this safe for a blocking gate.

A verification step prints both versions afterwards, so a bad restore fails loudly rather than surfacing later as a confusing "command not found". `govulncheck` gets the same treatment.

Expect `Lint` to drop from ~182s to well under a minute on cache hits — visible in this PR's own run, which is a cold cache, and then in the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)