### PR TITLE
fix(ratelimiter): answer POST /auth/otp when the auth context is unreadable

### DIFF
--- a/site/src/content/docs/reference/environment-variables.mdx
+++ b/site/src/content/docs/reference/environment-variables.mdx
@@ -213,9 +213,12 @@ When enabled, Goiabada applies rate limits to security-sensitive endpoints:
 
 | Endpoint | Limit | Key |
 |----------|-------|-----|
-| `POST /auth/pwd` (password login) | 10 req/min | email |
+| `POST /auth/pwd` (password login) | 15 req/min | email |
+| `POST /auth/pwd` (password login) | 30 req/min | IP address |
 | `POST /auth/otp` (OTP verification) | 10 req/min | user ID |
-| `GET /reset-password` | 5 req/5min | email |
+| `POST /forgot-password` | 5 req/5min | email |
+| `POST /forgot-password` | 20 req/5min | IP address |
+| `GET` and `POST /reset-password` | 5 req/5min | email |
 | `GET /account/activate` | 5 req/5min | email |
 | `POST /connect/register` (DCR) | 10 req/min | IP address |
 | `POST /auth/token` (ROPC grant) | 5 req/min | client_id + username + IP |

--- a/src/authserver/internal/handlers/handler_auth_otp_test.go
+++ b/src/authserver/internal/handlers/handler_auth_otp_test.go
@@ -298,6 +298,38 @@ func TestHandleAuthOtpPost(t *testing.T) {
 		authHelper.AssertExpectations(t)
 	})
 
+	// A missing auth context is what someone with an absent or expired session
+	// cookie hits, and it is the branch the OTP rate limiter now hands through to
+	// rather than answering itself (#114). It must redirect, not error.
+	t.Run("No auth context redirects to the profile URL", func(t *testing.T) {
+		previousBaseURL := config.GetAdminConsole().BaseURL
+		t.Cleanup(func() { config.GetAdminConsole().BaseURL = previousBaseURL })
+		config.GetAdminConsole().BaseURL = "https://admin.example.com"
+
+		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+		httpSession := mocks_sessionstore.NewStore(t)
+		authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+		database := mocks_data.NewDatabase(t)
+		auditLogger := mocks_audit.NewAuditLogger(t)
+
+		handler := HandleAuthOtpPost(httpHelper, httpSession, authHelper, database, auditLogger)
+
+		req, _ := http.NewRequest("POST", "/auth/otp", nil)
+		rr := httptest.NewRecorder()
+
+		authHelper.On("GetAuthContext", mock.Anything).Return(nil, customerrors.ErrNoAuthContext)
+
+		// No InternalServerError expectation is set, so the mock fails this subtest
+		// if the handler takes the other branch. Location is asserted against the
+		// literal rather than GetProfileURL(), which would move with the function it
+		// is meant to check; GetProfileURL is pinned by TestGetProfileURL.
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, "https://admin.example.com/account/profile", rr.Header().Get("Location"))
+		authHelper.AssertExpectations(t)
+	})
+
 	t.Run("Unexpected AuthState", func(t *testing.T) {
 		httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
 		httpSession := mocks_sessionstore.NewStore(t)

--- a/src/core/middleware/middleware_ratelimiter.go
+++ b/src/core/middleware/middleware_ratelimiter.go
@@ -82,7 +82,13 @@ func (m *RateLimiterMiddleware) LimitOtp(next http.Handler) http.Handler {
 
 		authContext, err := m.authHelper.GetAuthContext(r)
 		if err != nil {
-			slog.Error("Rate limiter - unable to get auth context", "error", err)
+			// No readable auth context means there is no user to key a bucket on, so hand
+			// the request to the handler, which answers a missing auth context the same way
+			// every other step of the auth flow does. It rejects the request before reaching
+			// the OTP secret or the database, so the skipped limit costs nothing. Returning
+			// here instead writes no response at all, which net/http turns into a blank 200
+			// (#114).
+			next.ServeHTTP(w, r)
 			return
 		}
 

--- a/src/core/middleware/middleware_ratelimiter_test.go
+++ b/src/core/middleware/middleware_ratelimiter_test.go
@@ -4,8 +4,29 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+
+	"github.com/leodip/goiabada/core/customerrors"
+	"github.com/leodip/goiabada/core/oauth"
 )
+
+// stubAuthHelper stands in for the real AuthHelper, which needs a session store
+// and a cookie to answer. It reads the user id from the request's query string so
+// one middleware instance can be driven with several users, which is what shows
+// the OTP budget is keyed per user rather than globally. A non-nil err is
+// returned for every request, standing for an unreadable auth context.
+type stubAuthHelper struct {
+	err error
+}
+
+func (s stubAuthHelper) GetAuthContext(r *http.Request) (*oauth.AuthContext, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	userId, _ := strconv.ParseInt(r.URL.Query().Get("userId"), 10, 64)
+	return &oauth.AuthContext{UserId: userId}, nil
+}
 
 // TestGetClientIPFromRequest verifies the rate-limit key is derived from
 // RemoteAddr only, ignoring spoofable X-Forwarded-For / X-Real-IP headers.
@@ -161,6 +182,82 @@ func TestLimitForgotPwd_PerEmailAndPerIP(t *testing.T) {
 		for i := 0; i < 40; i++ {
 			if run(m, "x@example.com", "203.0.113.1:5000") != http.StatusOK {
 				t.Fatal("disabled limiter should never block")
+			}
+		}
+	})
+}
+
+// TestLimitOtp_PerUserAndMissingAuthContext verifies the OTP limiter keys its
+// budget on the user id, and that a request whose auth context cannot be read
+// reaches the handler instead of being answered with a blank 200 (#114).
+//
+// The handler stub writes 418 rather than 200 on purpose: a middleware that
+// writes nothing produces exactly 200 with an empty body, so 418 is what tells
+// "the handler ran" apart from "nothing was written", and from 429.
+func TestLimitOtp_PerUserAndMissingAuthContext(t *testing.T) {
+	run := func(m *RateLimiterMiddleware, userId int) (int, bool) {
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/auth/otp?userId=%d", userId), nil)
+		rr := httptest.NewRecorder()
+		reached := false
+		m.LimitOtp(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reached = true
+			w.WriteHeader(http.StatusTeapot)
+		})).ServeHTTP(rr, req)
+		return rr.Code, reached
+	}
+
+	t.Run("unreadable auth context reaches the handler", func(t *testing.T) {
+		m := NewRateLimiterMiddleware(stubAuthHelper{err: customerrors.ErrNoAuthContext}, true)
+		// Well past the 10/min budget: the pass-through is deliberately not
+		// bounded by this middleware, since there is no user to key a bucket on.
+		for i := 0; i < 20; i++ {
+			code, reached := run(m, 0)
+			if code != http.StatusTeapot || !reached {
+				t.Fatalf("attempt %d: got code %d, handler reached %v; want %d and true",
+					i+1, code, reached, http.StatusTeapot)
+			}
+		}
+	})
+
+	t.Run("a readable auth context still spends the budget", func(t *testing.T) {
+		m := NewRateLimiterMiddleware(stubAuthHelper{}, true)
+		for i := 0; i < 10; i++ {
+			if code, reached := run(m, 42); code != http.StatusTeapot || !reached {
+				t.Fatalf("attempt %d: got code %d, handler reached %v; want %d and true",
+					i+1, code, reached, http.StatusTeapot)
+			}
+		}
+		if code, reached := run(m, 42); code != http.StatusTooManyRequests || reached {
+			t.Errorf("11th attempt: got code %d, handler reached %v; want %d and false",
+				code, reached, http.StatusTooManyRequests)
+		}
+	})
+
+	t.Run("each user id has its own budget", func(t *testing.T) {
+		m := NewRateLimiterMiddleware(stubAuthHelper{}, true)
+		blocked := false
+		for i := 0; i < 11; i++ {
+			if code, _ := run(m, 42); code == http.StatusTooManyRequests {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			t.Fatal("expected user 42 to be limited within 11 attempts")
+		}
+		// Same middleware instance, different user: a global key would block this.
+		if code, reached := run(m, 43); code != http.StatusTeapot || !reached {
+			t.Errorf("second user: got code %d, handler reached %v; want %d and true",
+				code, reached, http.StatusTeapot)
+		}
+	})
+
+	t.Run("disabled limiter never blocks", func(t *testing.T) {
+		m := NewRateLimiterMiddleware(stubAuthHelper{}, false)
+		for i := 0; i < 60; i++ {
+			if code, reached := run(m, 42); code != http.StatusTeapot || !reached {
+				t.Fatalf("attempt %d: disabled limiter should never block, got code %d, handler reached %v",
+					i+1, code, reached)
 			}
 		}
 	})


### PR DESCRIPTION
Closes #114.

## What this is for

When the auth server's rate limiter is enabled, `POST /auth/otp` answers a request whose auth
context cannot be read with a bare `200 OK` and an empty body. `LimitOtp` logs an error and returns
without calling the next handler, without writing a body and without setting a status, so Go's
`net/http` emits the default `200`. Measured while grounding this change: 50 of 50 such requests
produce status 200, zero-length body, no `Content-Type`, and the handler is never reached.

Nothing is bypassed by it. The next handler never runs, so no OTP is validated and no session is
issued. The harm is what the person and the operator see: a blank page instead of a way back into
the flow, and a success status on a request that failed.

## How the fix works

The branch now calls `next`, handing the request to `HandleAuthOtpPost`, which already answers a
missing auth context the way the rest of the auth flow does, with a `302` to the profile URL. So
`POST /auth/otp` stops being the one step of the flow that invents its own answer, and no
unlocalized English string enters the auth flow.

Skipping the rate limit for those requests costs nothing. The middleware and the handler call the
same `GetAuthContext` on the same `*http.Request`, and gorilla's session registry caches the
`(session, error)` pair per request and hangs the registry off the request pointer, which chi passes
through unchanged. The handler therefore cannot read an auth context the middleware could not: it
fails identically and rejects the request before reaching an OTP secret, the database or the audit
log. This is also already what the disabled configuration does, and disabled is the shipped default,
so the change makes the enabled and disabled paths agree rather than adding a state.

The middleware's `slog.Error` was removed with the branch it belonged to. The handler logs the same
event at `Warn` with the more useful detail of where it is sending the person, so keeping both
recorded one routine event twice and once at ERROR, which is the second of the two harms #114 names.

Two specifications were read rather than recalled. RFC 6749 section 4.1.2.1 and OpenID Connect Core
section 3.1.2.6 both say the server MUST NOT redirect to an invalid redirection URI; that is
satisfied either way here and cannot be violated, because the auth context is the only place the
flow holds the client's redirect URI, so once it is unreadable there is nothing to redirect to.
RFC 6749's accompanying SHOULD, that the server inform the resource owner of the error, is what a
blank `200` was failing to do.

## What landed

One stage, because the change is one branch in one function, two test seams and one documentation
table, which review, test and commit as a unit.

**Stage 1**, `88bbbb15`, "the pass-through, both seams, and the rate-limiting table":

- `LimitOtp`'s unreadable-auth-context branch calls `next.ServeHTTP(w, r)`, and its `slog.Error` is
  gone.
- `TestLimitOtp_PerUserAndMissingAuthContext` in `src/core/middleware/middleware_ratelimiter_test.go`,
  four subtests covering the pass-through, the per-user budget, budget separation between two users,
  and the disabled limiter. `AuthHelper` has one method, so the stub is three lines and no generated
  mock is involved. Test functions in that file: 3 before, 4 after.
- "No auth context redirects to the profile URL" in `TestHandleAuthOtpPost`, asserting the concrete
  `Location`. Subtests: 13 before, 14 after. The existing "Error when getting AuthContext" subtest is
  untouched and still covers the non-`ErrorDetail` case, which was the reason the redirect branch was
  uncovered: that subtest passes a plain `errors.New`, so it exercises `InternalServerError` and
  never the redirect this fix depends on.
- The rate-limiting table in `site/src/content/docs/reference/environment-variables.mdx` replaced
  with nine rows read off the limiter construction and the route wiring. It had understated the
  password limit as 10/min against the code's 15/min, omitted both per-IP buckets, omitted
  `POST /forgot-password` entirely, and listed only the GET for reset-password when `LimitResetPwd`
  guards both methods. `cd site && npm run build` green, 42 pages.

## Tests

Locally: unit green across `core`, `authserver` and `adminconsole`, 3036 pass, 0 fail, 46 packages.

Four mutations were run against the new cases and all four were caught, each credited on the failing
test's own name: removing `next.ServeHTTP` from the middleware branch, replacing the per-user limiter
key with a constant, corrupting the handler's redirect target, and inverting the `nil` check in
`customerrors.IsError`. That last one was caught by the new handler subtest and by nothing else in
three modules, so the condition had no other test pinning it.

Data and integration are not applicable here, and not merely skipped. There is no query, interface
method, migration or schema change, and `src/authserver/run-tests.sh` exports
`GOIABADA_AUTHSERVER_RATELIMITER_ENABLED=false` for the whole integration suite, so a test at
`POST /auth/otp` would exercise the disabled-limiter guard and pass with the branch still broken.

The four-engine result belongs to the check suite, which is green on `88bbbb15`:
[run 31345492342](https://github.com/leodip/goiabada/actions/runs/31345492342). All eleven jobs pass,
including `Tests / sqlite`, `Tests / mysql`, `Tests / postgres` and `Tests / mssql`, plus `Lint`,
`Vulnerabilities`, `Build validation` and `Versions`.

## Review

One round, clean, zero findings, all three axes reviewed and nothing left unchecked. Beyond reading
the diff, the reviewer reconciled all nine rate limiter constructions and the eight route
applications against the nine documentation rows, matching limit, duration, key, method and path on
each; built its own scratch overlay composing the real cookie store, auth helper, middleware and
handler across missing, corrupt, malformed and valid contexts; and ran two independent mutations of
its own, both caught.

Two of its findings-that-were-not-findings are worth recording. Its overlay confirmed that a valid
signed cookie carrying malformed auth-context JSON yields a 500 rather than the 302, which is the
`json.Unmarshal` path that is unreachable while the cookie HMAC holds. And it confirmed that a valid
user context still spends the per-user budget and gets a 429 on attempt 11 through the real chain
rather than through the test stub.

## Deviations

None. The stage matched its plan.

## Also in this thread

- [Deferred decisions](https://github.com/leodip/goiabada/pull/194#issuecomment-5234788339): none,
  with the five settled decisions and their reasoning.
- [Follow-ups](https://github.com/leodip/goiabada/pull/194#issuecomment-5234789524): one, ready to
  file, on the four rate limiters that still have no tests.
