### PR TITLE
fix(security): redact credentials from API debug logging

### DIFF
--- a/site/src/content/docs/reference/security.mdx
+++ b/site/src/content/docs/reference/security.mdx
@@ -61,3 +61,7 @@ Goiabada includes several built-in security features:
 - **CORS configuration** - Explicit web origin configuration required for JavaScript clients
 - **Proxy header trust** - Forwarded IP headers are ignored by default; enable `TRUST_PROXY_HEADERS` only behind a proxy. Behind multiple proxies or a CDN, set `TRUSTED_PROXIES` to your proxy IPs/CIDRs so the client IP is resolved from the trusted end of `X-Forwarded-For` and cannot be spoofed
 
+### Logging
+
+- **Credentials are redacted from verbose API logging** - `GOIABADA_AUTHSERVER_DEBUG_API_REQUESTS` writes the request and response bodies of every `/api/v1/admin` and `/api/v1/account` call to the log, so credential values are replaced by `[redacted]` before anything is written: passwords, TOTP codes, TOTP secrets and their enrollment QR image, client secrets, the SMTP password, email verification codes, and the logout URL that carries a signed `id_token_hint`. Field names are kept, so the shape of the body is still readable. The `Authorization` header has always been reduced to `Bearer [redacted]`. A body that is not valid JSON, is larger than 256 KB, or nests more than 32 levels deep outside a redacted value is replaced by a one-line note giving its size and why it was not logged, rather than being written out. Depth is only counted through the parts of the body that get logged, since a redacted value is replaced whole and whatever it contains is never looked at. The flag is off by default and is meant for development
+

--- a/src/authserver/internal/middleware/api_debug_middleware.go
+++ b/src/authserver/internal/middleware/api_debug_middleware.go
@@ -9,9 +9,193 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/leodip/goiabada/core/config"
 )
+
+const (
+	// A body larger than this is never parsed or logged: the map round-trip below
+	// costs roughly 12x what json.Indent did, so an unauthenticated caller could
+	// otherwise make the server spend hundreds of milliseconds and hundreds of
+	// megabytes formatting one request. 256 KB sits well above anything this API
+	// produces: the list endpoints cap at size=200, an audit page of about 100 KB.
+	maxLoggedBody = 256 * 1024
+
+	// Indentation cost grows as the square of the nesting depth, so a small but
+	// deeply nested body expands into a log line hundreds of megabytes long.
+	// 32 is four times the deepest body any endpoint here returns (UpdateUserResponse,
+	// at 8 levels), so nothing legitimate is refused.
+	maxLoggedDepth = 32
+
+	redactedValue = "[redacted]"
+)
+
+// Keys whose values are credentials, written in their struct-tag spelling and
+// folded at startup. logoutUrl is here because POST /api/v1/account/logout-request
+// returns a URL carrying a signed id_token_hint that /auth/logout accepts: the name
+// says nothing about that, so dropping the entry would log a usable token in the
+// clear (#145).
+var sensitiveKeys = foldKeySet(
+	"password", "currentPassword", "newPassword",
+	"otpCode", "secretKey", "base64Image",
+	"smtpPassword", "clientSecret", "client_secret",
+	"verificationCode", "logoutUrl",
+)
+
+// The backstop for credential fields nobody remembers to add above. It over-redacts
+// about fourteen harmless keys on this surface (otpEnabled, tokenExpirationInSeconds
+// and the like), which is accepted: none of them is a value anyone debugs with, and
+// every one is visible in the admin UI (#145).
+var sensitiveKeySubstrings = foldKeyList("password", "secret", "otp", "token")
+
+// foldRune maps a rune to the smallest rune it is case-equivalent to, which is what
+// encoding/json's own foldName does to struct-tag names. Lowercasing is not the same
+// thing and is a bypass rather than a rough edge: the decoder accepts
+// {"paſſword": ...} into the Password field, and a strings.ToLower matcher
+// returns false for it, so that request's password would be logged in the clear (#145).
+func foldRune(r rune) rune {
+	for {
+		folded := unicode.SimpleFold(r)
+		if folded <= r {
+			return folded
+		}
+		r = folded
+	}
+}
+
+// foldKey folds every rune of s, so foldKey(a) == foldKey(b) exactly when
+// strings.EqualFold(a, b).
+func foldKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		b.WriteRune(foldRune(r))
+	}
+	return b.String()
+}
+
+func foldKeySet(keys ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		set[foldKey(key)] = struct{}{}
+	}
+	return set
+}
+
+func foldKeyList(keys ...string) []string {
+	folded := make([]string, 0, len(keys))
+	for _, key := range keys {
+		folded = append(folded, foldKey(key))
+	}
+	return folded
+}
+
+// isSensitiveKey reports whether a JSON key's value must be redacted, matching the
+// named set and the substring net against the folded form of the key.
+func isSensitiveKey(key string) bool {
+	folded := foldKey(key)
+	if _, ok := sensitiveKeys[folded]; ok {
+		return true
+	}
+	for _, substring := range sensitiveKeySubstrings {
+		if strings.Contains(folded, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+// redact returns v with the value of every sensitive key replaced by redactedValue,
+// recursing through objects and arrays. A sensitive value is replaced whole, without
+// recursing into it, so an object-valued secret leaves nothing behind. The top-level
+// value is depth 1; a container nested deeper than maxLoggedDepth returns an error and
+// the caller logs a placeholder instead of the body.
+func redact(v any, depth int) (any, error) {
+	switch value := v.(type) {
+	case map[string]any:
+		if depth > maxLoggedDepth {
+			return nil, fmt.Errorf("nested deeper than %d levels", maxLoggedDepth)
+		}
+		for key, element := range value {
+			if isSensitiveKey(key) {
+				value[key] = redactedValue
+				continue
+			}
+			redacted, err := redact(element, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[key] = redacted
+		}
+		return value, nil
+	case []any:
+		if depth > maxLoggedDepth {
+			return nil, fmt.Errorf("nested deeper than %d levels", maxLoggedDepth)
+		}
+		for i, element := range value {
+			redacted, err := redact(element, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[i] = redacted
+		}
+		return value, nil
+	}
+	return v, nil
+}
+
+// bodyForLog returns the text to log for one request or response body: the body
+// pretty-printed with every credential replaced, or a one-line placeholder giving the
+// byte count and the reason. No part of a body that could not be parsed, that is too
+// large, or that is nested too deeply is ever returned.
+func bodyForLog(body []byte) string {
+	notLogged := func(reason any) string {
+		return fmt.Sprintf("%d bytes, not logged (%v)", len(body), reason)
+	}
+
+	if len(body) > maxLoggedBody {
+		return notLogged(fmt.Sprintf("larger than %d bytes", maxLoggedBody))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	// UseNumber keeps integers exact. Without it an int64 such as 9223372036854775807
+	// round-trips through float64 and is logged as 9223372036854776000, which reads
+	// like a real value and is not one (#145).
+	decoder.UseNumber()
+
+	var parsed any
+	if err := decoder.Decode(&parsed); err != nil {
+		return notLogged(err)
+	}
+	// A second Decode that ends in io.EOF is what proves the body was one complete
+	// value and nothing else. Decoder.More cannot do this job: it answers "is there
+	// another element in the container I am inside", so at the top level it reports
+	// no-more-input for a stray ] or }, and {"a":1}] would be logged as though the
+	// body were valid JSON. Requiring io.EOF accepts exactly what json.Indent accepts,
+	// trailing whitespace included (#145).
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return notLogged("unexpected trailing content after the top-level value")
+	}
+
+	redacted, err := redact(parsed, 1)
+	if err != nil {
+		return notLogged(err)
+	}
+
+	var out bytes.Buffer
+	encoder := json.NewEncoder(&out)
+	// SetEscapeHTML(false) keeps the body readable. With the default on, every "&" in
+	// a URL is rewritten as its backslash-u escape, u0026, and every "<" as u003c, so
+	// a websiteUrl in the log stops matching the one the client sent (#145).
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(redacted); err != nil {
+		return notLogged(err)
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
 
 type responseWriter struct {
 	http.ResponseWriter
@@ -66,13 +250,15 @@ func APIDebugMiddleware() func(http.Handler) http.Handler {
 }
 
 func debugLog(method, url string, reqBody []byte, statusCode int, respBody []byte, duration time.Duration, r *http.Request) {
-	// Sanitize auth header for logging
+	// Sanitize auth header for logging. "None" stays as it is, so a request that
+	// carried no credential is still distinguishable from one whose credential
+	// was removed here.
 	authHeader := "None"
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		if strings.HasPrefix(auth, "Bearer ") {
-			authHeader = "Bearer ***"
+			authHeader = "Bearer " + redactedValue
 		} else {
-			authHeader = "*** (unknown type)"
+			authHeader = redactedValue + " (unknown type)"
 		}
 	}
 
@@ -80,12 +266,12 @@ func debugLog(method, url string, reqBody []byte, statusCode int, respBody []byt
 	slog.Info(fmt.Sprintf("[DEBUG API] → %s %s", method, url))
 	slog.Info(fmt.Sprintf("[DEBUG API]   Headers: Authorization: %s", authHeader))
 
-	// Log request body (if applicable)
+	// Log request body (if applicable). Both bodies go through bodyForLog, which is
+	// the only path from a body to the log: there is no fallback that writes raw
+	// bytes, so a body that cannot be parsed produces a placeholder rather than
+	// appearing in the clear (#145).
 	if len(reqBody) > 0 {
-		var prettyReq bytes.Buffer
-		if json.Indent(&prettyReq, reqBody, "", "  ") == nil {
-			slog.Info(fmt.Sprintf("[DEBUG API]   Request Body:\n%s", prettyReq.String()))
-		}
+		slog.Info(fmt.Sprintf("[DEBUG API]   Request Body:\n%s", bodyForLog(reqBody)))
 	}
 
 	// Log response
@@ -94,12 +280,7 @@ func debugLog(method, url string, reqBody []byte, statusCode int, respBody []byt
 
 	// Log response body
 	if len(respBody) > 0 {
-		var prettyResp bytes.Buffer
-		if json.Indent(&prettyResp, respBody, "", "  ") == nil {
-			slog.Info(fmt.Sprintf("[DEBUG API]   Response Body:\n%s", prettyResp.String()))
-		} else {
-			slog.Info(fmt.Sprintf("[DEBUG API]   Response Body: %s", string(respBody)))
-		}
+		slog.Info(fmt.Sprintf("[DEBUG API]   Response Body:\n%s", bodyForLog(respBody)))
 	}
 
 	slog.Info("[DEBUG API]") // Empty line for separation

--- a/src/authserver/internal/middleware/api_debug_middleware_test.go
+++ b/src/authserver/internal/middleware/api_debug_middleware_test.go
@@ -2,7 +2,9 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/otp"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -643,4 +649,141 @@ func TestDebugLog_LogsBodiesFaithfully(t *testing.T) {
 		assert.Contains(t, output, `\n    \"inner\"`,
 			"the body is pretty printed, which is the point of logging it")
 	})
+}
+
+// -----------------------------------------------------------------------------
+// The middleware, end to end
+//
+// Everything above drives debugLog directly, which cannot show that the middleware
+// hands it the bytes it buffered and teed: the call site could pass the raw bodies
+// to anything and every case above would still pass. The two cases below run real
+// src/core/api payloads, built from a real TOTP seed, through the middleware mounted
+// the way routes.go mounts it, and assert on what an operator would find in the log.
+//
+// The handlers here are the tests' own. The production handler cannot be called from
+// this package because handlers/apihandlers imports this one, and reaching it would
+// need a mock database, a settings context value and a validated token. What is real
+// is what carries the credential: the response and request types, the seed and QR
+// from otp.OTPSecretGenerator, a live TOTP code, and the same
+// json.NewEncoder(w).Encode(resp) the endpoint writes its body with.
+// -----------------------------------------------------------------------------
+
+// debugAPIRouter mounts handler behind APIDebugMiddleware on a chi router, with the
+// middleware as the first r.Use under /api/v1/account, which is how routes.go builds
+// the account API. Debug logging is turned on for the duration of the test.
+func debugAPIRouter(t *testing.T, method, pattern string, handler http.HandlerFunc) *chi.Mux {
+	t.Helper()
+	withDebugAPIRequests(t, true)
+
+	router := chi.NewRouter()
+	router.Route("/api/v1/account", func(r chi.Router) {
+		r.Use(APIDebugMiddleware())
+		r.Method(method, pattern, handler)
+	})
+	return router
+}
+
+// GET /api/v1/account/otp/enrollment returns the TOTP seed twice: once as secretKey
+// and once inside base64Image, which is a QR of the otpauth:// URL the seed is in.
+// Both must be gone from the log, and the client must still receive exactly what the
+// handler wrote.
+func TestAPIDebugMiddleware_DoesNotLogARealOTPEnrollmentResponse(t *testing.T) {
+	logged := captureSlog(t)
+
+	generator := otp.OTPSecretGenerator{}
+	base64Image, secretKey, err := generator.GenerateOTPSecret("seam2@example.com", "Goiabada")
+	assert.NoError(t, err)
+
+	// What the handler wrote, captured as it writes it, so the comparison below is
+	// against the real bytes rather than against a second encode of the same struct.
+	var written bytes.Buffer
+	router := debugAPIRouter(t, http.MethodGet, "/otp/enrollment", func(w http.ResponseWriter, r *http.Request) {
+		resp := api.AccountOTPEnrollmentResponse{Base64Image: base64Image, SecretKey: secretKey}
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(io.MultiWriter(w, &written)).Encode(resp)
+		assert.NoError(t, err)
+	})
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/account/otp/enrollment", nil))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.NotEmpty(t, written.Bytes(),
+		"the handler must have run, or the comparison below holds between two empty slices")
+	assert.Equal(t, written.Bytes(), recorder.Body.Bytes(),
+		"buffering the response for the log must not change a byte of what the client receives")
+
+	output := logged.String()
+	assert.NotContains(t, output, secretKey,
+		"the TOTP seed must not reach the log")
+	// Asserted on a prefix rather than the whole string: a bug that logged only the
+	// first part of the image would pass a whole-string check and still publish the
+	// seed to anyone who reassembled it.
+	assert.NotContains(t, output, base64Image[:64],
+		"nor the QR code, which is the same seed in another form")
+
+	// Absence alone would also hold with the whole response body dropped, which is not
+	// what this change does: the shape of the body stays readable.
+	assert.Contains(t, output, "secretKey")
+	assert.Contains(t, output, "base64Image")
+	assert.Contains(t, output, redactedValue)
+}
+
+// PUT /api/v1/account/otp carries three credentials up: the account password, a live
+// TOTP code and the seed it was generated from. None may reach the log, and all three
+// must still reach the handler, which is the half that makes the middleware safe to
+// mount in front of a real endpoint rather than merely quiet.
+func TestAPIDebugMiddleware_DoesNotLogARealOTPUpdateRequest(t *testing.T) {
+	logged := captureSlog(t)
+
+	generator := otp.OTPSecretGenerator{}
+	_, secretKey, err := generator.GenerateOTPSecret("seam2@example.com", "Goiabada")
+	assert.NoError(t, err)
+
+	otpCode, err := totp.GenerateCode(secretKey, time.Now())
+	assert.NoError(t, err)
+
+	sent := api.UpdateAccountOTPRequest{
+		Enabled:   true,
+		Password:  "SENTINEL-account-password",
+		OtpCode:   otpCode,
+		SecretKey: secretKey,
+	}
+	body, err := json.Marshal(sent)
+	assert.NoError(t, err)
+
+	router := debugAPIRouter(t, http.MethodPut, "/otp", func(w http.ResponseWriter, r *http.Request) {
+		var received api.UpdateAccountOTPRequest
+		err := json.NewDecoder(r.Body).Decode(&received)
+		assert.NoError(t, err)
+		assert.Equal(t, sent, received,
+			"the handler must receive the credentials intact after the middleware read the body to log it")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"otpEnabled":true}`))
+		assert.NoError(t, err)
+	})
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPut, "/api/v1/account/otp", bytes.NewReader(body)))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	output := logged.String()
+	assert.NotContains(t, output, "SENTINEL-account-password",
+		"the account password must not reach the log")
+	assert.NotContains(t, output, otpCode,
+		"nor a live OTP code, which is usable until its step expires")
+	assert.NotContains(t, output, secretKey,
+		"nor the seed, which is usable indefinitely")
+
+	// The request body's one harmless field, asserted with its value and its opening
+	// quote. A bare "enabled" would also match the response's otpEnabled key, which
+	// the substring net redacts, so the case would pass with the request body dropped.
+	assert.Contains(t, output, `\"enabled\": true`,
+		"an ordinary field must survive, or the entry is worth nothing to debug with")
+	assert.Contains(t, output, "password")
+	assert.Contains(t, output, "otpCode")
+	assert.Contains(t, output, "secretKey")
+	assert.Contains(t, output, redactedValue)
 }

--- a/src/authserver/internal/middleware/api_debug_middleware_test.go
+++ b/src/authserver/internal/middleware/api_debug_middleware_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -169,19 +170,19 @@ func TestDebugLog_DoesNotLogTheAuthorizationHeaderVerbatim(t *testing.T) {
 			name:       "bearer token is reduced to a placeholder",
 			authHeader: "Bearer eyJhbGciOiJSUzI1NiJ9.SENTINEL-token-value.signature",
 			secret:     "SENTINEL-token-value",
-			wantInLog:  "Bearer ***",
+			wantInLog:  "Bearer [redacted]",
 		},
 		{
 			name:       "basic credentials are reduced to a placeholder",
 			authHeader: "Basic U0VOVElORUwtY2xpZW50OnNlY3JldA==",
 			secret:     "U0VOVElORUwtY2xpZW50OnNlY3JldA==",
-			wantInLog:  "*** (unknown type)",
+			wantInLog:  "[redacted] (unknown type)",
 		},
 		{
 			name:       "an unknown scheme is reduced to a placeholder",
 			authHeader: "Mystery SENTINEL-opaque-credential",
 			secret:     "SENTINEL-opaque-credential",
-			wantInLog:  "*** (unknown type)",
+			wantInLog:  "[redacted] (unknown type)",
 		},
 	}
 
@@ -214,7 +215,8 @@ func TestDebugLog_ReportsAnAbsentAuthorizationHeader(t *testing.T) {
 }
 
 // The bodies are logged deliberately, which is the point of the debug mode, so
-// this pins that they do reach the log when present.
+// this pins that they do reach the log when present. It is also the regression
+// guard against redaction becoming over-eager: an ordinary field must survive.
 func TestDebugLog_LogsRequestAndResponseBodies(t *testing.T) {
 	logged := captureSlog(t)
 
@@ -263,5 +265,382 @@ func TestDebugLog_HandlesUnknownStatusCode(t *testing.T) {
 	// the log line.
 	assert.NotPanics(t, func() {
 		debugLog("GET", "/api/v1/admin/users", nil, 799, nil, time.Millisecond, req)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Redaction
+//
+// Everything below observes the redactor through debugLog and the captured slog
+// output, which is the behaviour an operator sees. slog's text handler quotes the
+// whole message, so a JSON body arrives with its newlines as the two characters
+// \n and its quotes as \", which is why these assertions are written against
+// unquoted fragments and sentinels rather than against quoted JSON.
+// -----------------------------------------------------------------------------
+
+// logRequestBody runs debugLog over one request body and returns what was logged.
+func logRequestBody(t *testing.T, body string) string {
+	t.Helper()
+	logged := captureSlog(t)
+	req := httptest.NewRequest("POST", "/api/v1/admin/users", nil)
+	debugLog("POST", "/api/v1/admin/users", []byte(body),
+		http.StatusOK, nil, time.Millisecond, req)
+	return logged.String()
+}
+
+// nestedBody builds a body of `depth` nested objects with leaf at the bottom, so
+// the deepest container sits at exactly `depth`.
+func nestedBody(depth int, leaf string) string {
+	return strings.Repeat(`{"a":`, depth) + `"` + leaf + `"` + strings.Repeat(`}`, depth)
+}
+
+// sizedBody builds a valid JSON body of exactly `size` bytes carrying the sentinel.
+func sizedBody(size int, sentinel string) string {
+	const prefix, suffix = `{"note":"`, `"}`
+	padding := size - len(prefix) - len(suffix) - len(sentinel)
+	if padding < 0 {
+		panic("sizedBody: size too small for the sentinel")
+	}
+	return prefix + sentinel + strings.Repeat("x", padding) + suffix
+}
+
+// Every key in the vocabulary, one body per key. The redacted rows assert three
+// things rather than one: the value is gone, the key is still there, and the
+// placeholder is the agreed spelling. A table asserting absence only would pass
+// with the entry deleted outright, or with a different placeholder, and both are
+// things this change deliberately does not do.
+//
+// The hasSmtpPassword, otpEnabled, includeInIdToken and similar rows expect
+// [redacted] although their real values are harmless booleans and integers. That
+// is the accepted cost of the substring net catching credential fields nobody
+// remembered to name, not a bug: none of those values is one anyone debugs with,
+// and every one is visible in the admin UI.
+func TestDebugLog_RedactsSensitiveKeysInBodies(t *testing.T) {
+	testCases := []struct {
+		key          string
+		wantRedacted bool
+	}{
+		// The named set: every key that carries a credential on this surface.
+		{"password", true},
+		{"currentPassword", true},
+		{"newPassword", true},
+		{"otpCode", true},
+		{"secretKey", true},
+		{"base64Image", true},
+		{"smtpPassword", true},
+		{"clientSecret", true},
+		{"client_secret", true},
+		{"verificationCode", true},
+		{"logoutUrl", true},
+
+		// Caught by the substring net, and harmless: the accepted over-redaction.
+		{"passwordPolicy", true},
+		{"setPasswordType", true},
+		{"hasSmtpPassword", true},
+		{"otpEnabled", true},
+		{"resourceOwnerPasswordCredentialsEnabled", true},
+		{"includeInIdToken", true},
+		{"includeInAccessToken", true},
+		{"includeOpenIDConnectClaimsInIdToken", true},
+		{"includeOpenIDConnectClaimsInAccessToken", true},
+		{"tokenExpirationInSeconds", true},
+		{"refreshTokenOfflineIdleTimeoutInSeconds", true},
+		{"refreshTokenOfflineMaxLifetimeInSeconds", true},
+		{"token_endpoint_auth_method", true},
+		{"client_secret_expires_at", true},
+
+		// Ordinary fields, which are the reason the log exists at all.
+		{"email", false},
+		{"givenName", false},
+		{"id", false},
+		{"enabled", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			output := logRequestBody(t, `{"`+tc.key+`":"SENTINEL"}`)
+
+			if tc.wantRedacted {
+				assert.NotContains(t, output, "SENTINEL",
+					"the value of %q must never reach the log", tc.key)
+				assert.Contains(t, output, tc.key,
+					"the key must stay, so the log still shows what the request carried")
+				assert.Contains(t, output, "[redacted]",
+					"the value must be replaced by the agreed placeholder")
+			} else {
+				assert.Contains(t, output, "SENTINEL",
+					"%q carries no credential and must still be logged", tc.key)
+			}
+		})
+	}
+}
+
+// encoding/json matches struct tags with EqualFold semantics, so a handler accepts
+// {"PASSWORD": ...} and even {"paſſword": ...} into its Password field. A matcher
+// that missed either spelling would be a bypass: the handler would honour the
+// request and the log would carry the credential in the clear.
+func TestDebugLog_RedactsSensitiveKeysInAnyCase(t *testing.T) {
+	spellings := []string{
+		"PASSWORD", "PassWord", "SECRETKEY", "otpcode",
+		"paſſword", "ſecretKey",
+	}
+
+	for _, spelling := range spellings {
+		t.Run(spelling, func(t *testing.T) {
+			output := logRequestBody(t, `{"`+spelling+`":"SENTINEL"}`)
+
+			assert.NotContains(t, output, "SENTINEL",
+				"%q is a spelling the handler accepts, so it must be redacted", spelling)
+			assert.Contains(t, output, "[redacted]")
+		})
+	}
+}
+
+// foldKey has to agree with the standard library's notion of case equality exactly,
+// because that is what decides which spellings the handler accepts. Lowercasing does
+// not: it disagrees on the long-s rows below.
+func TestFoldKey_MatchesEqualFold(t *testing.T) {
+	spellings := []string{
+		"password", "PASSWORD", "PassWord", "Password",
+		"paſſword", "pasſword",
+		"passwords", "passwordPolicy", "secretKey", "", "PASSWORd",
+	}
+
+	for _, spelling := range spellings {
+		t.Run(spelling, func(t *testing.T) {
+			assert.Equal(t,
+				strings.EqualFold(spelling, "password"),
+				foldKey(spelling) == foldKey("password"),
+				"foldKey must classify %q the way encoding/json does", spelling)
+		})
+	}
+}
+
+// Credentials are not always at the top level: clientSecret arrives nested under
+// client, and a body can be a bare array. Each case carries its own sentinel so a
+// branch cannot be implemented wrongly and stay green on another case's evidence.
+func TestDebugLog_RedactsThroughNestedStructures(t *testing.T) {
+	t.Run("nested object", func(t *testing.T) {
+		output := logRequestBody(t, `{"client":{"clientSecret":"NESTED-SENTINEL"}}`)
+
+		assert.NotContains(t, output, "NESTED-SENTINEL")
+		assert.Contains(t, output, "clientSecret")
+		assert.Contains(t, output, "[redacted]")
+	})
+
+	t.Run("top level array", func(t *testing.T) {
+		output := logRequestBody(t, `[{"password":"ARRAY-SENTINEL"}]`)
+
+		assert.NotContains(t, output, "ARRAY-SENTINEL")
+		assert.Contains(t, output, "password")
+		assert.Contains(t, output, "[redacted]")
+	})
+
+	t.Run("array mixing sensitive and safe keys", func(t *testing.T) {
+		output := logRequestBody(t,
+			`[{"password":"MIXED-SECRET"},{"email":"MIXED-SAFE"}]`)
+
+		assert.NotContains(t, output, "MIXED-SECRET")
+		assert.Contains(t, output, "MIXED-SAFE", "the safe element must survive")
+		assert.Contains(t, output, "[redacted]")
+	})
+
+	// A sensitive key whose value is an object is replaced whole rather than walked
+	// into, so nothing it contained survives either.
+	t.Run("object valued secret is replaced whole", func(t *testing.T) {
+		output := logRequestBody(t, `{"password":{"safe":"OBJECT-SENTINEL"}}`)
+
+		assert.NotContains(t, output, "OBJECT-SENTINEL")
+		assert.NotContains(t, output, "safe",
+			"the whole value goes, including keys nested inside it")
+		assert.Contains(t, output, "password")
+		assert.Contains(t, output, "[redacted]")
+	})
+
+	t.Run("bare scalar body", func(t *testing.T) {
+		output := logRequestBody(t, `"SCALAR-SENTINEL"`)
+
+		assert.Contains(t, output, "SCALAR-SENTINEL",
+			"a scalar carries no key to judge, so it passes through")
+	})
+}
+
+// POST /api/v1/account/logout-request returns a URL carrying a signed id_token_hint
+// that /auth/logout accepts. Nothing about the name logoutUrl says so, which is why
+// it is in the named set rather than caught by the substring net: remove that entry
+// and this case is the one that fails.
+func TestDebugLog_RedactsTheLogoutUrlCarryingAnIdTokenHint(t *testing.T) {
+	output := logRequestBody(t, `{"logoutUrl":"https://localhost:8080/auth/logout`+
+		`?id_token_hint=JWT-SENTINEL&post_logout_redirect_uri=https%3A%2F%2Fc.test%2Fout"}`)
+
+	assert.NotContains(t, output, "JWT-SENTINEL",
+		"the signed token in the URL is a credential and must not be logged")
+	assert.Contains(t, output, "logoutUrl")
+	assert.Contains(t, output, "[redacted]")
+}
+
+// A body that cannot be parsed, is too large, or is nested too deeply is replaced by
+// a placeholder. There is no path that writes the bytes out anyway: the placeholder
+// says how many there were and why they are not shown, and nothing else.
+func TestDebugLog_RefusesBodiesItCannotSafelyLog(t *testing.T) {
+	testCases := []struct {
+		name       string
+		body       string
+		sentinel   string
+		wantReason string
+	}{
+		{
+			name:       "not json",
+			body:       `garbage NOT-JSON-SENTINEL`,
+			sentinel:   "NOT-JSON-SENTINEL",
+			wantReason: "invalid character",
+		},
+		{
+			name:       "trailing content after a valid value",
+			body:       `{"a":1} TRAILING-SENTINEL`,
+			sentinel:   "TRAILING-SENTINEL",
+			wantReason: "trailing content",
+		},
+		{
+			name:       "concatenated objects",
+			body:       `{"a":1}{"b":"CONCAT-SENTINEL"}`,
+			sentinel:   "CONCAT-SENTINEL",
+			wantReason: "trailing content",
+		},
+		// An unmatched closing delimiter is the trailing content that does not look
+		// like trailing content. json.Decoder.More answers "is there another element
+		// in the container I am inside", so at the top level it reports no-more-input
+		// for a stray ] or }, and a body ending in one was logged as valid JSON.
+		{
+			name:       "unmatched closing bracket",
+			body:       `{"a":"BRACKET-SENTINEL"}]`,
+			sentinel:   "BRACKET-SENTINEL",
+			wantReason: "trailing content",
+		},
+		{
+			name:       "unmatched closing brace",
+			body:       `{"a":"BRACE-SENTINEL"}}`,
+			sentinel:   "BRACE-SENTINEL",
+			wantReason: "trailing content",
+		},
+		{
+			name:       "whitespace before an unmatched closing bracket",
+			body:       `{"a":"SPACED-BRACKET-SENTINEL"} ]`,
+			sentinel:   "SPACED-BRACKET-SENTINEL",
+			wantReason: "trailing content",
+		},
+		{
+			name:       "newline before an unmatched closing brace",
+			body:       "{\"a\":\"NEWLINE-BRACE-SENTINEL\"}\n}",
+			sentinel:   "NEWLINE-BRACE-SENTINEL",
+			wantReason: "trailing content",
+		},
+		{
+			name:       "one byte over the size limit",
+			body:       sizedBody(maxLoggedBody+1, "SIZE-SENTINEL"),
+			sentinel:   "SIZE-SENTINEL",
+			wantReason: "larger than",
+		},
+		{
+			name:       "one level deeper than the depth limit",
+			body:       nestedBody(maxLoggedDepth+1, "DEPTH-SENTINEL"),
+			sentinel:   "DEPTH-SENTINEL",
+			wantReason: "nested deeper than",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := logRequestBody(t, tc.body)
+
+			assert.NotContains(t, output, tc.sentinel,
+				"no fragment of a refused body may be logged")
+			assert.Contains(t, output, fmt.Sprintf("%d bytes", len(tc.body)),
+				"the operator needs to know a body was there and how big it was")
+			assert.Contains(t, output, tc.wantReason,
+				"and why it was not logged, or the placeholder says nothing useful")
+		})
+	}
+}
+
+// The other side of the refusals, which have the opposite oracle and so are separate
+// cases: a body sitting exactly on a bound is logged, and an absent body produces no
+// body line at all rather than a placeholder.
+func TestDebugLog_LogsBodiesOnTheAcceptedSideOfEveryBound(t *testing.T) {
+	t.Run("empty body logs no body line", func(t *testing.T) {
+		output := logRequestBody(t, "")
+
+		assert.NotContains(t, output, "Request Body:",
+			"a bodyless request must stay distinguishable from a refused body")
+	})
+
+	t.Run("exactly the size limit", func(t *testing.T) {
+		output := logRequestBody(t, sizedBody(maxLoggedBody, "AT-SIZE-SENTINEL"))
+
+		assert.Contains(t, output, "AT-SIZE-SENTINEL",
+			"the bound is exclusive, so a body of exactly this size is logged")
+	})
+
+	t.Run("exactly the depth limit", func(t *testing.T) {
+		output := logRequestBody(t, nestedBody(maxLoggedDepth, "AT-DEPTH-SENTINEL"))
+
+		assert.Contains(t, output, "AT-DEPTH-SENTINEL",
+			"the deepest container may sit at exactly the limit")
+	})
+
+	// Depth is only counted through what actually gets logged. A sensitive value is
+	// replaced whole and never traversed, so however deep it is, it costs the encoder
+	// nothing and the body is still worth logging. Refusing here would throw away a
+	// readable body over a subtree that was going to be one word.
+	t.Run("a sensitive value may nest deeper than the depth limit", func(t *testing.T) {
+		body := `{"password":` + nestedBody(maxLoggedDepth+8, "DEEP-SECRET-SENTINEL") + `}`
+
+		output := logRequestBody(t, body)
+
+		assert.NotContains(t, output, "DEEP-SECRET-SENTINEL",
+			"the secret is still redacted, whatever it is wrapped in")
+		assert.NotContains(t, output, "nested deeper than",
+			"an untraversed subtree cannot make the body too expensive to log")
+		assert.Contains(t, output, redactedValue)
+		assert.Contains(t, output, "password")
+	})
+
+	// The other side of the unmatched-delimiter refusals. Requiring the second decode
+	// to end in io.EOF must not start refusing the trailing whitespace that every
+	// json.Encoder writes, or every body a Go client sends stops being logged.
+	t.Run("trailing whitespace after a complete value", func(t *testing.T) {
+		output := logRequestBody(t, "{\"a\":\"TRAILING-WS-SENTINEL\"}\n  ")
+
+		assert.Contains(t, output, "TRAILING-WS-SENTINEL",
+			"whitespace after the value is not trailing content")
+	})
+}
+
+// Three ways the encoder can quietly corrupt a body that is otherwise redacted
+// correctly. All three pass silently with the wrong encoder settings, so they are
+// cases rather than assumptions.
+func TestDebugLog_LogsBodiesFaithfully(t *testing.T) {
+	t.Run("large integers keep their value", func(t *testing.T) {
+		output := logRequestBody(t, `{"maxLifetime":9223372036854775807}`)
+
+		assert.Contains(t, output, "9223372036854775807",
+			"a float64 round trip would log 9223372036854776000, which is not the value sent")
+	})
+
+	t.Run("ampersands are not HTML escaped", func(t *testing.T) {
+		output := logRequestBody(t, `{"websiteUrl":"https://c.test/a?x=1&y=2"}`)
+
+		assert.Contains(t, output, "&")
+		assert.NotContains(t, output, "u0026",
+			"HTML escaping would make the logged URL differ from the one sent")
+	})
+
+	t.Run("nested objects are indented", func(t *testing.T) {
+		output := logRequestBody(t, `{"outer":{"inner":1}}`)
+
+		// slog quotes the message, so a newline arrives as the two characters \n
+		// and the second indentation level as the four spaces after it.
+		assert.Contains(t, output, `\n    \"inner\"`,
+			"the body is pretty printed, which is the point of logging it")
 	})
 }


### PR DESCRIPTION
Closes #145.

## What this is for

When `GOIABADA_AUTHSERVER_DEBUG_API_REQUESTS=true`, the API debug middleware writes the request and
response bodies of every route under `/api/v1/admin` and `/api/v1/account` to the log. It redacts one
thing today, the `Authorization` header. Everything else goes in verbatim.

Executed against the code before this change, a single `PUT /api/v1/account/otp` writes 2865 bytes of
log containing the account password, the live TOTP code, the TOTP seed, and the enrollment QR PNG,
which is a second copy of the seed because `pquerna/otp` QR-encodes the `otpauth://...?secret=...`
URL. The bearer token is the only credential the old code keeps out.

That sits against a decision this repository already made elsewhere: TOTP secrets are encrypted at
rest (#82), and so are client secrets and signing keys. The debug log was the one place a plaintext
copy was written.

No OAuth or OIDC document governs what an authorization server writes to its own logs, and the
silence is itself the finding: this is a product decision, constrained by documents about credential
custody rather than about logging. RFC 6819 section 4.6.7 is titled "Token Leakage via Log Files and
HTTP Referrers" and RFC 9700 section 1 keeps 6819 in force. RFC 6238 section 5.1 says TOTP keys
"SHOULD be protected against unauthorized access and usage" and recommends "exposing them only when
required". A log file is neither a secure area nor a program required by the validation system.

## What this changes

Every body reaching the log goes through one formatter, and there is no path from a body to the log
that does not pass through it. A named set of credential-bearing JSON keys, plus a substring net over
`password`, `secret`, `otp` and `token`, decides what is replaced. A matched value becomes
`"[redacted]"` whatever its type was; the key stays, because "this request carried a `secretKey`" is
most of the debugging value and none of the secret.

**Keys are matched by folding runes, not by lowercasing them.** That is what `encoding/json` does to
struct-tag names, so the decoder accepts `{"paſſword": ...}` into the `Password` field. A handler
honours that request, and a `strings.ToLower` matcher returns false for it, which would log that
password in the clear. Case-sensitivity is the obvious bypass and lowercasing is the same bypass one
rune further out.

**The set is eleven keys, not the six the issue names.** `base64Image` is the TOTP seed in QR form,
`verificationCode` is a live credential on two endpoints, `smtpPassword` is an operator credential,
and `logoutUrl` is the account logout-request response's URL carrying a signed `id_token_hint` that
`/auth/logout` accepts. `client_secret` is kept although the DCR endpoint is not under this
middleware today, so the entry is not the one missing on the day someone mounts it there. The
substring net over-redacts about fourteen harmless keys such as `otpEnabled`, which is accepted: none
is a value anyone debugs with and every one is visible in the admin UI.

**The response body's raw fallback is deleted.** It printed an unparseable response verbatim, where
the request body was silently dropped, and a redactor walking only parsed JSON would have inherited
that asymmetry untouched. Both sides now log a one-line placeholder carrying the byte count and the
reason, which also stops a multipart upload being indistinguishable from a bodyless GET.

**Two bounds, both landing at that same placeholder:** 256 KB on the raw body and 32 levels of
nesting outside a redacted value. The map round-trip costs about 12x what `json.Indent` did, and
indentation cost grows as the square of the depth, so a 60 KB body nested 10000 deep expands into a
200 MB log line. This middleware is the first `r.Use` on both API mounts, ahead of
`RequireBearerTokenScope`, `RequireUserBoundToken` and `RequireValidSession`, so it formats bodies
before any authentication middleware runs and the amplification is unauthenticated.

The `Authorization` line becomes `Bearer [redacted]`, so one word means one thing across a log entry.
`None` is unchanged, because an absent credential must stay distinguishable from a redacted one.

The redactor is unexported and lives beside `debugLog` in `src/authserver/internal/middleware`.
Nothing new is exported and no package is created. #159 is in the same module, so if it wants this key
vocabulary it can call `isSensitiveKey` directly; the two share the key list and nothing else, since
this one walks decoded JSON and #159 walks `url.Values`.

## The goal, executed

Re-running the same probe that produced the 2865-byte leak above, against the merged code:

```
== Q1: what reaches the log today? ==
  account password:                    present in log: false
  live OTP code:                       present in log: false
  TOTP seed (request):                 present in log: false
  QR PNG (response, first 40 chars):   present in log: false
  bearer token:                        present in log: false

  total log bytes for this one request: 707
```

All four credentials that were present are absent, the bearer token is still absent, and the same
request now writes 707 bytes instead of 2865.

## What landed

| Stage | Commit | What |
|---|---|---|
| 1 | [`6794f4c7`](https://github.com/leodip/goiabada/commit/6794f4c7fc8c947ad5863957d4d0399158f7ce95) | the redactor, `bodyForLog`, `debugLog`, the exhaustive key table, and the `### Logging` docs subsection |
| 2 | [`a2e48f9c`](https://github.com/leodip/goiabada/commit/a2e48f9c6152f5a9b574cdb6df32a24b6f188eee) | the middleware wiring, end to end |

### Stage 1

`api_debug_middleware.go` gains the key vocabulary (`foldKey`, `foldRune`, `sensitiveKeys`,
`sensitiveKeySubstrings`, `isSensitiveKey`), the traversal (`redact`), the single body formatter
(`bodyForLog`) and the three constants. `debugLog` routes both bodies through `bodyForLog` and the
raw-response fallback is deleted. `security.mdx` gains a `### Logging` subsection saying what verbose
API logging writes and what it redacts.

**Tests: unit 3028 pass, 0 fail**, the middleware package going from 187 to 193 cases. **20 mutations
run, 20 caught, 0 survived.**

**Two review rounds, both productive, nothing contested.** Round 1 found that the trailing-content
check used `json.Decoder.More`, which is container-scoped and therefore reports no-more-input for a
top-level stray `]` or `}`, so `{"a":1}]` was logged as though it were valid JSON. It is now a second
`Decode` that must return `io.EOF`. No credential leaked by that path, since the accepted prefix still
went through the full redactor; what it cost was the guarantee that a malformed body is identifiable
as malformed. Round 1 also found the depth sentence in `security.mdx` overstated what is refused,
since a sensitive value is replaced whole and never traversed. Round 2 differentially tested the new
rule against `json.Indent` over 1,526,408 bodies and found no acceptance mismatch, and came back clean
on all three axes.

### Stage 2

Test-only, by design: no production code moved, which the tree hash confirms rather than asserts.
Stage 1 shipped the whole redactor, and this stage proves `APIDebugMiddleware` actually routes the
bytes it buffered and teed through it. Two cases drive a real `chi.NewRouter()` with the middleware
mounted exactly as `routes.go` composes it, one per direction: a real
`api.AccountOTPEnrollmentResponse` with a generated seed and QR on the response side, and a real
`api.UpdateAccountOTPRequest` with a live `totp.GenerateCode` on the request side. Both assert the
credentials are absent from the log while the bytes the client sends and receives are unchanged.

Two cases rather than one because the two bodies come from two different sources, the request buffer
and the response tee, and one case cannot fail if the other wire is cut. **Four mutations run, four
caught**: neutralising each formatter call, and separately cutting each wire at the call site. The
reviewer ran six of its own, including restoring an empty `r.Body` downstream and stopping
`responseWriter.Write` forwarding to the client, all caught.

**Tests: unit 3030 pass, 0 fail.** Review round 1 clean, zero findings, `unchecked` empty.

## Tiers

- **Local, per stage:** the unit tier, `3028` then `3030` passing with zero failures, plus the
  middleware package verbose and `go vet`. Every new test seam was mutation-tested: **24 mutations
  across the two stages, 24 caught, 0 survived.**
- **The check suite, on each pushed commit:** the data and integration tiers on sqlite, mysql,
  postgres and mssql as four parallel jobs, plus `Lint`, `Vulnerabilities`, `Build validation` and the
  version check. **Green on `a2e48f9c`:**
  [run 31338403002](https://github.com/leodip/goiabada/actions/runs/31338403002), all eleven jobs
  passing.
- **Data and integration were not applicable to either stage** and nothing local ran them. No query,
  interface method, migration or schema change exists here. The integration harness starts the
  authserver as a separate process, so a test cannot set the debug flag in its memory nor read its
  `slog` output; stage 2 is the in-process substitute for exactly that coverage.

## Deviations worth knowing

- **The trailing-content check.** The design said `dec.More()`; it shipped as a second `Decode`
  requiring `io.EOF`, because `More` is container-scoped and accepts a top-level stray `]` or `}`.
  Found by review, verified independently over 14 shapes and then over 1.5 million bodies.
- **`redact` counts depth on containers only**, at the top of the map and slice cases rather than on
  entry, so a body whose deepest container sits at exactly the limit is accepted. Both sides of that
  boundary are pinned by cases.
- **A sensitive value is replaced whole and never traversed**, so nesting below a redacted key is
  never counted against the depth bound. The documentation said otherwise for one round and now says
  this.
- **The seam 2 handler is the test's own**, not the production OTP handler:
  `handlers/apihandlers` imports `internal/middleware`, so calling it from a test in package
  `middleware` is an import cycle. What carries the credentials is real either way, the response and
  request types, the seed, the QR, a live TOTP code and the encoder call.

## Before merging

- [One deferred decision](https://github.com/leodip/goiabada/pull/189#issuecomment-5234391714), on
  `logoutUrl` being redacted whole and taking its other query parameters with it.
- [Two drafted follow-ups](https://github.com/leodip/goiabada/pull/189#issuecomment-5234391768), each
  ready to file: the middleware's unbounded pre-auth body read, and `.gitignore`'s unanchored `docs/`
  rule reaching into the documentation site.
