### PR TITLE
chore: gitignore the whole docs/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -428,10 +428,16 @@ src/todo.txt
 .playwright-mcp/
 
 
-# Agreement documents for the two-agent workflow. /leo-spec and /leo-run write and read
-# them under docs/issue-<n>-<slug>/ and they are the run's working memory, but they are
-# deliberately not pushed: the pull request body carries the narrative, the filed issues
-# carry the follow-ups, and the code comments carry the reasoning that constrains future
-# edits. Anything already pushed stays in git history.
-docs/issue-*/
-docs/issue-*.md
+# Working documents. /leo-spec and /leo-run write agreement documents under
+# docs/issue-<n>-<slug>/, and design and planning documents live here too. All
+# of it is the working memory of a piece of work, deliberately not pushed: the
+# pull request body carries the narrative, the filed issues carry the
+# follow-ups, and the code comments carry the reasoning that constrains future
+# edits. A plan left in the repo after it has been executed invites drift from
+# the thing it describes, and a reader finding both has no way to tell which is
+# true. Anything already pushed stays in git history.
+#
+# To track something here later, change this to `docs/*` and add a negation:
+# git does not descend into an excluded directory, so `!docs/keep.md` has no
+# effect while the directory itself is excluded.
+docs/


### PR DESCRIPTION
Two problems with what was there.

**The `.gitignore` entry never landed.** #171 staged only the deletion — `git rm --cached` stages that, but the `.gitignore` edit beside it was never `git add`ed. So the file came back as untracked.

**And naming a specific filename doesn't generalise.** The next planning document would need another line, and nobody would remember to add it. Fair point — it read as oddly specific because it was.

Replaces `docs/issue-*/`, `docs/issue-*.md` and the design document's own entry with a single `docs/`.

**Nothing under `docs/` is tracked**, so this changes nothing about the repository's contents — only what shows up as untracked noise:

```
$ git ls-files docs/
(empty)

$ git check-ignore -v docs/ci-v2-design.md docs/some-future-plan.md docs/issue-200-foo/notes.md
.gitignore:443:docs/    docs/ci-v2-design.md
.gitignore:443:docs/    docs/some-future-plan.md
.gitignore:443:docs/    docs/issue-200-foo/notes.md
```

One pattern, covering the three it replaces plus anything added later.

**One nuance recorded in the comment**, because `docs/` forecloses something: git does not descend into an excluded *directory*, so `!docs/keep.md` has no effect on its own. Tracking a file there later means switching the pattern to `docs/*` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)