### PR TITLE
fix(gitignore): anchor the docs/ rule to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -437,7 +437,13 @@ src/todo.txt
 # the thing it describes, and a reader finding both has no way to tell which is
 # true. Anything already pushed stays in git history.
 #
-# To track something here later, change this to `docs/*` and add a negation:
-# git does not descend into an excluded directory, so `!docs/keep.md` has no
+# The leading slash anchors the rule to the repository root, and it has to stay.
+# A bare `docs/` has no slash of its own, so git applies it at every directory
+# level: it also excluded site/src/content/docs/, the entire content tree of the
+# documentation site, which made every new page silently unstageable (issue
+# #191).
+#
+# To track something here later, change this to `/docs/*` and add a negation:
+# git does not descend into an excluded directory, so `!/docs/keep.md` has no
 # effect while the directory itself is excluded.
-docs/
+/docs/


### PR DESCRIPTION
Closes #191.

## The problem

`.gitignore` ended with a bare `docs/`, written to exclude the working-document directory at the repository root. A pattern with no slash of its own applies at every directory level, so git also matched `site/src/content/docs/`, the entire content tree of the documentation site.

The 41 pages already tracked there kept working, which is what hid it. The breakage only showed on a *new* page: the file was ignored, `git add -A` staged nothing, and `git add <path>` failed with "The following paths are ignored by one of your .gitignore files". The site builds from that directory, so a page that existed locally and not in the repository published nothing.

## The fix

One character: `docs/` becomes `/docs/`. The leading slash anchors the pattern to the `.gitignore` location, so it still covers the root working-document directory and stops reaching into `site/`. The surrounding comment now says why the slash is there, so it does not get dropped again, and the "to track something here later" hint was updated to match (`/docs/*`, `!/docs/keep.md`).

## Verification

| Check | Before | After |
|---|---|---|
| `git check-ignore -v site/src/content/docs/reference/a-brand-new-page.mdx` | `.gitignore:443:docs/` | not ignored |
| `git check-ignore -v --no-index site/src/content/docs/reference/security.mdx` | `.gitignore:443:docs/` | not ignored |
| `git check-ignore -v docs/issue-191-.../agreement.md` | ignored | ignored (`/docs/`) |
| Stage a new `.mdx` under `site/src/content/docs/` | fails | stages without `-f` |
| Stage a new file under root `docs/` | refused | still refused |
| `git ls-files \| git check-ignore --no-index -v --stdin` | 41 tracked files shadowed | empty |

That last row is the sweep the issue asked for. `docs/` was the only rule shadowing tracked content, all 41 hits, and they are all gone. The other unanchored patterns in the file are stock `VisualStudio.gitignore` entries (`bin/`, `obj/`, `node_modules/`, `[Rr]elease/`) that are meant to match at any depth, so they were left alone. The repo-specific additions (`.devdata/`, `.review/`, `.playwright-mcp/`, `tmp/`) collide with nothing today; the same latent risk applies to them if a nested directory with one of those names ever appears, which felt like speculative churn to change in this pass.

No code paths touched, so there is nothing to test beyond the git behaviour above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
