### PR TITLE
fix(core): rotate signing keys in one transaction, refusing before anything is destroyed

### DIFF
--- a/site/src/content/docs/integration/rest-api.mdx
+++ b/site/src/content/docs/integration/rest-api.mdx
@@ -1235,6 +1235,8 @@ POST /api/v1/admin/settings/keys/rotate
 
 Rotates to a new signing key. The old key remains available for validation.
 
+Answers `409` with error code `ROTATION_IN_PROGRESS` when another rotation won the race. Do not retry: that rotation already happened, and a retry rotates a second time.
+
 ```
 DELETE /api/v1/admin/settings/keys/{id}
 ```

--- a/site/src/content/docs/integration/rest-api.mdx
+++ b/site/src/content/docs/integration/rest-api.mdx
@@ -179,6 +179,7 @@ Common `error_code` categories:
 - `INVALID_REQUEST_BODY` - Malformed JSON in request
 - `VALIDATION_ERROR` - Input validation failed
 - `NOT_FOUND` - Resource not found
+- `FORBIDDEN` - The token is valid but the resource belongs to another user
 - `TOO_MANY_REQUESTS` - Rate limit reached; the response carries a `Retry-After` header
 - `INTERNAL_SERVER_ERROR` - Server-side error
 
@@ -274,6 +275,8 @@ POST /api/v1/admin/users/create
 | <span style="white-space: nowrap;">`familyName`</span> | string | No | Last name |
 | <span style="white-space: nowrap;">`setPasswordType`</span> | string | No | `"now"` to set password immediately, `"email"` to send setup email |
 | <span style="white-space: nowrap;">`password`</span> | string | Conditional | Required if `setPasswordType` is `"now"` |
+
+Answers `409` with error code `EMAIL_ALREADY_EXISTS` when the address is already registered. Retrying the same address will not succeed.
 
 #### Update user profile
 

--- a/src/adminconsole/go.mod
+++ b/src/adminconsole/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/sym01/htmlsanitizer v1.1.1 // indirect
 	github.com/toorop/go-dkim v0.0.0-20250226130143-9025cce95817 // indirect
 	github.com/xhit/go-simple-mail/v2 v2.16.0 // indirect

--- a/src/adminconsole/internal/handlers/adminsettingshandlers/handler_admin_settings_keys.go
+++ b/src/adminconsole/internal/handlers/adminsettingshandlers/handler_admin_settings_keys.go
@@ -99,7 +99,12 @@ func HandleAdminSettingsKeysRotatePost(
 		}
 
 		if err := apiClient.RotateSettingsKeys(jwtInfo.TokenResponse.AccessToken); err != nil {
-			httpHelper.JsonError(w, r, err)
+			// Not JsonError directly: the API answers 409 when another rotation won the race,
+			// and JsonError's generic branch would show the administrator "An unexpected
+			// server error has occurred" with a request id, for something neither unexpected
+			// nor a server error. HandleAPIErrorJson forwards the API's description instead,
+			// so the modal reads "Another key rotation is in progress" (#251).
+			handlers.HandleAPIErrorJson(httpHelper, w, r, err)
 			return
 		}
 

--- a/src/adminconsole/internal/handlers/adminsettingshandlers/handler_admin_settings_keys_test.go
+++ b/src/adminconsole/internal/handlers/adminsettingshandlers/handler_admin_settings_keys_test.go
@@ -1,0 +1,147 @@
+package adminsettingshandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leodip/goiabada/adminconsole/internal/apiclient"
+	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/handlerhelpers"
+	"github.com/leodip/goiabada/core/oauth"
+)
+
+// stubApiClient embeds apiclient.ApiClient so its hundred-odd other methods come for free
+// and any of them that a test does not stub panics on a nil interface, which is the right
+// outcome for a call the test did not expect. There is no generated mock: adminconsole has
+// no .mockery.yaml. Same shape as adminclienthandlers' stub, for the same reason.
+type stubApiClient struct {
+	apiclient.ApiClient
+	rotateErr error
+}
+
+func (s *stubApiClient) RotateSettingsKeys(accessToken string) error {
+	return s.rotateErr
+}
+
+// TestHandleAdminSettingsKeysRotatePost_APIErrorReachesTheBrowser owns the wiring between
+// the rotate handler and HandleAPIErrorJson. The helper's own forwarding is pinned next
+// door in api_error_helper_test.go, but that test cannot see which of the two error paths
+// this handler calls: swapping HandleAPIErrorJson back to a direct JsonError leaves the
+// helper's tests and the whole admin console suite green while putting the 409 back behind
+// "An unexpected server error has occurred" and a request id.
+//
+// That sentence is the entire point of the change. The auth server answers 409
+// ROTATION_IN_PROGRESS when another rotation won the race, which is a fact about the
+// administrator's own request and something they can act on, and the modal that
+// sendAjaxRequest opens shows error_description verbatim (#251).
+//
+// The rows for the other statuses are what keeps the forwarding narrow: a genuine server
+// fault must stay a generic 500 with its detail in the log rather than on the screen.
+func TestHandleAdminSettingsKeysRotatePost_APIErrorReachesTheBrowser(t *testing.T) {
+
+	const refusal = "Another key rotation is in progress"
+
+	const generic = "An unexpected server error has occurred"
+
+	testCases := []struct {
+		name            string
+		apiErr          error
+		wantStatus      int
+		wantError       string
+		wantDescription string
+	}{
+		{
+			name:            "a 409 is forwarded with its status and description",
+			apiErr:          &apiclient.APIError{Code: "ROTATION_IN_PROGRESS", Message: refusal, StatusCode: http.StatusConflict},
+			wantStatus:      http.StatusConflict,
+			wantError:       "ROTATION_IN_PROGRESS",
+			wantDescription: refusal,
+		},
+		{
+			name:            "a 400 is forwarded too, which is what #122 established",
+			apiErr:          &apiclient.APIError{Code: "VALIDATION_ERROR", Message: "bad request", StatusCode: http.StatusBadRequest},
+			wantStatus:      http.StatusBadRequest,
+			wantError:       "VALIDATION_ERROR",
+			wantDescription: "bad request",
+		},
+		{
+			name:            "an incomplete key set stays generic, since 500 is not the administrator's mistake",
+			apiErr:          &apiclient.APIError{Code: "KEY_SET_INCOMPLETE", Message: "Expected current and next keys to exist", StatusCode: http.StatusInternalServerError},
+			wantStatus:      http.StatusInternalServerError,
+			wantError:       "server_error",
+			wantDescription: generic,
+		},
+		{
+			name:            "a transport error stays generic",
+			apiErr:          errors.New("connection refused"),
+			wantStatus:      http.StatusInternalServerError,
+			wantError:       "server_error",
+			wantDescription: generic,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// templateFS is nil because JsonError renders no template. This is the real
+			// helper rather than a mock so the assertions below are on the bytes the
+			// browser receives.
+			httpHelper := handlerhelpers.NewHttpHelper(nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/settings/keys/rotate", nil)
+			req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeyJwtInfo,
+				oauth.JwtInfo{TokenResponse: oauth.TokenResponse{AccessToken: "an-access-token"}}))
+
+			rec := httptest.NewRecorder()
+
+			handler := HandleAdminSettingsKeysRotatePost(httpHelper, &stubApiClient{rotateErr: tc.apiErr})
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code)
+
+			var response map[string]string
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.wantError, response["error"])
+			assert.Contains(t, response["error_description"], tc.wantDescription)
+
+			if tc.wantStatus == http.StatusInternalServerError {
+				// The generic branch must not leak the API's message either: that is
+				// what sends it to the log rather than the screen.
+				assert.NotContains(t, response["error_description"], tc.apiErr.Error())
+			}
+		})
+	}
+}
+
+// TestHandleAdminSettingsKeysRotatePost_SuccessIsUnchanged is here so that routing the
+// failure path through a different helper cannot alter what a successful rotation answers.
+func TestHandleAdminSettingsKeysRotatePost_SuccessIsUnchanged(t *testing.T) {
+
+	httpHelper := handlerhelpers.NewHttpHelper(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/settings/keys/rotate", nil)
+	req = req.WithContext(context.WithValue(req.Context(), constants.ContextKeyJwtInfo,
+		oauth.JwtInfo{TokenResponse: oauth.TokenResponse{AccessToken: "an-access-token"}}))
+
+	rec := httptest.NewRecorder()
+
+	handler := HandleAdminSettingsKeysRotatePost(httpHelper, &stubApiClient{rotateErr: nil})
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response struct {
+		Success bool
+	}
+	err := json.Unmarshal(rec.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.True(t, response.Success)
+}

--- a/src/adminconsole/internal/handlers/api_error_helper.go
+++ b/src/adminconsole/internal/handlers/api_error_helper.go
@@ -40,9 +40,11 @@ func HandleAPIErrorWithCallback(httpHelper HttpHelper, w http.ResponseWriter, r 
 //
 // Routes on HTTP status the same way: 400 Bad Request from the auth server API is a
 // user-correctable validation failure, so its status and English description are forwarded
-// to the browser. Anything else, including an error that is not an *apiclient.APIError,
-// falls through to JsonError's other branch: HTTP 500, the detail in the server log, and a
-// request id on screen.
+// to the browser. 409 Conflict is forwarded for the same reason: it says another operation
+// won a race, which is a fact about the administrator's own request rather than a server
+// fault, and it names an action they should not repeat. Anything else, including an error
+// that is not an *apiclient.APIError, falls through to JsonError's other branch: HTTP 500,
+// the detail in the server log, and a request id on screen.
 //
 // This exists because JsonError preserves a status and a description only for
 // *customerrors.ErrorDetail. An *apiclient.APIError handed to it directly takes the generic
@@ -55,7 +57,8 @@ func HandleAPIErrorWithCallback(httpHelper HttpHelper, w http.ResponseWriter, r 
 // escaping is load-bearing rather than defensive, because showModalDialog assigns the
 // description to innerHTML.
 func HandleAPIErrorJson(httpHelper HttpHelper, w http.ResponseWriter, r *http.Request, err error) {
-	if apiErr, ok := err.(*apiclient.APIError); ok && apiErr.StatusCode == http.StatusBadRequest {
+	if apiErr, ok := err.(*apiclient.APIError); ok &&
+		(apiErr.StatusCode == http.StatusBadRequest || apiErr.StatusCode == http.StatusConflict) {
 		httpHelper.JsonError(w, r, customerrors.NewErrorDetailWithHttpStatusCode(
 			apiErr.Code, apiErr.Message, apiErr.StatusCode))
 		return

--- a/src/adminconsole/internal/handlers/api_error_helper_test.go
+++ b/src/adminconsole/internal/handlers/api_error_helper_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/leodip/goiabada/adminconsole/internal/apiclient"
+	"github.com/leodip/goiabada/core/customerrors"
+	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// This is the first behavioural test in this package: the three files here today are two lint tests
+// and TestMain.
+//
+// It owns what HandleAPIErrorJson forwards, which is the only observable half of #251's admin
+// console change. The modal itself is sendAjaxRequest in utils.js, unchanged, and no test in this
+// repository drives a browser, so this is where "the administrator reads the API's sentence rather
+// than a request id" is pinned. The distinction it tests is invisible at runtime unless you read the
+// screen: both branches call JsonError, and only the argument differs.
+//
+// mocks_handlerhelpers.HttpHelper is the core module's mock. Its method set is a superset of this
+// package's HttpHelper interface, so it satisfies it without a hand-written stub.
+
+// captureJsonError registers JsonError and returns a pointer to the error it was handed.
+func captureJsonError(httpHelper *mocks_handlerhelpers.HttpHelper) *error {
+	var captured error
+	httpHelper.On("JsonError", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured, _ = args.Get(2).(error)
+		}).Return().Once()
+	return &captured
+}
+
+// TestHandleAPIErrorJson_ForwardsConflict is #251's case. A 409 from the auth server API says
+// another rotation won the race, which is a fact about the administrator's own request, so its code,
+// description and status reach the browser instead of "An unexpected server error has occurred".
+func TestHandleAPIErrorJson_ForwardsConflict(t *testing.T) {
+	httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+	captured := captureJsonError(httpHelper)
+
+	HandleAPIErrorJson(httpHelper, httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/admin/settings/keys/rotate", nil),
+		&apiclient.APIError{
+			Code:       "ROTATION_IN_PROGRESS",
+			Message:    "Another key rotation is in progress",
+			StatusCode: http.StatusConflict,
+		})
+
+	detail, ok := (*captured).(*customerrors.ErrorDetail)
+	require.True(t, ok, "expected an *customerrors.ErrorDetail, got %T", *captured)
+	assert.Equal(t, "ROTATION_IN_PROGRESS", detail.GetCode())
+	assert.Equal(t, "Another key rotation is in progress", detail.GetDescription())
+	assert.Equal(t, http.StatusConflict, detail.GetHttpStatusCode())
+}
+
+// TestHandleAPIErrorJson_ForwardsBadRequest pins the behaviour #122 established. It is here so that
+// adding 409 to the condition cannot quietly replace 400 rather than join it.
+func TestHandleAPIErrorJson_ForwardsBadRequest(t *testing.T) {
+	httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+	captured := captureJsonError(httpHelper)
+
+	HandleAPIErrorJson(httpHelper, httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/admin/clients/1/redirect-uris", nil),
+		&apiclient.APIError{
+			Code:       "VALIDATION_ERROR",
+			Message:    "Invalid redirect URI",
+			StatusCode: http.StatusBadRequest,
+		})
+
+	detail, ok := (*captured).(*customerrors.ErrorDetail)
+	require.True(t, ok, "expected an *customerrors.ErrorDetail, got %T", *captured)
+	assert.Equal(t, "VALIDATION_ERROR", detail.GetCode())
+	assert.Equal(t, "Invalid redirect URI", detail.GetDescription())
+	assert.Equal(t, http.StatusBadRequest, detail.GetHttpStatusCode())
+}
+
+// TestHandleAPIErrorJson_GenericBranchForOtherStatuses is the other side of the boundary. A 500 from
+// the API is a server fault, so it keeps going to the log with a request id on screen rather than
+// having its English text shown to an administrator who can do nothing with it.
+func TestHandleAPIErrorJson_GenericBranchForOtherStatuses(t *testing.T) {
+	httpHelper := mocks_handlerhelpers.NewHttpHelper(t)
+	captured := captureJsonError(httpHelper)
+
+	apiErr := &apiclient.APIError{
+		Code:       "INTERNAL_ERROR",
+		Message:    "Failed to rotate signing keys",
+		StatusCode: http.StatusInternalServerError,
+	}
+	HandleAPIErrorJson(httpHelper, httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/admin/settings/keys/rotate", nil), apiErr)
+
+	assert.Same(t, apiErr, *captured,
+		"a status outside the forwarded set must reach JsonError unwrapped, for its generic branch")
+}

--- a/src/authserver/go.mod
+++ b/src/authserver/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/leodip/goiabada/core => ../core
@@ -66,7 +67,6 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.75.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.12.0 // indirect

--- a/src/authserver/internal/handlers/apihandlers/handler_api_settings_keys.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_settings_keys.go
@@ -1,24 +1,20 @@
 package apihandlers
 
 import (
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"encoding/pem"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/authserver/internal/handlers"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
-	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
-	"github.com/leodip/goiabada/core/models"
-	"github.com/leodip/goiabada/core/rsautil"
+	"github.com/leodip/goiabada/core/oauth"
+	"github.com/pkg/errors"
 )
 
 // HandleAPISettingsKeysGet - GET /api/v1/admin/settings/keys
@@ -82,115 +78,50 @@ func HandleAPISettingsKeysGet(
 }
 
 // HandleAPISettingsKeysRotatePost - POST /api/v1/admin/settings/keys/rotate
+//
+// The transition itself lives in oauth.SigningKeyRotator, which takes it as one transaction.
+// This used to be five unsynchronised writes here, and the delete of the previous key ran
+// before the check that a next key even existed, so a rotation that was about to be refused
+// had already destroyed the key still signing live tokens (#251).
 func HandleAPISettingsKeysRotatePost(
 	authHelper handlers.AuthHelper,
 	database data.Database,
 	auditLogger handlers.AuditLogger,
 ) http.HandlerFunc {
+
+	rotator := oauth.NewSigningKeyRotator(database)
+
 	return func(w http.ResponseWriter, r *http.Request) {
-		allSigningKeys, err := database.GetAllSigningKeys(nil)
-		if err != nil {
-			writeJSONError(w, "Failed to get signing keys", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
+		err := rotator.Rotate()
 
-		var currentKey *models.KeyPair
-		var nextKey *models.KeyPair
-		var previousKey *models.KeyPair
-		for i := range allSigningKeys {
-			kp := &allSigningKeys[i]
-			keyState, err := enums.KeyStateFromString(kp.State)
-			if err != nil {
-				writeJSONError(w, "Invalid key state", "INTERNAL_ERROR", http.StatusInternalServerError)
-				return
-			}
-			switch keyState {
-			case enums.KeyStateCurrent:
-				currentKey = kp
-			case enums.KeyStateNext:
-				nextKey = kp
-			case enums.KeyStatePrevious:
-				previousKey = kp
-			}
-		}
+		switch {
+		case err == nil:
+			// Audited here and only here, so the log carries exactly one entry per rotation
+			// that actually happened.
+			auditLogger.Log(constants.AuditRotatedKeys, map[string]interface{}{
+				"loggedInUser": authHelper.GetLoggedInSubject(r),
+			})
 
-		// Delete existing previous key, if any
-		if previousKey != nil {
-			if err := database.DeleteKeyPair(nil, previousKey.Id); err != nil {
-				writeJSONError(w, "Failed to delete previous key", "INTERNAL_ERROR", http.StatusInternalServerError)
-				return
-			}
-		}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
 
-		if currentKey == nil || nextKey == nil {
-			writeJSONError(w, "Expected current and next keys to exist", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
+		case errors.Is(err, oauth.ErrRotationInProgress):
+			// 409 rather than 200: this call rotated nothing. Reporting success would have the
+			// admin console announce one rotation twice, and would invite a caller to believe
+			// it holds a key it never created. Retrying is wrong for the same reason, which is
+			// what the REST API page now says.
+			writeJSONError(w, "Another key rotation is in progress", "ROTATION_IN_PROGRESS",
+				http.StatusConflict)
 
-		// current -> previous
-		currentKey.State = enums.KeyStatePrevious.String()
-		if err := database.UpdateKeyPair(nil, currentKey); err != nil {
-			writeJSONError(w, "Failed to update current key", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
+		case errors.Is(err, oauth.ErrKeySetIncomplete):
+			writeJSONError(w, "Expected current and next keys to exist", "KEY_SET_INCOMPLETE",
+				http.StatusInternalServerError)
 
-		// next -> current
-		nextKey.State = enums.KeyStateCurrent.String()
-		if err := database.UpdateKeyPair(nil, nextKey); err != nil {
-			writeJSONError(w, "Failed to update next key", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
+		default:
+			writeJSONError(w, "Failed to rotate signing keys", "INTERNAL_ERROR",
+				http.StatusInternalServerError)
 		}
-
-		// create new next key (RSA 4096, RS256), same as today
-		privateKey, err := rsautil.GeneratePrivateKey(4096)
-		if err != nil {
-			writeJSONError(w, "Unable to generate a private key", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
-		privateKeyPEM := rsautil.EncodePrivateKeyToPEM(privateKey)
-		// Encrypt the private key at rest (issue #83) before storing it.
-		privateKeyPEMEncrypted, err := encryption.EncryptData(string(privateKeyPEM))
-		if err != nil {
-			writeJSONError(w, "Failed to encrypt private key", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
-
-		publicKeyASN1Der, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-		if err != nil {
-			writeJSONError(w, "Unable to marshal public key to PKIX", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
-		publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: publicKeyASN1Der})
-
-		kid := uuid.New().String()
-		publicKeyJWK, err := rsautil.MarshalRSAPublicKeyToJWK(&privateKey.PublicKey, kid)
-		if err != nil {
-			writeJSONError(w, "Failed to marshal JWK", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
-
-		keyPair := &models.KeyPair{
-			State:             enums.KeyStateNext.String(),
-			KeyIdentifier:     kid,
-			Type:              "RSA",
-			Algorithm:         "RS256",
-			PrivateKeyPEM:     privateKeyPEMEncrypted,
-			PublicKeyPEM:      publicKeyPEM,
-			PublicKeyASN1_DER: publicKeyASN1Der,
-			PublicKeyJWK:      publicKeyJWK,
-		}
-		if err := database.CreateKeyPair(nil, keyPair); err != nil {
-			writeJSONError(w, "Failed to create new key", "INTERNAL_ERROR", http.StatusInternalServerError)
-			return
-		}
-
-		auditLogger.Log(constants.AuditRotatedKeys, map[string]interface{}{
-			"loggedInUser": authHelper.GetLoggedInSubject(r),
-		})
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
 	}
 }
 

--- a/src/authserver/internal/handlers/apihandlers/handler_api_settings_keys_test.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_settings_keys_test.go
@@ -1,0 +1,175 @@
+package apihandlers
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
+	"github.com/leodip/goiabada/core/constants"
+	mocks_data "github.com/leodip/goiabada/core/data/mocks"
+	"github.com/leodip/goiabada/core/enums"
+	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// This file did not exist before #251 stage 3, and section 1 of the agreement recorded its absence:
+// the rotate endpoint had no unit coverage at all, which is how five unsynchronised writes survived
+// since v0.7.
+//
+// What it owns is the mapping from oauth.SigningKeyRotator's outcomes to a status, an error code and
+// an audit entry. Deliberately nothing about storage: the rotator's own tests own what reaches the
+// key_pairs table, and asserting rows from here would be a side channel that passes with the mapping
+// broken.
+//
+// Every case drives the REAL rotator over a mocked Database, because the handler constructs it and
+// the agreement kept the (authHelper, database, auditLogger) signature so routes.go stays untouched.
+// That costs one real 4096-bit key generation per case, about 300ms, since the rotator generates the
+// replacement before opening the transaction and so on every path including the refusals.
+
+// rotateTx is an opaque non-nil transaction. Letting BeginTransaction return nil would exercise a
+// shape production never runs.
+var rotateTx = &sql.Tx{}
+
+// signingKey builds a key_pairs row in the given state. Only Id and State matter here: nothing in
+// this file reads key material.
+func signingKey(id int64, state enums.KeyState) models.KeyPair {
+	return models.KeyPair{Id: id, State: state.String(), Type: "RSA", Algorithm: "RS256"}
+}
+
+// stubRotateRead registers the transaction open, the classify read and the rollback the rotator
+// always defers. The rollback is registered for every case, including the successful one, because
+// the deferred call runs after the commit and the mock would otherwise fail the test.
+func stubRotateRead(database *mocks_data.Database, keys []models.KeyPair) {
+	database.On("BeginTransaction").Return(rotateTx, nil).Once()
+	database.On("GetAllSigningKeys", rotateTx).Return(keys, nil).Once()
+	database.On("RollbackTransaction", rotateTx).Return(nil).Once()
+}
+
+func rotateRequest() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/api/v1/admin/settings/keys/rotate", nil)
+}
+
+// TestHandleAPISettingsKeysRotatePost_Success is the wiring test: the whole transition runs and the
+// audit entry is written once. It also pins that the audit happens only after a commit, which is the
+// property the three refusal cases below assert the other half of.
+func TestHandleAPISettingsKeysRotatePost_Success(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	const subject = "the-admin"
+
+	stubRotateRead(database, []models.KeyPair{
+		signingKey(1, enums.KeyStatePrevious),
+		signingKey(2, enums.KeyStateCurrent),
+		signingKey(3, enums.KeyStateNext),
+	})
+	database.On("DeleteKeyPair", rotateTx, int64(1)).Return(nil).Once()
+	database.On("UpdateKeyPairState", rotateTx, int64(2),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).Return(true, nil).Once()
+	database.On("UpdateKeyPairState", rotateTx, int64(3),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).Return(true, nil).Once()
+	database.On("CreateKeyPair", rotateTx, mock.MatchedBy(func(kp *models.KeyPair) bool {
+		return kp.State == enums.KeyStateNext.String()
+	})).Return(nil).Once()
+	database.On("CommitTransaction", rotateTx).Return(nil).Once()
+
+	authHelper.On("GetLoggedInSubject", mock.Anything).Return(subject)
+	var payload map[string]interface{}
+	auditLogger.On("Log", constants.AuditRotatedKeys, mock.Anything).
+		Run(func(args mock.Arguments) {
+			payload = args.Get(1).(map[string]interface{})
+		}).Return().Once()
+
+	rr := httptest.NewRecorder()
+	HandleAPISettingsKeysRotatePost(authHelper, database, auditLogger).ServeHTTP(rr, rotateRequest())
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `{"success":true}`, rr.Body.String())
+	require.NotNil(t, payload)
+	assert.Equal(t, subject, payload["loggedInUser"])
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+}
+
+// TestHandleAPISettingsKeysRotatePost_RotationInProgress covers the loser of a race. 409 rather than
+// 200 because this call rotated nothing, and no audit entry because the log must carry exactly one
+// entry per rotation that happened.
+func TestHandleAPISettingsKeysRotatePost_RotationInProgress(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	stubRotateRead(database, []models.KeyPair{
+		signingKey(2, enums.KeyStateCurrent),
+		signingKey(3, enums.KeyStateNext),
+	})
+	// The compare-and-set transitions no row: another rotation already moved this key.
+	database.On("UpdateKeyPairState", rotateTx, int64(2),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).Return(false, nil).Once()
+
+	rr := httptest.NewRecorder()
+	HandleAPISettingsKeysRotatePost(authHelper, database, auditLogger).ServeHTTP(rr, rotateRequest())
+
+	assert.Equal(t, http.StatusConflict, rr.Code)
+	body := decodeErrorBody(t, rr)
+	assert.Equal(t, "ROTATION_IN_PROGRESS", body.ErrorCode)
+	assert.Equal(t, "Another key rotation is in progress", body.ErrorDescription)
+	// No CommitTransaction and no CreateKeyPair were registered, so the mock fails the test if the
+	// handler committed anything. auditLogger has no expectation at all, which NewAuditLogger's
+	// cleanup turns into a failure on any Log call.
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+}
+
+// TestHandleAPISettingsKeysRotatePost_KeySetIncomplete is the defect the issue opens with: a
+// deployment with no next key. No DeleteKeyPair expectation is registered, so the mock fails the
+// test if the handler destroys the previous key on its way to refusing, which is exactly what the
+// old handler did.
+func TestHandleAPISettingsKeysRotatePost_KeySetIncomplete(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	stubRotateRead(database, []models.KeyPair{
+		signingKey(1, enums.KeyStatePrevious),
+		signingKey(2, enums.KeyStateCurrent),
+	})
+
+	rr := httptest.NewRecorder()
+	HandleAPISettingsKeysRotatePost(authHelper, database, auditLogger).ServeHTTP(rr, rotateRequest())
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	body := decodeErrorBody(t, rr)
+	assert.Equal(t, "KEY_SET_INCOMPLETE", body.ErrorCode)
+	assert.Equal(t, "Expected current and next keys to exist", body.ErrorDescription)
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+}
+
+// TestHandleAPISettingsKeysRotatePost_InternalError covers everything that is neither sentinel: an
+// engine failure keeps the generic code, so a caller cannot mistake a broken database for a lost
+// race and retry into it.
+func TestHandleAPISettingsKeysRotatePost_InternalError(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	auditLogger := mocks_audit.NewAuditLogger(t)
+	authHelper := mocks_handlerhelpers.NewAuthHelper(t)
+
+	database.On("BeginTransaction").Return(rotateTx, nil).Once()
+	database.On("GetAllSigningKeys", rotateTx).
+		Return([]models.KeyPair(nil), assert.AnError).Once()
+	database.On("RollbackTransaction", rotateTx).Return(nil).Once()
+
+	rr := httptest.NewRecorder()
+	HandleAPISettingsKeysRotatePost(authHelper, database, auditLogger).ServeHTTP(rr, rotateRequest())
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "INTERNAL_ERROR", decodeErrorBody(t, rr).ErrorCode)
+	database.AssertExpectations(t)
+	auditLogger.AssertExpectations(t)
+}

--- a/src/authserver/internal/server/openapi_contract_lint_test.go
+++ b/src/authserver/internal/server/openapi_contract_lint_test.go
@@ -1,0 +1,660 @@
+package server
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/leodip/goiabada/authserver/web"
+	"gopkg.in/yaml.v3"
+)
+
+// The tests in this file hold web/openapi.yaml to what routes.go and the handlers actually
+// do. That file is embedded by web/embed_fs.go and served at GET /openapi.yaml, so
+// it is not a README: it is the contract a caller generates a client from, and a status a
+// handler can return but the spec does not declare reaches that client as an unmodelled
+// error rather than as the failure it is.
+//
+// Nothing enforced the two agreeing before this, and they had drifted a long way: the
+// duplicate-email 409 on createUser was undeclared, so were the two ownership 403s, so was
+// every 500, and deleteSettingsKey declared a 404 its handler cannot produce. Every one of
+// those is a branch a generated client either lacks or carries for nothing.
+//
+// The instrument is lexical, which is what it can be without executing the server, and the
+// honest consequence is stated here rather than discovered later. It reads the statuses a
+// handler *mentions*, not the ones it can be driven to return, so an unreachable branch is
+// still documented (the conservative direction: a caller told about a failure that cannot
+// happen loses nothing) and a status produced by a value computed at run time would be
+// missed. No handler in this module does the latter today: writeJSONError is always called
+// with an http.Status constant, which TestAPIHandlers_WriteStatusesAsConstants below is
+// what keeps true.
+//
+// What it does not check: response bodies, schemas, parameters, or whether an operation's
+// description is true. Those stay hand-maintained.
+
+// httpStatusConstants is the net/http spelling of every status this module may name. An
+// unknown one fails the scan rather than being skipped, because silently ignoring a status
+// nobody taught this file about is exactly the drift it exists to stop.
+var httpStatusConstants = map[string]int{
+	"StatusOK":                    200,
+	"StatusCreated":               201,
+	"StatusAccepted":              202,
+	"StatusNoContent":             204,
+	"StatusMovedPermanently":      301,
+	"StatusFound":                 302,
+	"StatusSeeOther":              303,
+	"StatusNotModified":           304,
+	"StatusTemporaryRedirect":     307,
+	"StatusPermanentRedirect":     308,
+	"StatusBadRequest":            400,
+	"StatusUnauthorized":          401,
+	"StatusForbidden":             403,
+	"StatusNotFound":              404,
+	"StatusMethodNotAllowed":      405,
+	"StatusConflict":              409,
+	"StatusGone":                  410,
+	"StatusRequestEntityTooLarge": 413,
+	"StatusUnsupportedMediaType":  415,
+	"StatusUnprocessableEntity":   422,
+	"StatusTooManyRequests":       429,
+	"StatusInternalServerError":   500,
+	"StatusNotImplemented":        501,
+	"StatusBadGateway":            502,
+	"StatusServiceUnavailable":    503,
+}
+
+// routeRegistration is one line of routes.go: what a caller reaches, where it lands, and
+// whether a rate limiter sits in front of it.
+type routeRegistration struct {
+	method      string // lower case, as the spec spells it
+	path        string // as written, with routes.go's own parameter names
+	key         string // method + path with parameter names erased, the join key with the spec
+	handler     string
+	rateLimited bool
+	line        int
+}
+
+// pathParam erases the name of a path parameter. routes.go and the spec disagree on several
+// of them (routes.go says /user-sessions/{id} where the spec says {sessionIdentifier}), and
+// that disagreement is invisible on the wire: an OpenAPI path template's parameter names are
+// local to the document. Joining on the erased form matches the two by the URL a caller
+// actually sends.
+var pathParam = regexp.MustCompile(`\{[^}]*\}`)
+
+func routeKey(method, path string) string {
+	return method + " " + pathParam.ReplaceAllString(path, "{}")
+}
+
+// knownUndocumentedRoutes are the API routes web/openapi.yaml does not describe at all.
+// Documenting them means writing full operations, several needing request and response
+// schemas that do not exist yet (the profile picture endpoints carry image bytes, the audit
+// log ones a query surface), which is a larger piece of work than reconciling the statuses
+// of the operations that are already there.
+//
+// The list is exact in both directions. A new API route that is not documented fails
+// TestOpenAPI_DescribesEveryAPIRoute unless it is added here deliberately, and an entry that
+// stops being a gap fails it too, so documenting one of these forces the line to go.
+var knownUndocumentedRoutes = map[string]string{
+	"get /api/v1/admin/users/{}/profile-picture":    "image bytes, no schema in the spec yet",
+	"post /api/v1/admin/users/{}/profile-picture":   "multipart upload, no schema in the spec yet",
+	"delete /api/v1/admin/users/{}/profile-picture": "paired with the two above",
+	"get /api/v1/account/profile-picture":           "image bytes, no schema in the spec yet",
+	"post /api/v1/account/profile-picture":          "multipart upload, no schema in the spec yet",
+	"delete /api/v1/account/profile-picture":        "paired with the two above",
+	"get /api/v1/admin/groups/search":               "search response schema not in the spec yet",
+	"get /api/v1/admin/clients/{}/sessions":         "session list schema not in the spec yet",
+	"get /api/v1/admin/audit-logs":                  "audit log query surface not in the spec yet",
+	"get /api/v1/admin/settings/audit-logs":         "audit log settings not in the spec yet",
+	"put /api/v1/admin/settings/audit-logs":         "audit log settings not in the spec yet",
+}
+
+// TestOpenAPI_DeclaresEveryStatusTheHandlersEmit is the forward direction: a status a
+// handler can write must appear in the spec. This is the one that matters to a caller,
+// because the statuses it catches are the ones a generated client has no branch for.
+func TestOpenAPI_DeclaresEveryStatusTheHandlersEmit(t *testing.T) {
+	routes := parseRoutes(t)
+	statuses := parseHandlerStatuses(t)
+	spec := parseSpec(t)
+
+	for _, r := range routes {
+		op, documented := spec[r.key]
+		if !documented {
+			continue // TestOpenAPI_DescribesEveryAPIRoute owns this case
+		}
+		emitted, known := statuses[r.handler]
+		if !known {
+			t.Errorf("routes.go:%d: %s %s lands in %s, which no non-test source under "+
+				"internal/handlers declares", r.line, strings.ToUpper(r.method), r.path, r.handler)
+			continue
+		}
+		for _, code := range sortedCodes(emitted) {
+			if op.responses[code] {
+				continue
+			}
+			t.Errorf("%s (%s %s) can answer %d, which openapi.yaml does not declare: a "+
+				"generated client has no branch for it. Handler: %s",
+				op.operationId, strings.ToUpper(r.method), r.path, code, r.handler)
+		}
+	}
+}
+
+// TestOpenAPI_DeclaresNoStatusTheHandlersCannotEmit is the reverse: a documented failure
+// must be one the handler can actually produce, so the spec does not send a caller off
+// writing a branch that never runs. Two operations declared a 404 for exactly that reason.
+// deleteSettingsKey answers 400 for an id that matches no key, and getResourcePermissions
+// never looks its resource up at all, so an unknown id comes back as an empty list.
+//
+// Only failures are checked, because a success status can be implicit: a handler that calls
+// httpHelper.EncodeJson and never touches WriteHeader answers 200 without naming it, so
+// absence from the source would not be absence from the wire.
+//
+// Two failures are exempt, both because something other than the handler writes them, and
+// neither is merely waved through. 401 comes from the bearer-token middleware, which sits on
+// every API route. 429 comes from the rate limiter, which sits on three, and that one is
+// checked in both directions below: declared only where a limiter is in front, and required
+// wherever one is.
+func TestOpenAPI_DeclaresNoStatusTheHandlersCannotEmit(t *testing.T) {
+	routes := parseRoutes(t)
+	statuses := parseHandlerStatuses(t)
+	spec := parseSpec(t)
+
+	for _, r := range routes {
+		op, documented := spec[r.key]
+		if !documented {
+			continue
+		}
+		emitted := statuses[r.handler]
+		for _, code := range sortedCodes(op.responses) {
+			if code < 400 || emitted[code] {
+				continue
+			}
+			if code == 401 {
+				continue // the bearer-token middleware, not the handler
+			}
+			if code == 429 {
+				if !r.rateLimited {
+					t.Errorf("%s (%s %s) declares 429, but routes.go:%d puts no rate "+
+						"limiter in front of it", op.operationId, strings.ToUpper(r.method),
+						r.path, r.line)
+				}
+				continue
+			}
+			t.Errorf("%s (%s %s) declares %d, which %s never writes: the spec is promising "+
+				"a failure that cannot arrive", op.operationId, strings.ToUpper(r.method),
+				r.path, code, r.handler)
+		}
+	}
+
+	// The pair of the 429 rule above. A rate limiter in front of a route that does not
+	// declare 429 is the same defect in the other direction: the caller is not told to
+	// expect it, and a Retry-After it does not read is the whole point of the status.
+	for _, r := range routes {
+		op, documented := spec[r.key]
+		if !documented || !r.rateLimited {
+			continue
+		}
+		if !op.responses[429] {
+			t.Errorf("%s (%s %s) is rate limited at routes.go:%d but does not declare 429",
+				op.operationId, strings.ToUpper(r.method), r.path, r.line)
+		}
+	}
+}
+
+// TestOpenAPI_DescribesEveryAPIRoute keeps the two surfaces the same size. Every route under
+// /api/v1 is either in the spec or named in knownUndocumentedRoutes with a reason, and the
+// spec describes no operation that no longer exists.
+func TestOpenAPI_DescribesEveryAPIRoute(t *testing.T) {
+	routes := parseRoutes(t)
+	spec := parseSpec(t)
+
+	routed := map[string]bool{}
+	for _, r := range routes {
+		routed[r.key] = true
+		if !strings.HasPrefix(r.path, "/api/v1/") {
+			continue
+		}
+		_, documented := spec[r.key]
+		_, allowed := knownUndocumentedRoutes[r.key]
+		switch {
+		case documented && allowed:
+			t.Errorf("%s %s is documented now, so its knownUndocumentedRoutes entry %q is "+
+				"stale and must go", strings.ToUpper(r.method), r.path, r.key)
+		case !documented && !allowed:
+			t.Errorf("routes.go:%d: %s %s is not in openapi.yaml. Document it, or add it to "+
+				"knownUndocumentedRoutes with the reason it cannot be documented yet",
+				r.line, strings.ToUpper(r.method), r.path)
+		}
+	}
+
+	for key, op := range spec {
+		if !routed[key] {
+			t.Errorf("openapi.yaml describes %s (%s), which routes.go does not register",
+				op.operationId, key)
+		}
+	}
+}
+
+// TestAPIHandlers_WriteStatusesAsConstants is what lets the three tests above be lexical.
+// Every writeJSONError call passes an http.Status constant, so reading the constants out of
+// a handler reads its whole failure surface. A status computed at run time would be
+// invisible to the scan and the spec could drift under it unnoticed, which is a hole worth
+// closing at the one call site that could open it.
+func TestAPIHandlers_WriteStatusesAsConstants(t *testing.T) {
+	calls := 0
+	forEachHandlerSource(t, func(t *testing.T, path string, fset *token.FileSet, file *ast.File) {
+		if filepath.Base(path) == "api_common.go" {
+			return // the helper's own signature takes the int; its callers are the subject
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name, ok := call.Fun.(*ast.Ident)
+			if !ok || name.Name != "writeJSONError" || len(call.Args) != 4 {
+				return true
+			}
+			calls++
+			sel, ok := call.Args[3].(*ast.SelectorExpr)
+			if !ok {
+				t.Errorf("%s:%d: writeJSONError is called with a computed status; the "+
+					"openapi.yaml lint reads statuses lexically and cannot see it",
+					path, fset.Position(call.Args[3].Pos()).Line)
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "http" || httpStatusConstants[sel.Sel.Name] == 0 {
+				t.Errorf("%s:%d: writeJSONError is called with %s rather than an http.Status "+
+					"constant", path, fset.Position(call.Args[3].Pos()).Line, sel.Sel.Name)
+			}
+			return true
+		})
+	})
+
+	// A scan that inspected nothing passes while guarding nothing. This is the floor that
+	// says the walk still reaches the handlers.
+	if calls < 100 {
+		t.Errorf("found only %d writeJSONError calls; the walk is no longer reaching the "+
+			"API handlers", calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The three parsers.
+// ---------------------------------------------------------------------------
+
+// parseRoutes reads routes.go rather than starting a server, because the registration is
+// what the spec is a description of, and a running server would answer only the routes a
+// test happened to call.
+func parseRoutes(t *testing.T) []routeRegistration {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "routes.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parsing routes.go: %v", err)
+	}
+
+	var out []routeRegistration
+	collectRoutes(t, fset, file, "", &out)
+
+	// The floor. A parse that silently stopped matching chi's registration shape would make
+	// every test above vacuous, and the failure would look like a pass.
+	api := 0
+	for _, r := range out {
+		if strings.HasPrefix(r.path, "/api/v1/") {
+			api++
+		}
+	}
+	if api < 100 {
+		t.Fatalf("parsed only %d routes under /api/v1 from routes.go; the parse is no longer "+
+			"matching the way routes are registered", api)
+	}
+	return out
+}
+
+var httpVerbs = map[string]string{
+	"Get": "get", "Post": "post", "Put": "put", "Delete": "delete",
+	"Patch": "patch", "Head": "head", "Options": "options",
+}
+
+// specVerbs is the same set as the spec spells it, used to tell an operation apart from the
+// path-level keys that sit beside it.
+var specVerbs = func() map[string]bool {
+	out := map[string]bool{}
+	for _, v := range httpVerbs {
+		out[v] = true
+	}
+	return out
+}()
+
+func collectRoutes(t *testing.T, fset *token.FileSet, node ast.Node, prefix string, out *[]routeRegistration) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		// r.Route("/api/v1/admin", func(r chi.Router) { ... }): descend with the prefix and
+		// stop the outer walk, so the body is read once and under the right path.
+		if sel.Sel.Name == "Route" && len(call.Args) == 2 {
+			sub, subOK := stringLiteral(call.Args[0])
+			body, bodyOK := call.Args[1].(*ast.FuncLit)
+			if subOK && bodyOK {
+				collectRoutes(t, fset, body, prefix+sub, out)
+				return false
+			}
+		}
+
+		verb, isVerb := httpVerbs[sel.Sel.Name]
+		if !isVerb || len(call.Args) != 2 {
+			return true
+		}
+		path, pathOK := stringLiteral(call.Args[0])
+		handler, handlerOK := handlerConstructor(call.Args[1])
+		if !pathOK || !handlerOK {
+			return true
+		}
+		full := prefix + path
+		*out = append(*out, routeRegistration{
+			method:      verb,
+			path:        full,
+			key:         routeKey(verb, full),
+			handler:     handler,
+			rateLimited: mentionsRateLimiter(sel.X),
+			line:        fset.Position(call.Pos()).Line,
+		})
+		return true
+	})
+}
+
+func stringLiteral(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// handlerConstructor pulls HandleX out of apihandlers.HandleX(deps...). Every API route is
+// registered that way; anything else (a file server, a bare http.HandlerFunc) is not an
+// operation the spec describes and is left alone.
+func handlerConstructor(e ast.Expr) (string, bool) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name, strings.HasPrefix(fn.Sel.Name, "Handle")
+	case *ast.Ident:
+		return fn.Name, strings.HasPrefix(fn.Name, "Handle")
+	}
+	return "", false
+}
+
+// mentionsRateLimiter looks for the limiter in the .With(...) chain the verb hangs off.
+func mentionsRateLimiter(e ast.Expr) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == "rateLimiter" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// parseHandlerStatuses maps every Handle* constructor under internal/handlers to the
+// statuses its body can write.
+func parseHandlerStatuses(t *testing.T) map[string]map[int]bool {
+	t.Helper()
+
+	out := map[string]map[int]bool{}
+	seenIn := map[string]string{}
+	forEachHandlerSource(t, func(t *testing.T, path string, fset *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "Handle") {
+				continue
+			}
+			// Two handlers of the same name in different packages would make the lookup by
+			// name ambiguous and the result arbitrary. There are none; this says so.
+			if prev, dup := seenIn[fn.Name.Name]; dup {
+				t.Fatalf("%s is declared in both %s and %s; the status scan looks handlers "+
+					"up by name and cannot tell them apart", fn.Name.Name, prev, path)
+			}
+			seenIn[fn.Name.Name] = path
+			out[fn.Name.Name] = statusesWrittenIn(t, path, fset, fn)
+		}
+	})
+
+	if len(out) < 100 {
+		t.Fatalf("found only %d Handle* functions under internal/handlers; the walk is no "+
+			"longer reaching the handler sources", len(out))
+	}
+	return out
+}
+
+// statusesWrittenIn reads one handler's failure surface. Four spellings write a status in
+// this module and all four are read here; anything else is a fifth nobody has taught this
+// file about, which is what the unknown-constant failure below is for.
+func statusesWrittenIn(t *testing.T, path string, fset *token.FileSet, fn *ast.FuncDecl) map[int]bool {
+	out := map[int]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.SelectorExpr:
+			// http.StatusXxx, wherever it appears: w.WriteHeader, writeJSONError's fourth
+			// argument, or a comparison.
+			pkg, ok := e.X.(*ast.Ident)
+			if !ok || pkg.Name != "http" || !strings.HasPrefix(e.Sel.Name, "Status") {
+				return true
+			}
+			if e.Sel.Name == "StatusText" {
+				return true // the formatter, not a status
+			}
+			code, known := httpStatusConstants[e.Sel.Name]
+			if !known {
+				t.Errorf("%s:%d: %s uses http.%s, which openapi_contract_lint_test.go does "+
+					"not know the number of; add it to httpStatusConstants",
+					path, fset.Position(e.Pos()).Line, fn.Name.Name, e.Sel.Name)
+				return true
+			}
+			out[code] = true
+		case *ast.CallExpr:
+			switch f := e.Fun.(type) {
+			case *ast.Ident:
+				// writeValidationError names no constant; it is a 400 by
+				// construction. Nothing depends on this line today: every handler
+				// that calls it also writes an http.StatusBadRequest somewhere
+				// else, so removing it changes no result and a mutation of it
+				// survives. It is here for the first handler that validates and
+				// does nothing else, which would otherwise have its 400 go
+				// undocumented with every test in this file still passing.
+				if f.Name == "writeValidationError" {
+					out[400] = true
+				}
+			case *ast.SelectorExpr:
+				switch f.Sel.Name {
+				case "InternalServerError", "JsonError":
+					// httpHelper's two error renderers. Both write 500 for a bare error,
+					// which is the only kind these handlers hand them.
+					out[500] = true
+				case "NotFound":
+					if pkg, ok := f.X.(*ast.Ident); ok && pkg.Name == "http" {
+						out[404] = true
+					}
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// forEachHandlerSource walks the non-test Go sources under internal/handlers. Tests are
+// skipped: a test names statuses to assert on them, and it is production code that decides
+// what a route can answer.
+func forEachHandlerSource(t *testing.T, visit func(*testing.T, string, *token.FileSet, *ast.File)) {
+	t.Helper()
+
+	// go test runs with the package directory as the working directory, so this is
+	// src/authserver/internal/handlers.
+	root := filepath.Join("..", "handlers")
+	files := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, pErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if pErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, pErr)
+		}
+		files++
+		visit(t, filepath.ToSlash(path), fset, file)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	if files == 0 {
+		t.Fatalf("walked no non-test Go files under %s", root)
+	}
+}
+
+// specOperation is the part of an operation these tests read.
+type specOperation struct {
+	operationId string
+	responses   map[int]bool
+}
+
+// parseSpec reads the embedded bytes rather than the file on disk, so what is checked is
+// what GET /openapi.yaml serves.
+func parseSpec(t *testing.T) map[string]specOperation {
+	t.Helper()
+
+	var doc struct {
+		Paths map[string]map[string]struct {
+			OperationId string               `yaml:"operationId"`
+			Responses   map[string]yaml.Node `yaml:"responses"`
+		} `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(web.OpenAPISpec(), &doc); err != nil {
+		t.Fatalf("parsing the embedded openapi.yaml: %v", err)
+	}
+
+	out := map[string]specOperation{}
+	for path, item := range doc.Paths {
+		for verb, op := range item {
+			if !specVerbs[verb] {
+				continue // parameters, summary and the other path-level keys
+			}
+			responses := map[int]bool{}
+			for code := range op.Responses {
+				n, err := strconv.Atoi(code)
+				if err != nil {
+					t.Errorf("%s %s declares a response keyed %q, which is not a status code",
+						strings.ToUpper(verb), path, code)
+					continue
+				}
+				responses[n] = true
+			}
+			out[routeKey(verb, path)] = specOperation{operationId: op.OperationId, responses: responses}
+		}
+	}
+
+	if len(out) < 90 {
+		t.Fatalf("read only %d operations out of the embedded openapi.yaml; the parse is no "+
+			"longer matching the document's shape", len(out))
+	}
+	return out
+}
+
+func sortedCodes(set map[int]bool) []int {
+	out := make([]int, 0, len(set))
+	for code := range set {
+		out = append(out, code)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// TestOpenAPI_ResponseRefsResolve is the structural guard on the reconciliation above. Most
+// of the failure entries in this document are one line, a $ref into components/responses,
+// and a $ref whose target is missing or misspelled is not a documentation slip: every
+// generator resolves it, so the document stops being usable rather than merely being wrong.
+// The alternative shape, an entry written out in place, has to carry a description, since an
+// empty response body tells a caller nothing at all.
+func TestOpenAPI_ResponseRefsResolve(t *testing.T) {
+	var doc struct {
+		Paths map[string]map[string]struct {
+			Responses map[string]map[string]yaml.Node `yaml:"responses"`
+		} `yaml:"paths"`
+		Components struct {
+			Responses map[string]yaml.Node `yaml:"responses"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(web.OpenAPISpec(), &doc); err != nil {
+		t.Fatalf("parsing the embedded openapi.yaml: %v", err)
+	}
+
+	checked := 0
+	used := map[string]bool{}
+	for path, item := range doc.Paths {
+		for verb, op := range item {
+			if !specVerbs[verb] {
+				continue
+			}
+			for code, response := range op.Responses {
+				checked++
+				ref, isRef := response["$ref"]
+				if !isRef {
+					if _, described := response["description"]; !described {
+						t.Errorf("%s %s '%s' is written out in place with no description",
+							strings.ToUpper(verb), path, code)
+					}
+					continue
+				}
+				name := ref.Value[strings.LastIndex(ref.Value, "/")+1:]
+				used[name] = true
+				if _, ok := doc.Components.Responses[name]; !ok {
+					t.Errorf("%s %s '%s' refers to %s, which components/responses does not "+
+						"define", strings.ToUpper(verb), path, code, ref.Value)
+				}
+			}
+		}
+	}
+
+	// The other direction. A shared response nothing refers to is dead weight in a published
+	// contract, and the way one appears is a reconciliation that stopped half done.
+	for name := range doc.Components.Responses {
+		if !used[name] {
+			t.Errorf("components/responses defines %s, which no operation refers to", name)
+		}
+	}
+
+	if checked < 300 {
+		t.Errorf("checked only %d response entries; the walk is no longer reaching the "+
+			"document's operations", checked)
+	}
+}

--- a/src/authserver/tests/data/key_pair_test.go
+++ b/src/authserver/tests/data/key_pair_test.go
@@ -442,6 +442,55 @@ func TestUpdateKeyPairState_EnlistsInCallersTransaction(t *testing.T) {
 	}
 }
 
+// TestUpdateKeyPairState_StorageFailureIsAnError separates a storage fault from a lost
+// compare-and-set. Both leave the row where it found it, and both come back with moved
+// false, so the error return is the only thing that tells them apart.
+//
+// It matters because of what the caller does with the distinction. SigningKeyRotator maps
+// a false return to ErrRotationInProgress, which the API answers with 409 and the admin
+// console renders as "Another key rotation is in progress": an administrator reading that
+// understands the rotation they asked for already happened, and does not retry. A storage
+// failure reported through that same path is a rotation that never occurred, described to
+// the operator as one that did (#251).
+//
+// A transaction that has already been rolled back is the deterministic way to make the
+// statement fail on every engine: database/sql answers sql.ErrTxDone from tx.Exec itself,
+// before any driver is reached, so this is real-implementation behaviour rather than a
+// per-dialect quirk or an injected fake.
+func TestUpdateKeyPairState_StorageFailureIsAnError(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	previous := enums.KeyStatePrevious.String()
+
+	keyPair := createKeyPairInState(t, current)
+	clearKeyPairState(t, previous)
+
+	tx, err := database.BeginTransaction()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+	if err := database.RollbackTransaction(tx); err != nil {
+		t.Fatalf("Failed to roll back transaction: %v", err)
+	}
+
+	moved, err := database.UpdateKeyPairState(tx, keyPair.Id, current, previous)
+	if err == nil {
+		t.Fatal("Expected an error when the statement could not execute, got nil")
+	}
+	if moved {
+		t.Error("Expected no transition to be reported when the statement failed")
+	}
+
+	// And the row is genuinely untouched, so the error is not reporting a failure
+	// after a transition that happened anyway.
+	retrieved, err := database.GetKeyPairById(nil, keyPair.Id)
+	if err != nil {
+		t.Fatalf("Failed to retrieve key pair: %v", err)
+	}
+	if retrieved.State != current {
+		t.Errorf("Expected State to stay %s, got %s", current, retrieved.State)
+	}
+}
+
 // TestUpdateKeyPairState_Concurrent is the property seam 2 owns: two transactions
 // racing the same transition produce exactly one winner, the loser reporting false
 // rather than an error. This is probe/probe_251_test.go.txt's Q3 lifted onto the

--- a/src/authserver/tests/data/key_pair_test.go
+++ b/src/authserver/tests/data/key_pair_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCreateKeyPair(t *testing.T) {
-	keyPair := createTestKeyPair(t)
+	keyPair := createKeyPairInState(t, enums.KeyStateCurrent.String())
 
 	if keyPair.Id == 0 {
 		t.Error("Expected non-zero ID after creation")
@@ -32,7 +32,14 @@ func TestCreateKeyPair(t *testing.T) {
 }
 
 func TestUpdateKeyPair(t *testing.T) {
-	keyPair := createTestKeyPair(t)
+	keyPair := createKeyPairInState(t, enums.KeyStateCurrent.String())
+
+	// The destination state is cleared before the row is moved into it. UNIQUE (state)
+	// refuses an update into an occupied state, and the data-test database is shared and
+	// never dropped, so a 'previous' row left behind by an earlier case or an earlier run
+	// would fail this update on all four engines. Production observes the same ordering:
+	// the rotator deletes the previous key before demoting the current one (#251).
+	clearKeyPairState(t, enums.KeyStatePrevious.String())
 
 	// Update all properties
 	keyPair.State = enums.KeyStatePrevious.String()
@@ -88,7 +95,7 @@ func TestUpdateKeyPair(t *testing.T) {
 }
 
 func TestGetKeyPairById(t *testing.T) {
-	keyPair := createTestKeyPair(t)
+	keyPair := createKeyPairInState(t, enums.KeyStateCurrent.String())
 
 	retrievedKeyPair, err := database.GetKeyPairById(nil, keyPair.Id)
 	if err != nil {
@@ -121,8 +128,13 @@ func TestGetAllSigningKeys(t *testing.T) {
 		}
 	}
 
-	keyPair1 := createTestKeyPair(t)
-	keyPair2 := createTestKeyPair(t)
+	// Two states rather than two rows in one: UNIQUE (state) forbids the second
+	// 'current' row this case used to create. What it is actually for is unchanged, and
+	// is the reason it holds two rows at all: GetAllSigningKeys returns every signing
+	// key whatever state it is in, which is what lets the token parser fall back to a
+	// previous key and what lets /certs publish the whole set (#251).
+	keyPair1 := createKeyPairInState(t, enums.KeyStateCurrent.String())
+	keyPair2 := createKeyPairInState(t, enums.KeyStateNext.String())
 
 	keyPairs, err = database.GetAllSigningKeys(nil)
 	if err != nil {
@@ -172,12 +184,7 @@ func TestGetCurrentSigningKey(t *testing.T) {
 		t.Fatal("Expected an error when no key pair is in the current state, got nil")
 	}
 
-	keyPair := createTestKeyPair(t)
-	keyPair.State = enums.KeyStateCurrent.String()
-	err = database.UpdateKeyPair(nil, keyPair)
-	if err != nil {
-		t.Fatalf("Failed to update key pair: %v", err)
-	}
+	keyPair := createKeyPairInState(t, enums.KeyStateCurrent.String())
 
 	currentKeyPair, err := database.GetCurrentSigningKey(nil)
 	if err != nil {
@@ -192,7 +199,7 @@ func TestGetCurrentSigningKey(t *testing.T) {
 }
 
 func TestDeleteKeyPair(t *testing.T) {
-	keyPair := createTestKeyPair(t)
+	keyPair := createKeyPairInState(t, enums.KeyStateCurrent.String())
 
 	err := database.DeleteKeyPair(nil, keyPair.Id)
 	if err != nil {
@@ -211,24 +218,6 @@ func TestDeleteKeyPair(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error when deleting non-existent key pair, got: %v", err)
 	}
-}
-
-func createTestKeyPair(t *testing.T) *models.KeyPair {
-	keyPair := &models.KeyPair{
-		State:             enums.KeyStateCurrent.String(),
-		KeyIdentifier:     gofakeit.UUID(),
-		Type:              "RSA",
-		Algorithm:         "RS256",
-		PrivateKeyPEM:     []byte(gofakeit.LoremIpsumSentence(100)),
-		PublicKeyPEM:      []byte(gofakeit.LoremIpsumSentence(50)),
-		PublicKeyASN1_DER: []byte(gofakeit.LoremIpsumSentence(30)),
-		PublicKeyJWK:      []byte(gofakeit.LoremIpsumSentence(40)),
-	}
-	err := database.CreateKeyPair(nil, keyPair)
-	if err != nil {
-		t.Fatalf("Failed to create test key pair: %v", err)
-	}
-	return keyPair
 }
 
 func compareKeyPairs(t *testing.T, expected, actual *models.KeyPair) {
@@ -291,7 +280,10 @@ func clearKeyPairState(t *testing.T, state string) {
 }
 
 // createKeyPairInState creates a key pair already in state, clearing whatever held
-// that state first.
+// that state first. It is the only key-pair fixture in this package: UNIQUE (state)
+// means a fixture that always stamped 'current' could not be called twice, so the
+// state is the caller's to choose rather than something to correct afterwards with an
+// update.
 func createKeyPairInState(t *testing.T, state string) *models.KeyPair {
 	t.Helper()
 

--- a/src/authserver/tests/data/key_pair_test.go
+++ b/src/authserver/tests/data/key_pair_test.go
@@ -1,6 +1,7 @@
 package datatests
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -162,6 +163,15 @@ func TestGetCurrentSigningKey(t *testing.T) {
 		}
 	}
 
+	// The absent case runs here, while the table is still empty, and it has to: create
+	// the current key first and there is nothing left to observe. GetCurrentSigningKey
+	// returns an error rather than (nil, nil) because every caller dereferences the
+	// result, so a missing current key is a panic at eight sites instead of a
+	// diagnosable failure (#251). Reverse that and this assertion fails.
+	if _, err := database.GetCurrentSigningKey(nil); err == nil {
+		t.Fatal("Expected an error when no key pair is in the current state, got nil")
+	}
+
 	keyPair := createTestKeyPair(t)
 	keyPair.State = enums.KeyStateCurrent.String()
 	err = database.UpdateKeyPair(nil, keyPair)
@@ -248,5 +258,288 @@ func compareKeyPairs(t *testing.T, expected, actual *models.KeyPair) {
 	}
 	if string(actual.PublicKeyJWK) != string(expected.PublicKeyJWK) {
 		t.Errorf("Expected PublicKeyJWK %s, got %s", expected.PublicKeyJWK, actual.PublicKeyJWK)
+	}
+}
+
+// contentionHold is how long the winning transaction keeps its row lock in
+// TestUpdateKeyPairState_Concurrent before committing. Long enough that the loser's
+// wait is unmistakable against scheduling noise, short enough to pay four times
+// (once per engine) without the suite noticing.
+const contentionHold = 300 * time.Millisecond
+
+// clearKeyPairState deletes every key pair sitting in state, so a row can be created
+// there or moved into it. Stage 4's UNIQUE (state) refuses an update into an occupied
+// state, and the data-test database is shared and never dropped, so a row left in
+// 'previous' by an earlier case or an earlier run would fail every current -> previous
+// transition below on all four engines. This is the same ordering production observes:
+// the rotator deletes the previous key before demoting the current one (#251).
+func clearKeyPairState(t *testing.T, state string) {
+	t.Helper()
+
+	keyPairs, err := database.GetAllSigningKeys(nil)
+	if err != nil {
+		t.Fatalf("Failed to get all signing keys: %v", err)
+	}
+	for _, kp := range keyPairs {
+		if kp.State != state {
+			continue
+		}
+		if err := database.DeleteKeyPair(nil, kp.Id); err != nil {
+			t.Fatalf("Failed to delete key pair in state %s: %v", state, err)
+		}
+	}
+}
+
+// createKeyPairInState creates a key pair already in state, clearing whatever held
+// that state first.
+func createKeyPairInState(t *testing.T, state string) *models.KeyPair {
+	t.Helper()
+
+	clearKeyPairState(t, state)
+
+	keyPair := &models.KeyPair{
+		State:             state,
+		KeyIdentifier:     gofakeit.UUID(),
+		Type:              "RSA",
+		Algorithm:         "RS256",
+		PrivateKeyPEM:     []byte(gofakeit.LoremIpsumSentence(100)),
+		PublicKeyPEM:      []byte(gofakeit.LoremIpsumSentence(50)),
+		PublicKeyASN1_DER: []byte(gofakeit.LoremIpsumSentence(30)),
+		PublicKeyJWK:      []byte(gofakeit.LoremIpsumSentence(40)),
+	}
+	if err := database.CreateKeyPair(nil, keyPair); err != nil {
+		t.Fatalf("Failed to create test key pair in state %s: %v", state, err)
+	}
+	return keyPair
+}
+
+func TestUpdateKeyPairState_TransitionsAndReadsBack(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	previous := enums.KeyStatePrevious.String()
+
+	keyPair := createKeyPairInState(t, current)
+	clearKeyPairState(t, previous)
+
+	moved, err := database.UpdateKeyPairState(nil, keyPair.Id, current, previous)
+	if err != nil {
+		t.Fatalf("Failed to update key pair state: %v", err)
+	}
+	if !moved {
+		t.Fatal("Expected the transition to be made by this call")
+	}
+
+	retrieved, err := database.GetKeyPairById(nil, keyPair.Id)
+	if err != nil {
+		t.Fatalf("Failed to retrieve key pair: %v", err)
+	}
+	if retrieved.State != previous {
+		t.Errorf("Expected State %s, got %s", previous, retrieved.State)
+	}
+}
+
+func TestUpdateKeyPairState_RepeatedCallDoesNotTransition(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	previous := enums.KeyStatePrevious.String()
+
+	keyPair := createKeyPairInState(t, current)
+	clearKeyPairState(t, previous)
+
+	moved, err := database.UpdateKeyPairState(nil, keyPair.Id, current, previous)
+	if err != nil {
+		t.Fatalf("Failed to update key pair state: %v", err)
+	}
+	if !moved {
+		t.Fatal("Expected the first call to make the transition")
+	}
+
+	// The id still matches, so the state = fromState predicate is the only thing that
+	// can reject this. Remove it and the same row transitions twice, which is exactly
+	// what lets a losing rotation act on a snapshot the winner has already moved past.
+	moved, err = database.UpdateKeyPairState(nil, keyPair.Id, current, previous)
+	if err != nil {
+		t.Fatalf("Expected no error on the repeated call, got: %v", err)
+	}
+	if moved {
+		t.Error("Expected the repeated call to report no transition: the row is no longer in the from-state")
+	}
+}
+
+func TestUpdateKeyPairState_WrongFromStateDoesNotTransition(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	next := enums.KeyStateNext.String()
+	previous := enums.KeyStatePrevious.String()
+
+	// A row in 'next' asked to make the current -> previous transition. This varies
+	// exactly one thing from TestUpdateKeyPairState_TransitionsAndReadsBack.
+	keyPair := createKeyPairInState(t, next)
+	clearKeyPairState(t, previous)
+
+	moved, err := database.UpdateKeyPairState(nil, keyPair.Id, current, previous)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if moved {
+		t.Error("Expected no transition for a row that is not in the from-state")
+	}
+
+	retrieved, err := database.GetKeyPairById(nil, keyPair.Id)
+	if err != nil {
+		t.Fatalf("Failed to retrieve key pair: %v", err)
+	}
+	if retrieved.State != next {
+		t.Errorf("Expected State to be left at %s, got %s", next, retrieved.State)
+	}
+}
+
+func TestUpdateKeyPairState_MissingIdDoesNotTransition(t *testing.T) {
+	moved, err := database.UpdateKeyPairState(nil, 99999,
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String())
+	if err != nil {
+		t.Fatalf("Expected no error for a non-existent key pair, got: %v", err)
+	}
+	if moved {
+		t.Error("Expected no transition for a non-existent key pair")
+	}
+}
+
+func TestUpdateKeyPairState_ZeroIdIsAnError(t *testing.T) {
+	moved, err := database.UpdateKeyPairState(nil, 0,
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String())
+	if err == nil {
+		t.Fatal("Expected an error for a zero key pair id, got nil")
+	}
+	if moved {
+		t.Error("Expected no transition for a zero key pair id")
+	}
+}
+
+func TestUpdateKeyPairState_EnlistsInCallersTransaction(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	previous := enums.KeyStatePrevious.String()
+
+	keyPair := createKeyPairInState(t, current)
+	clearKeyPairState(t, previous)
+
+	tx, err := database.BeginTransaction()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+
+	moved, err := database.UpdateKeyPairState(tx, keyPair.Id, current, previous)
+	if err != nil {
+		_ = database.RollbackTransaction(tx)
+		t.Fatalf("Failed to update key pair state: %v", err)
+	}
+	if !moved {
+		_ = database.RollbackTransaction(tx)
+		t.Fatal("Expected the transition to be made by this call")
+	}
+
+	if err := database.RollbackTransaction(tx); err != nil {
+		t.Fatalf("Failed to roll back transaction: %v", err)
+	}
+
+	// A statement that ignored the caller's tx and used the pool instead would have
+	// committed, and the rollback would not have undone it.
+	retrieved, err := database.GetKeyPairById(nil, keyPair.Id)
+	if err != nil {
+		t.Fatalf("Failed to retrieve key pair: %v", err)
+	}
+	if retrieved.State != current {
+		t.Errorf("Expected the rollback to leave State at %s, got %s", current, retrieved.State)
+	}
+}
+
+// TestUpdateKeyPairState_Concurrent is the property seam 2 owns: two transactions
+// racing the same transition produce exactly one winner, the loser reporting false
+// rather than an error. This is probe/probe_251_test.go.txt's Q3 lifted onto the
+// interface method.
+//
+// One winner is not on its own evidence of a race: two calls run end to end in
+// sequence produce the same pair of answers, because the second finds the row no
+// longer in the from-state. So each goroutine times the span from just before
+// BeginTransaction to just after UpdateKeyPairState returns, and the loser's span
+// must be at least a third of contentionHold, which it can only be if it was blocked
+// while the winner still held. A sequential run measures the loser at near zero.
+//
+// The mechanism differs per engine and the observable does not: on postgres, mysql
+// and mssql the loser waits on the row lock, and on sqlite it waits on the pool,
+// which SetMaxOpenConns(1) limits to one connection. Asserting that the two
+// transactions overlapped would be unprovable on sqlite, where that setting makes
+// overlap impossible by construction, so the assertion is on being blocked (#251).
+func TestUpdateKeyPairState_Concurrent(t *testing.T) {
+	current := enums.KeyStateCurrent.String()
+	previous := enums.KeyStatePrevious.String()
+
+	keyPair := createKeyPairInState(t, current)
+	clearKeyPairState(t, previous)
+
+	type outcome struct {
+		moved bool
+		err   error
+		span  time.Duration
+	}
+	outcomes := make([]outcome, 2)
+
+	// Both goroutines wait on the same barrier so they reach the row together.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			began := time.Now()
+			tx, err := database.BeginTransaction()
+			if err != nil {
+				outcomes[i] = outcome{err: err, span: time.Since(began)}
+				return
+			}
+			moved, err := database.UpdateKeyPairState(tx, keyPair.Id, current, previous)
+			span := time.Since(began)
+			if err != nil {
+				_ = database.RollbackTransaction(tx)
+				outcomes[i] = outcome{err: err, span: span}
+				return
+			}
+
+			// The winner holds its lock while the loser is still trying, so the
+			// loser's wait is observable.
+			time.Sleep(contentionHold)
+
+			if err := database.CommitTransaction(tx); err != nil {
+				outcomes[i] = outcome{moved: moved, err: err, span: span}
+				return
+			}
+			outcomes[i] = outcome{moved: moved, span: span}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	wins := 0
+	var loser outcome
+	for i, o := range outcomes {
+		if o.err != nil {
+			t.Fatalf("goroutine %d: expected no error, got: %v", i, o.err)
+		}
+		if o.moved {
+			wins++
+		} else {
+			loser = o
+		}
+	}
+
+	if wins != 1 {
+		t.Fatalf("Expected exactly 1 winner among 2 concurrent transitions, got %d", wins)
+	}
+
+	minWait := contentionHold / 3
+	if loser.span < minWait {
+		t.Errorf("Expected the loser to be blocked for at least %v while the winner held, "+
+			"but it returned after %v: the two transitions did not contend", minWait, loser.span)
 	}
 }

--- a/src/authserver/tests/data/migration_000030_key_pairs_state_unique_test.go
+++ b/src/authserver/tests/data/migration_000030_key_pairs_state_unique_test.go
@@ -1,0 +1,171 @@
+package datatests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keyPairsStateIndex000030 is the index the migration adds, on every engine.
+const keyPairsStateIndex000030 = "idx_key_pairs_state"
+
+// TestMigration000030_KeyPairsStateUnique exercises the migration that makes
+// key_pairs hold at most one row per state (#251). It runs against an ISOLATED
+// database of the configured dialect (see migration_testdb_helper.go): seed
+// duplicates at 000029, apply 000030, and assert what survived and what the index
+// now refuses.
+//
+// The assertions worth explaining:
+//
+//  1. Absent at 000029, so the index found afterwards is the one 000030 created
+//     rather than one already there under a colliding name. idx_state, from the
+//     initial migration, is a different index on the same column and stays.
+//  2. The uniqueness flag's polarity is checked on this engine before it is trusted,
+//     using idx_state as a control. Each catalog reports uniqueness differently and
+//     MySQL reports it inverted (NON_UNIQUE), so "unique" would otherwise pass on an
+//     engine whose flag was being read backwards, which is the one way this test
+//     could report green on an index that constrains nothing. 000025's control runs
+//     in the opposite polarity, which is what makes this one the right way round.
+//  3. The sweep keeps exactly one row per state, and keeps the HIGHEST id of each.
+//     Asserting only the count would pass with MAX(id) written as MIN(id), which is
+//     the wrong end: id is monotonic on every engine, so the newest key is the one
+//     the deployment is actually using.
+//  4. The index covers exactly [state] and is unique. Name-only presence is not
+//     enough: an index built on the wrong column, or built non-unique, would pass a
+//     name check while enforcing nothing.
+//  5. It bites. A second 'current' insert is refused. The catalog can report a shape
+//     the engine does not enforce only if the index were somehow filtered, and this
+//     is the assertion that closes that off without reading any engine's DDL back.
+//  6. The down migration runs and re-applying is clean. The down is not a true
+//     inverse, since the swept rows are gone for good, which the file says.
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestMigration000030_KeyPairsStateUnique
+func TestMigration000030_KeyPairsStateUnique(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(29), "migrate to 000029")
+
+	// 2. Control: a known non-unique index on the same column must read as non-unique
+	// here. This is what makes the "unique" assertion below mean something.
+	control := describeIndex(t, h, "key_pairs", "idx_state")
+	require.True(t, control.Exists, "control index idx_state must exist at 000029")
+	require.False(t, control.Unique,
+		"control index idx_state is non-unique on every engine; reading it as unique means the uniqueness flag is being read backwards")
+
+	// 1. Absent before the migration.
+	require.False(t, describeIndex(t, h, "key_pairs", keyPairsStateIndex000030).Exists,
+		"%s must not exist at 000029", keyPairsStateIndex000030)
+
+	// The shape probe/probe_251b_test.go.txt ran: duplicates in all three states, more
+	// than two in one of them so a sweep that merely deduplicated pairs would still
+	// leave a duplicate behind.
+	seeded := map[string][]int64{}
+	for _, s := range []struct {
+		state string
+		n     int
+	}{{"current", 2}, {"next", 3}, {"previous", 2}} {
+		for i := 0; i < s.n; i++ {
+			seeded[s.state] = append(seeded[s.state], seedKeyPair000030(t, h, s.state))
+		}
+	}
+	require.EqualValues(t, 7, countKeyPairs000030(t, h, ""), "seven rows seeded at 000029")
+
+	require.NoError(t, h.Migrator.Migrate(30), "apply 000030")
+
+	// 3. One row per state, and it is the highest id of that state.
+	require.EqualValues(t, 3, countKeyPairs000030(t, h, ""),
+		"the sweep must leave exactly one row per state")
+	for state, ids := range seeded {
+		require.EqualValues(t, 1, countKeyPairs000030(t, h, state),
+			"exactly one %s row must survive the sweep", state)
+
+		want := ids[len(ids)-1] // seeded in ascending id order
+		var got int64
+		require.NoError(t, h.SQL.QueryRow(
+			fmt.Sprintf("SELECT id FROM key_pairs WHERE state = '%s'", state)).Scan(&got),
+			"read the surviving %s row", state)
+		assert.Equalf(t, want, got,
+			"the sweep must keep the HIGHEST id in state %s (MAX(id), not MIN(id)): "+
+				"id is monotonic on every engine, so the newest key is the one in use", state)
+	}
+
+	// 4 and 5.
+	assertKeyPairsStateIndex000030(t, h, "after apply")
+
+	// 6. Down, then up again.
+	require.NoError(t, h.Migrator.Migrate(29), "roll back 000030")
+	assert.False(t, describeIndex(t, h, "key_pairs", keyPairsStateIndex000030).Exists,
+		"%s must be gone after rolling back to 000029", keyPairsStateIndex000030)
+
+	require.NoError(t, h.Migrator.Migrate(30), "re-apply 000030")
+	assertKeyPairsStateIndex000030(t, h, "after down/up round trip")
+}
+
+// assertKeyPairsStateIndex000030 checks the index's shape in the catalog and then
+// checks that the engine actually enforces it.
+func assertKeyPairsStateIndex000030(t *testing.T, h *isolatedDB, phase string) {
+	t.Helper()
+
+	shape := describeIndex(t, h, "key_pairs", keyPairsStateIndex000030)
+
+	require.Truef(t, shape.Exists, "[%s] %s is missing", phase, keyPairsStateIndex000030)
+	assert.Equalf(t, []string{"state"}, shape.Columns,
+		"[%s] %s must cover exactly state", phase, keyPairsStateIndex000030)
+	assert.Truef(t, shape.Unique,
+		"[%s] %s must be UNIQUE: it is the whole point of the migration", phase, keyPairsStateIndex000030)
+
+	// 5. Enforced, not merely declared.
+	before := countKeyPairs000030(t, h, "current")
+	require.EqualValuesf(t, 1, before, "[%s] expected one current row before the duplicate attempt", phase)
+
+	_, err := h.SQL.Exec(insertKeyPair000030SQL("current"))
+	assert.Errorf(t, err, "[%s] a second row in state 'current' must be refused", phase)
+	assert.EqualValuesf(t, 1, countKeyPairs000030(t, h, "current"),
+		"[%s] the refused insert must leave no row behind", phase)
+}
+
+// insertKeyPair000030SQL builds an insert naming only the NOT NULL columns of the
+// key_pairs table, which are the same four on all four engines. Literals rather than
+// placeholders because the dialects disagree on placeholder syntax and every value
+// here is test-controlled, following seedPreMigration000028User.
+func insertKeyPair000030SQL(state string) string {
+	return fmt.Sprintf(
+		`INSERT INTO key_pairs (state, key_identifier, type, algorithm)
+		 VALUES ('%s', '%s', 'RSA', 'RS256')`, state, uuid.NewString())
+}
+
+// seedKeyPair000030 inserts one key_pairs row in state and returns its id. Callers
+// rely on successive calls returning ascending ids, which every engine's identity
+// column provides.
+func seedKeyPair000030(t *testing.T, h *isolatedDB, state string) int64 {
+	t.Helper()
+
+	q := insertKeyPair000030SQL(state)
+	_, err := h.SQL.Exec(q)
+	require.NoErrorf(t, err, "seed key pair in state %s", state)
+
+	var id int64
+	require.NoErrorf(t, h.SQL.QueryRow("SELECT MAX(id) FROM key_pairs").Scan(&id),
+		"read back seeded key pair id")
+	return id
+}
+
+// countKeyPairs000030 counts key_pairs rows, in one state or in all of them when
+// state is empty.
+func countKeyPairs000030(t *testing.T, h *isolatedDB, state string) int64 {
+	t.Helper()
+
+	q := "SELECT COUNT(*) FROM key_pairs"
+	if state != "" {
+		q = fmt.Sprintf("%s WHERE state = '%s'", q, state)
+	}
+
+	var n int64
+	require.NoErrorf(t, h.SQL.QueryRow(q).Scan(&n), "count key_pairs: %s", q)
+	return n
+}

--- a/src/authserver/tests/data/signing_key_rotator_test.go
+++ b/src/authserver/tests/data/signing_key_rotator_test.go
@@ -1,0 +1,177 @@
+package datatests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/leodip/goiabada/core/encryption"
+	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/oauth"
+)
+
+// This is seam 1 at the data tier, on all four engines: the rotator's composition against
+// real SQL rather than against a mock's idea of it. The unit tests in
+// core/oauth/signing_key_rotator_test.go own which calls are made in which order and what
+// happens on every refusal; only this one can say the resulting statements are accepted by
+// mysql, postgres, mssql and sqlite and leave the key set the rotation claims.
+//
+// The concurrency property is deliberately not asserted here. The replacement key is
+// generated before the transaction opens and a 4096-bit generation takes about 300ms with
+// wide variance, so two goroutines calling Rotate() may not overlap at all, and when they
+// do not, both rotations succeed, which is correct behaviour that would fail such a test.
+// The race is covered where it is deterministic: TestUpdateKeyPairState_Concurrent in
+// key_pair_test.go, and the two losing branches driven directly at the unit tier.
+
+// seedOneKeyPerState leaves exactly one row in each state and returns them. Exactly one,
+// because stage 4's UNIQUE (state) must not be able to falsify this case, and because the
+// data-test database is shared and never dropped, so rows from an earlier run would
+// otherwise decide what the rotation finds.
+func seedOneKeyPerState(t *testing.T) (previous, current, next *models.KeyPair) {
+	t.Helper()
+
+	previous = createKeyPairInState(t, enums.KeyStatePrevious.String())
+	current = createKeyPairInState(t, enums.KeyStateCurrent.String())
+	next = createKeyPairInState(t, enums.KeyStateNext.String())
+	return previous, current, next
+}
+
+func TestSigningKeyRotator_Rotate_MovesEveryKeyOneStep(t *testing.T) {
+	previous, current, next := seedOneKeyPerState(t)
+
+	if err := oauth.NewSigningKeyRotator(database).Rotate(); err != nil {
+		t.Fatalf("Rotate failed: %v", err)
+	}
+
+	keyPairs, err := database.GetAllSigningKeys(nil)
+	if err != nil {
+		t.Fatalf("Failed to get all signing keys: %v", err)
+	}
+	if len(keyPairs) != 3 {
+		t.Fatalf("Expected 3 key pairs after rotating, got %d", len(keyPairs))
+	}
+
+	byState := map[string]*models.KeyPair{}
+	for i := range keyPairs {
+		kp := &keyPairs[i]
+		if existing, duplicate := byState[kp.State]; duplicate {
+			t.Fatalf("Two key pairs in state %s: ids %d and %d", kp.State, existing.Id, kp.Id)
+		}
+		byState[kp.State] = kp
+	}
+
+	// The old current key is now the only previous one. This is the key that signed every
+	// token still in flight, and retaining it is what OIDC Core 10.1.1 asks for.
+	newPrevious := byState[enums.KeyStatePrevious.String()]
+	if newPrevious == nil {
+		t.Fatal("Expected a previous key after rotating")
+	}
+	if newPrevious.Id != current.Id {
+		t.Errorf("Expected the old current key (id %d) to be previous, got id %d",
+			current.Id, newPrevious.Id)
+	}
+
+	// The old next key is now current, so the deployment can still sign.
+	newCurrent := byState[enums.KeyStateCurrent.String()]
+	if newCurrent == nil {
+		t.Fatal("Expected a current key after rotating")
+	}
+	if newCurrent.Id != next.Id {
+		t.Errorf("Expected the old next key (id %d) to be current, got id %d",
+			next.Id, newCurrent.Id)
+	}
+
+	// The key that was previous before the rotation is gone, which is the one deletion
+	// the rotation is entitled to make.
+	deleted, err := database.GetKeyPairById(nil, previous.Id)
+	if err != nil {
+		t.Fatalf("Failed to look up the old previous key: %v", err)
+	}
+	if deleted != nil {
+		t.Errorf("Expected the old previous key (id %d) to be gone, it is still in state %s",
+			previous.Id, deleted.State)
+	}
+
+	// A freshly generated next key, not a row moved from somewhere else.
+	newNext := byState[enums.KeyStateNext.String()]
+	if newNext == nil {
+		t.Fatal("Expected a next key after rotating")
+	}
+	if newNext.Id == previous.Id || newNext.Id == current.Id || newNext.Id == next.Id {
+		t.Errorf("Expected a newly created next key, got the seeded id %d", newNext.Id)
+	}
+	if newNext.KeyIdentifier == next.KeyIdentifier {
+		t.Error("Expected the new next key to carry a fresh key identifier")
+	}
+	if newNext.Type != "RSA" || newNext.Algorithm != "RS256" {
+		t.Errorf("Expected an RSA/RS256 key, got %s/%s", newNext.Type, newNext.Algorithm)
+	}
+	if len(newNext.PublicKeyASN1_DER) == 0 || len(newNext.PublicKeyJWK) == 0 {
+		t.Error("Expected the new next key to carry its DER and JWK encodings")
+	}
+
+	// The private key survives the round trip through the column encrypted (#83), so it
+	// decrypts back to a PEM rather than being stored in the clear.
+	decrypted, err := encryption.DecryptData(newNext.PrivateKeyPEM)
+	if err != nil {
+		t.Fatalf("Failed to decrypt the new next key's private key: %v", err)
+	}
+	if len(decrypted) == 0 {
+		t.Error("Expected the decrypted private key to be non-empty")
+	}
+
+	// GetCurrentSigningKey is what every token issuer asks, so the promotion has to be
+	// visible through it and not only through GetAllSigningKeys.
+	signingKey, err := database.GetCurrentSigningKey(nil)
+	if err != nil {
+		t.Fatalf("Failed to get the current signing key: %v", err)
+	}
+	if signingKey.Id != next.Id {
+		t.Errorf("Expected the current signing key to be id %d, got id %d", next.Id, signingKey.Id)
+	}
+}
+
+// TestSigningKeyRotator_Rotate_RefusesWithNoNextKeyAndKeepsThePrevious is the issue's own
+// first test: a rotation attempted with no next row refuses without deleting the previous
+// key. Against a real engine, so the refusal's rollback is a real rollback.
+func TestSigningKeyRotator_Rotate_RefusesWithNoNextKeyAndKeepsThePrevious(t *testing.T) {
+	previous, current, _ := seedOneKeyPerState(t)
+	clearKeyPairState(t, enums.KeyStateNext.String())
+
+	err := oauth.NewSigningKeyRotator(database).Rotate()
+	if err == nil {
+		t.Fatal("Expected the rotation to be refused")
+	}
+	if !errors.Is(err, oauth.ErrKeySetIncomplete) {
+		t.Fatalf("Expected ErrKeySetIncomplete, got %v", err)
+	}
+
+	// Nothing moved. The previous key is the whole point: the old code deleted it before
+	// discovering it could not rotate, retiring every token it had signed (#251).
+	survivor, err := database.GetKeyPairById(nil, previous.Id)
+	if err != nil {
+		t.Fatalf("Failed to look up the previous key: %v", err)
+	}
+	if survivor == nil {
+		t.Fatal("The previous key was deleted by a rotation that then refused")
+	}
+	if survivor.State != enums.KeyStatePrevious.String() {
+		t.Errorf("Expected the previous key to be untouched, it is in state %s", survivor.State)
+	}
+
+	stillCurrent, err := database.GetKeyPairById(nil, current.Id)
+	if err != nil {
+		t.Fatalf("Failed to look up the current key: %v", err)
+	}
+	if stillCurrent == nil || stillCurrent.State != enums.KeyStateCurrent.String() {
+		t.Error("Expected the current key to be untouched by the refused rotation")
+	}
+
+	keyPairs, err := database.GetAllSigningKeys(nil)
+	if err != nil {
+		t.Fatalf("Failed to get all signing keys: %v", err)
+	}
+	if len(keyPairs) != 2 {
+		t.Errorf("Expected the refused rotation to write nothing, found %d key pairs", len(keyPairs))
+	}
+}

--- a/src/authserver/tests/data/unique_constraint_test.go
+++ b/src/authserver/tests/data/unique_constraint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,12 +15,13 @@ import (
 
 // Unique constraints.
 //
-// The schema declares eleven of them, and like the cascade rules they are written
+// The schema declares twelve of them, and like the cascade rules they are written
 // out separately for each of the four engines, in one case as a named index and in
 // another inline on the column. Nothing asserted that any of them actually bites,
 // so a constraint missing from one dialect would have gone unnoticed. These are the
 // invariants the auth flows lean on: two clients cannot share a client_identifier,
-// two refresh tokens cannot share a jti, a code hash cannot be reused.
+// two refresh tokens cannot share a jti, a code hash cannot be reused, and only one
+// signing key can be in any given state.
 //
 // Only the fact of an error is asserted, never its text, which differs per engine
 // (mysql "Duplicate entry", postgres "duplicate key value violates unique
@@ -100,6 +102,23 @@ func TestUnique_CodeHash(t *testing.T) {
 	duplicate.Code = "other_" + gofakeit.LetterN(6)
 	err := database.CreateCode(nil, &duplicate)
 	assert.Error(t, err, "two codes must not share a code_hash")
+}
+
+func TestUnique_KeyPairState(t *testing.T) {
+	// 'next' rather than 'current', because 'next' is the only duplicate the rotation
+	// defect could actually produce: two concurrent rotations both inserting a new next
+	// key. The constraint covers all three states identically (#251).
+	next := enums.KeyStateNext.String()
+	existing := createKeyPairInState(t, next)
+
+	duplicate := &models.KeyPair{
+		State:         existing.State,
+		KeyIdentifier: gofakeit.UUID(),
+		Type:          "RSA",
+		Algorithm:     "RS256",
+	}
+	err := database.CreateKeyPair(nil, duplicate)
+	assert.Error(t, err, "two key pairs must not share a state")
 }
 
 func TestUnique_RefreshTokenJti(t *testing.T) {

--- a/src/authserver/web/openapi.yaml
+++ b/src/authserver/web/openapi.yaml
@@ -87,8 +87,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchUsersResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/create:
     post:
@@ -113,6 +119,17 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: |
+            The email address is already registered. error_code is
+            EMAIL_ALREADY_EXISTS. Answered both by the explicit duplicate check
+            and by the user creator, which derives the username from the email.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}:
     get:
@@ -129,10 +146,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Users]
       summary: Delete user
@@ -147,10 +168,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/profile:
     put:
@@ -179,6 +204,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/email:
     put:
@@ -207,6 +234,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/email/verification-code:
     post:
@@ -226,10 +255,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenerateUserEmailVerificationCodeResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/phone:
     put:
@@ -258,6 +291,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/address:
     put:
@@ -286,6 +321,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/password:
     put:
@@ -314,6 +351,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/enabled:
     put:
@@ -336,10 +375,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UpdateUserResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/otp:
     put:
@@ -368,6 +411,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/groups:
     get:
@@ -384,10 +429,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserGroupsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Users]
       summary: Set user groups
@@ -414,6 +463,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/users/{id}/permissions:
     get:
@@ -430,10 +481,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserPermissionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Permissions]
       summary: Set user permissions
@@ -460,6 +515,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - USER ATTRIBUTES
@@ -479,10 +536,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/user-attributes:
     post:
@@ -507,6 +568,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/user-attributes/{id}:
     get:
@@ -529,10 +594,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserAttributeResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [User Attributes]
       summary: Update user attribute
@@ -565,6 +634,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [User Attributes]
       summary: Delete user attribute
@@ -585,10 +656,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - USER SESSIONS
@@ -608,10 +683,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserSessionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/user-sessions/{sessionIdentifier}:
     get:
@@ -633,10 +712,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [User Sessions]
       summary: Update session
@@ -662,10 +745,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [User Sessions]
       summary: Delete session
@@ -689,10 +776,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - USER CONSENTS
@@ -712,10 +803,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUserConsentsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          description: |
+            The request failed inside the server. Unlike every other failure on
+            this endpoint, the body is the server's HTML error page rather than
+            the JSON error envelope, because this handler renders the shared
+            error template.
+          content:
+            text/html:
+              schema:
+                type: string
 
   /api/v1/admin/user-consents/{id}:
     delete:
@@ -738,10 +841,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          description: |
+            The request failed inside the server. Unlike every other failure on
+            this endpoint, the body is the server's HTML error page rather than
+            the JSON error envelope, because this handler renders the shared
+            error template.
+          content:
+            text/html:
+              schema:
+                type: string
 
   # =============================================================================
   # ADMIN API - GROUPS
@@ -761,6 +876,8 @@ paths:
                 $ref: '#/components/schemas/GetGroupsResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Groups]
       summary: Create group
@@ -783,6 +900,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/groups/{id}:
     get:
@@ -799,10 +918,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGroupResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Groups]
       summary: Update group
@@ -829,6 +952,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Groups]
       summary: Delete group
@@ -843,10 +968,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/groups/{id}/members:
     get:
@@ -865,10 +994,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGroupMembersResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Group Members]
       summary: Add group member
@@ -883,7 +1016,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AddGroupMemberRequest'
       responses:
-        '200':
+        '201':
           description: Member added
           content:
             application/json:
@@ -895,6 +1028,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/groups/{id}/members/{userId}:
     delete:
@@ -918,10 +1053,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/groups/{id}/permissions:
     get:
@@ -938,10 +1077,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGroupPermissionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Permissions]
       summary: Set group permissions
@@ -968,6 +1111,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - GROUP ATTRIBUTES
@@ -987,10 +1132,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGroupAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/group-attributes:
     post:
@@ -1015,6 +1164,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/group-attributes/{id}:
     get:
@@ -1037,10 +1190,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGroupAttributeResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Group Attributes]
       summary: Update group attribute
@@ -1073,6 +1230,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Group Attributes]
       summary: Delete group attribute
@@ -1093,10 +1252,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - RESOURCES
@@ -1116,6 +1279,8 @@ paths:
                 $ref: '#/components/schemas/GetResourcesResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Resources]
       summary: Create resource
@@ -1138,6 +1303,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/resources/{id}:
     get:
@@ -1154,10 +1321,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Resources]
       summary: Update resource
@@ -1184,6 +1355,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Resources]
       summary: Delete resource
@@ -1198,10 +1371,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/resources/{id}/permissions:
     get:
@@ -1213,15 +1390,20 @@ paths:
         - $ref: '#/components/parameters/ResourceIdParam'
       responses:
         '200':
-          description: Resource permissions
+          description: |
+            Resource permissions. An id that matches no resource is answered
+            here with an empty list rather than a 404: the handler queries the
+            permissions by resource id and never looks the resource up.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetPermissionsByResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Resources]
       summary: Update resource permissions
@@ -1248,6 +1430,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/permissions/{id}/users:
     get:
@@ -1272,10 +1456,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUsersByPermissionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ADMIN API - CLIENTS
@@ -1295,6 +1483,8 @@ paths:
                 $ref: '#/components/schemas/GetClientsResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Clients]
       summary: Create client
@@ -1317,6 +1507,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}:
     get:
@@ -1333,10 +1525,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetClientResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Clients]
       summary: Update client settings
@@ -1363,6 +1559,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Clients]
       summary: Delete client
@@ -1377,10 +1575,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/authentication:
     put:
@@ -1409,6 +1611,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/oauth2-flows:
     put:
@@ -1437,6 +1641,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/redirect-uris:
     put:
@@ -1465,6 +1671,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/web-origins:
     put:
@@ -1493,6 +1701,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/tokens:
     put:
@@ -1521,6 +1731,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/permissions:
     get:
@@ -1537,10 +1749,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetClientPermissionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Clients]
       summary: Set client permissions
@@ -1567,6 +1783,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/clients/{id}/logo:
     get:
@@ -1583,10 +1801,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClientLogoInfoResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags: [Clients]
       summary: Upload client logo
@@ -1620,6 +1842,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     delete:
       tags: [Clients]
       summary: Delete client logo
@@ -1634,10 +1858,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /client/logo/{clientIdentifier}:
     get:
@@ -1674,6 +1902,16 @@ paths:
           description: Not modified (ETag match)
         '404':
           description: Client or logo not found
+        '500':
+          description: |
+            The request failed inside the server. Unlike every other failure on
+            this endpoint, the body is the server's HTML error page rather than
+            the JSON error envelope, because this handler renders the shared
+            error template.
+          content:
+            text/html:
+              schema:
+                type: string
 
   # =============================================================================
   # ADMIN API - SETTINGS
@@ -1693,6 +1931,8 @@ paths:
                 $ref: '#/components/schemas/SettingsGeneralResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Settings]
       summary: Update general settings
@@ -1715,6 +1955,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/email:
     get:
@@ -1731,6 +1973,8 @@ paths:
                 $ref: '#/components/schemas/SettingsEmailResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Settings]
       summary: Update email settings
@@ -1753,6 +1997,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/email/send-test:
     post:
@@ -1777,6 +2023,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/sessions:
     get:
@@ -1793,6 +2041,8 @@ paths:
                 $ref: '#/components/schemas/SettingsSessionsResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Settings]
       summary: Update session settings
@@ -1815,6 +2065,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/ui-theme:
     get:
@@ -1831,6 +2083,8 @@ paths:
                 $ref: '#/components/schemas/SettingsUIThemeResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Settings]
       summary: Update UI theme
@@ -1853,6 +2107,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/tokens:
     get:
@@ -1869,6 +2125,8 @@ paths:
                 $ref: '#/components/schemas/SettingsTokensResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Settings]
       summary: Update token settings
@@ -1891,6 +2149,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/keys:
     get:
@@ -1907,6 +2167,8 @@ paths:
                 $ref: '#/components/schemas/GetSettingsKeysResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/settings/keys/rotate:
     post:
@@ -1928,6 +2190,17 @@ paths:
             Another rotation won the race and this call rotated nothing.
             error_code is ROTATION_IN_PROGRESS. Do not retry: the rotation
             it conflicted with already happened.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: |
+            error_code is KEY_SET_INCOMPLETE when the deployment has no current
+            or no next key, which is an operator problem rather than a
+            transient one and a retry will not clear it, or INTERNAL_ERROR for
+            a storage or key generation failure. Nothing was rotated either
+            way: the whole transition is one transaction.
           content:
             application/json:
               schema:
@@ -1954,10 +2227,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: |
+            error_code is VALIDATION_ERROR. The id is malformed, matches no
+            key, or names a key that is not in the previous state, since only a
+            previous key can be revoked. A key that does not exist is answered
+            here rather than with a 404.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/admin/phone-countries:
     get:
@@ -1974,6 +2257,8 @@ paths:
                 $ref: '#/components/schemas/GetPhoneCountriesResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   # =============================================================================
   # ACCOUNT API
@@ -1993,6 +2278,10 @@ paths:
                 $ref: '#/components/schemas/GetUserResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     put:
       tags: [Account]
       summary: Update own profile
@@ -2015,6 +2304,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/email:
     put:
@@ -2039,6 +2332,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/email/verification/send:
     post:
@@ -2053,8 +2350,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccountEmailVerificationSendResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/email/verification:
     post:
@@ -2079,8 +2382,12 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/phone:
     put:
@@ -2105,6 +2412,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/address:
     put:
@@ -2129,6 +2440,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/password:
     put:
@@ -2153,8 +2468,12 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/otp/enrollment:
     get:
@@ -2173,6 +2492,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/otp:
     put:
@@ -2197,8 +2520,12 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/consents:
     get:
@@ -2215,6 +2542,10 @@ paths:
                 $ref: '#/components/schemas/GetUserConsentsResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/consents/{id}:
     delete:
@@ -2237,10 +2568,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/sessions:
     get:
@@ -2257,6 +2594,10 @@ paths:
                 $ref: '#/components/schemas/GetUserSessionsResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/sessions/{id}:
     delete:
@@ -2279,10 +2620,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/v1/account/logout-request:
     post:
@@ -2307,6 +2654,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
 components:
   securitySchemes:
@@ -2387,6 +2736,16 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: |
+        The authenticated user does not own the resource. error_code is
+        FORBIDDEN. Returned by the account endpoints, which resolve a
+        resource by id and then check it belongs to the caller, so a valid
+        token for the wrong user reaches this rather than a 404.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
     TooManyRequests:
       description: |
         Rate limit reached. Returned only when rate limiting is enabled
@@ -2398,6 +2757,16 @@ components:
           description: Seconds to wait before retrying
           schema:
             type: integer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalServerError:
+      description: |
+        The request failed inside the server, most often a storage error.
+        error_code is INTERNAL_ERROR, INTERNAL_SERVER_ERROR or an operation
+        specific code; the description is safe to show and carries no detail
+        about the failure. Retrying is reasonable.
       content:
         application/json:
           schema:

--- a/src/authserver/web/openapi.yaml
+++ b/src/authserver/web/openapi.yaml
@@ -1923,6 +1923,15 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: |
+            Another rotation won the race and this call rotated nothing.
+            error_code is ROTATION_IN_PROGRESS. Do not retry: the rotation
+            it conflicted with already happened.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/v1/admin/settings/keys/{id}:
     delete:

--- a/src/core/data/commondb/key_pair.go
+++ b/src/core/data/commondb/key_pair.go
@@ -68,6 +68,42 @@ func (d *CommonDatabase) UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) erro
 	return nil
 }
 
+// UpdateKeyPairState moves one key from fromState to toState, and reports whether this call
+// is the one that made the transition. The state predicate is what makes it a compare-and-set:
+// without it two concurrent rotations both write the snapshot they read, and the loser deletes
+// the previous key the winner had just demoted, retiring every token that key signed (#251).
+func (d *CommonDatabase) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string,
+	toState string) (bool, error) {
+
+	if keyPairId == 0 {
+		return false, errors.WithStack(errors.New("can't update the state of a keyPair with id 0"))
+	}
+
+	ub := sqlbuilder.NewUpdateBuilder()
+	ub.Update("key_pairs")
+	ub.Set(
+		ub.Assign("state", toState),
+		ub.Assign("updated_at", time.Now().UTC()),
+	)
+	ub.Where(
+		ub.Equal("id", keyPairId),
+		ub.Equal("state", fromState),
+	)
+
+	query, args := ub.BuildWithFlavor(d.Flavor)
+	result, err := d.ExecSql(tx, query, args...)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to update keyPair state")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get rows affected when updating keyPair state")
+	}
+
+	return rowsAffected == 1, nil
+}
+
 func (d *CommonDatabase) getKeyPairCommon(tx *sql.Tx, selectBuilder *sqlbuilder.SelectBuilder,
 	keyPairStruct *sqlbuilder.Struct) (*models.KeyPair, error) {
 
@@ -141,6 +177,12 @@ func (d *CommonDatabase) GetAllSigningKeys(tx *sql.Tx) ([]models.KeyPair, error)
 	return keyPairs, nil
 }
 
+// GetCurrentSigningKey returns an error when no key is in the current state, departing from
+// the (nil, nil) this package returns for a lookup that may legitimately miss. Every caller
+// dereferences the result to read key material, so a nil pair is a panic rather than a
+// diagnosable failure, and a deployment with no current key cannot validate the bearer token
+// needed to repair itself. Returning the error here is what makes all of those sites correct
+// at once, including ones added later (#251).
 func (d *CommonDatabase) GetCurrentSigningKey(tx *sql.Tx) (*models.KeyPair, error) {
 	keyPairStruct := sqlbuilder.NewStruct(new(models.KeyPair)).
 		For(d.Flavor)
@@ -151,6 +193,10 @@ func (d *CommonDatabase) GetCurrentSigningKey(tx *sql.Tx) (*models.KeyPair, erro
 	keyPair, err := d.getKeyPairCommon(tx, selectBuilder, keyPairStruct)
 	if err != nil {
 		return nil, err
+	}
+
+	if keyPair == nil {
+		return nil, errors.WithStack(errors.New("no current signing key found"))
 	}
 
 	return keyPair, nil

--- a/src/core/data/database.go
+++ b/src/core/data/database.go
@@ -166,8 +166,24 @@ type Database interface {
 
 	CreateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) error
 	UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) error
+	// UpdateKeyPairState moves one key from an expected state to a new one, and reports
+	// whether this call is the one that made the transition. Compare-and-set for the same
+	// reason MarkCodeAsUsed is: a read-then-unconditional-write lets two concurrent
+	// rotations both act on the snapshot they read, and the loser then destroys the key
+	// the winner had just demoted for the grace period rotation exists to provide (#251).
+	//
+	// A false return means no row transitioned, so the caller lost a race or the row is
+	// gone. It is not an error.
+	UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string, toState string) (bool, error)
 	GetKeyPairById(tx *sql.Tx, keyPairId int64) (*models.KeyPair, error)
 	GetAllSigningKeys(tx *sql.Tx) ([]models.KeyPair, error)
+	// GetCurrentSigningKey returns an error when no key is in the current state, rather
+	// than the (nil, nil) this codebase returns for a lookup that may legitimately miss.
+	// The current signing key is a singleton the server cannot run without: every caller
+	// dereferences the result to read key material, so (nil, nil) is a nil-pointer panic
+	// at each of them and one more at every call site added later. Narrowing the contract
+	// here is what makes all of them correct at once, as IncrementUserAuthStateGeneration
+	// rejects a nil transaction rather than tolerating it (#251).
 	GetCurrentSigningKey(tx *sql.Tx) (*models.KeyPair, error)
 	DeleteKeyPair(tx *sql.Tx, keyPairId int64) error
 

--- a/src/core/data/mocks/database_mock.go
+++ b/src/core/data/mocks/database_mock.go
@@ -11145,6 +11145,84 @@ func (_c *Database_UpdateKeyPair_Call) RunAndReturn(run func(tx *sql.Tx, keyPair
 	return _c
 }
 
+// UpdateKeyPairState provides a mock function for the type Database
+func (_mock *Database) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string, toState string) (bool, error) {
+	ret := _mock.Called(tx, keyPairId, fromState, toState)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateKeyPairState")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, int64, string, string) (bool, error)); ok {
+		return returnFunc(tx, keyPairId, fromState, toState)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*sql.Tx, int64, string, string) bool); ok {
+		r0 = returnFunc(tx, keyPairId, fromState, toState)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(*sql.Tx, int64, string, string) error); ok {
+		r1 = returnFunc(tx, keyPairId, fromState, toState)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Database_UpdateKeyPairState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateKeyPairState'
+type Database_UpdateKeyPairState_Call struct {
+	*mock.Call
+}
+
+// UpdateKeyPairState is a helper method to define mock.On call
+//   - tx *sql.Tx
+//   - keyPairId int64
+//   - fromState string
+//   - toState string
+func (_e *Database_Expecter) UpdateKeyPairState(tx any, keyPairId any, fromState any, toState any) *Database_UpdateKeyPairState_Call {
+	return &Database_UpdateKeyPairState_Call{Call: _e.mock.On("UpdateKeyPairState", tx, keyPairId, fromState, toState)}
+}
+
+func (_c *Database_UpdateKeyPairState_Call) Run(run func(tx *sql.Tx, keyPairId int64, fromState string, toState string)) *Database_UpdateKeyPairState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *sql.Tx
+		if args[0] != nil {
+			arg0 = args[0].(*sql.Tx)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *Database_UpdateKeyPairState_Call) Return(b bool, err error) *Database_UpdateKeyPairState_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Database_UpdateKeyPairState_Call) RunAndReturn(run func(tx *sql.Tx, keyPairId int64, fromState string, toState string) (bool, error)) *Database_UpdateKeyPairState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePermission provides a mock function for the type Database
 func (_mock *Database) UpdatePermission(tx *sql.Tx, permission *models.Permission) error {
 	ret := _mock.Called(tx, permission)

--- a/src/core/data/mssqldb/key_pair.go
+++ b/src/core/data/mssqldb/key_pair.go
@@ -63,6 +63,11 @@ func (d *MsSQLDatabase) UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) error
 	return d.CommonDB.UpdateKeyPair(tx, keyPair)
 }
 
+func (d *MsSQLDatabase) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string,
+	toState string) (bool, error) {
+	return d.CommonDB.UpdateKeyPairState(tx, keyPairId, fromState, toState)
+}
+
 func (d *MsSQLDatabase) GetKeyPairById(tx *sql.Tx, keyPairId int64) (*models.KeyPair, error) {
 	return d.CommonDB.GetKeyPairById(tx, keyPairId)
 }

--- a/src/core/data/mssqldb/migrations/000030_add_key_pairs_state_unique.down.sql
+++ b/src/core/data/mssqldb/migrations/000030_add_key_pairs_state_unique.down.sql
@@ -1,0 +1,2 @@
+-- Dropping the index cannot restore the rows the up migration swept (#251).
+DROP INDEX [idx_key_pairs_state] ON [key_pairs];

--- a/src/core/data/mssqldb/migrations/000030_add_key_pairs_state_unique.up.sql
+++ b/src/core/data/mssqldb/migrations/000030_add_key_pairs_state_unique.up.sql
@@ -1,0 +1,12 @@
+-- One key per state (#251). See the sqlite migration of the same number for which
+-- readers already assume it, why the sweep keeps the highest id per state, and why a
+-- duplicate is swept rather than failing the migration.
+--
+-- No EXEC and no named default constraint here, unlike 000029 and 000026: this
+-- migration adds no column, so nothing in the batch names an identifier the same
+-- batch has just created, and there is no default for the down migration to drop
+-- before the column.
+DELETE FROM [key_pairs]
+ WHERE [id] NOT IN (SELECT [id] FROM (SELECT MAX([id]) AS [id] FROM [key_pairs] GROUP BY [state]) AS keep);
+
+CREATE UNIQUE INDEX [idx_key_pairs_state] ON [key_pairs]([state]);

--- a/src/core/data/mssqldb/schema.sql
+++ b/src/core/data/mssqldb/schema.sql
@@ -431,6 +431,7 @@ CREATE UNIQUE INDEX [idx_client_identifier] ON [clients] (client_identifier);
 CREATE UNIQUE INDEX [idx_code_hash] ON [codes] (code_hash);
 CREATE UNIQUE INDEX [idx_group_identifier] ON [groups] (group_identifier);
 CREATE INDEX [idx_state] ON [key_pairs] (state);
+CREATE UNIQUE INDEX [idx_key_pairs_state] ON [key_pairs] (state);
 CREATE UNIQUE INDEX [idx_permission_identifier_resource] ON [permissions] (permission_identifier, resource_id);
 CREATE INDEX [idx_pre_reg_email] ON [pre_registrations] (email);
 CREATE UNIQUE INDEX [idx_pre_reg_verification_code_hash] ON [pre_registrations] ([verification_code_hash]);

--- a/src/core/data/mysqldb/key_pair.go
+++ b/src/core/data/mysqldb/key_pair.go
@@ -14,6 +14,11 @@ func (d *MySQLDatabase) UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) error
 	return d.CommonDB.UpdateKeyPair(tx, keyPair)
 }
 
+func (d *MySQLDatabase) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string,
+	toState string) (bool, error) {
+	return d.CommonDB.UpdateKeyPairState(tx, keyPairId, fromState, toState)
+}
+
 func (d *MySQLDatabase) GetKeyPairById(tx *sql.Tx, keyPairId int64) (*models.KeyPair, error) {
 	return d.CommonDB.GetKeyPairById(tx, keyPairId)
 }

--- a/src/core/data/mysqldb/migrations/000030_add_key_pairs_state_unique.down.sql
+++ b/src/core/data/mysqldb/migrations/000030_add_key_pairs_state_unique.down.sql
@@ -1,0 +1,2 @@
+-- Dropping the index cannot restore the rows the up migration swept (#251).
+DROP INDEX `idx_key_pairs_state` ON `key_pairs`;

--- a/src/core/data/mysqldb/migrations/000030_add_key_pairs_state_unique.up.sql
+++ b/src/core/data/mysqldb/migrations/000030_add_key_pairs_state_unique.up.sql
@@ -1,0 +1,11 @@
+-- One key per state (#251). See the sqlite migration of the same number for which
+-- readers already assume it, why the sweep keeps the highest id per state, and why a
+-- duplicate is swept rather than failing the migration.
+--
+-- The derived table exists for this engine in particular: MySQL refuses a subquery
+-- naming the table being deleted from ("You can't specify target table 'key_pairs'
+-- for update in FROM clause") unless it is wrapped in one.
+DELETE FROM `key_pairs`
+ WHERE `id` NOT IN (SELECT `id` FROM (SELECT MAX(`id`) AS `id` FROM `key_pairs` GROUP BY `state`) AS keep);
+
+CREATE UNIQUE INDEX `idx_key_pairs_state` ON `key_pairs`(`state`);

--- a/src/core/data/mysqldb/schema.sql
+++ b/src/core/data/mysqldb/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE `key_pairs` (
   `public_key_asn1_der` longblob,
   `public_key_jwk` longblob,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_key_pairs_state` (`state`),
   KEY `idx_state` (`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/src/core/data/postgresdb/key_pair.go
+++ b/src/core/data/postgresdb/key_pair.go
@@ -58,6 +58,11 @@ func (d *PostgresDatabase) UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) er
 	return d.CommonDB.UpdateKeyPair(tx, keyPair)
 }
 
+func (d *PostgresDatabase) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string,
+	toState string) (bool, error) {
+	return d.CommonDB.UpdateKeyPairState(tx, keyPairId, fromState, toState)
+}
+
 func (d *PostgresDatabase) GetKeyPairById(tx *sql.Tx, keyPairId int64) (*models.KeyPair, error) {
 	return d.CommonDB.GetKeyPairById(tx, keyPairId)
 }

--- a/src/core/data/postgresdb/migrations/000030_add_key_pairs_state_unique.down.sql
+++ b/src/core/data/postgresdb/migrations/000030_add_key_pairs_state_unique.down.sql
@@ -1,0 +1,2 @@
+-- Dropping the index cannot restore the rows the up migration swept (#251).
+DROP INDEX idx_key_pairs_state;

--- a/src/core/data/postgresdb/migrations/000030_add_key_pairs_state_unique.up.sql
+++ b/src/core/data/postgresdb/migrations/000030_add_key_pairs_state_unique.up.sql
@@ -1,0 +1,7 @@
+-- One key per state (#251). See the sqlite migration of the same number for which
+-- readers already assume it, why the sweep keeps the highest id per state, and why a
+-- duplicate is swept rather than failing the migration.
+DELETE FROM key_pairs
+ WHERE id NOT IN (SELECT id FROM (SELECT MAX(id) AS id FROM key_pairs GROUP BY state) AS keep);
+
+CREATE UNIQUE INDEX idx_key_pairs_state ON key_pairs(state);

--- a/src/core/data/postgresdb/schema.sql
+++ b/src/core/data/postgresdb/schema.sql
@@ -1429,6 +1429,13 @@ CREATE INDEX idx_state ON public.key_pairs USING btree (state);
 
 
 --
+-- Name: idx_key_pairs_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_key_pairs_state ON public.key_pairs USING btree (state);
+
+
+--
 -- Name: idx_subject; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/src/core/data/sqlitedb/key_pair.go
+++ b/src/core/data/sqlitedb/key_pair.go
@@ -14,6 +14,11 @@ func (d *SQLiteDatabase) UpdateKeyPair(tx *sql.Tx, keyPair *models.KeyPair) erro
 	return d.CommonDB.UpdateKeyPair(tx, keyPair)
 }
 
+func (d *SQLiteDatabase) UpdateKeyPairState(tx *sql.Tx, keyPairId int64, fromState string,
+	toState string) (bool, error) {
+	return d.CommonDB.UpdateKeyPairState(tx, keyPairId, fromState, toState)
+}
+
 func (d *SQLiteDatabase) GetKeyPairById(tx *sql.Tx, keyPairId int64) (*models.KeyPair, error) {
 	return d.CommonDB.GetKeyPairById(tx, keyPairId)
 }

--- a/src/core/data/sqlitedb/migrations/000030_add_key_pairs_state_unique.down.sql
+++ b/src/core/data/sqlitedb/migrations/000030_add_key_pairs_state_unique.down.sql
@@ -1,0 +1,4 @@
+-- Dropping the index cannot restore the rows the up migration swept. They are gone,
+-- and rolling back returns the table to accepting duplicates rather than to the
+-- contents it had before (#251).
+DROP INDEX `idx_key_pairs_state`;

--- a/src/core/data/sqlitedb/migrations/000030_add_key_pairs_state_unique.up.sql
+++ b/src/core/data/sqlitedb/migrations/000030_add_key_pairs_state_unique.up.sql
@@ -1,0 +1,34 @@
+-- One key per state (#251).
+--
+-- key_pairs holds at most one row in each of 'current', 'next' and 'previous', and
+-- every reader has always assumed it. GetCurrentSigningKey is a plain
+-- WHERE state = 'current' with no ORDER BY and no LIMIT, so with two current rows it
+-- returns whichever the driver yields first; /certs assigns previousKey in a loop and
+-- so publishes only the last duplicate it sees; the admin console offers to revoke
+-- "the previous key", singular. The assumption was enforced nowhere. idx_state, from
+-- the initial migration, is a plain index on all four engines and stays as it is:
+-- it serves the lookups, this one serves the invariant.
+--
+-- The rotation that could break the assumption is fixed separately, in the same
+-- change: it now runs in one transaction with each state change written as a
+-- compare-and-set. This index is what makes the invariant enforceable rather than
+-- merely intended, and it is why GetCurrentSigningKey's single row is provable
+-- instead of arbitrary.
+--
+-- THE SWEEP. Existing deployments may already carry duplicates, because until this
+-- release two concurrent rotations could both insert a new 'next' row. Keeping the
+-- highest id per state keeps the newest, since id is monotonic on every engine
+-- (sqlite AUTOINCREMENT, mysql AUTO_INCREMENT, postgres sequence, mssql IDENTITY).
+-- Extra 'next' rows are the only duplicates this defect can actually produce, and a
+-- 'next' key has signed nothing, so in the reachable case the sweep destroys nothing
+-- anyone can be holding a token from.
+--
+-- The derived table is not decoration: MySQL refuses a subquery that names the table
+-- being deleted from, and wrapping it makes the same statement legal on all four
+-- engines. Sweeping rather than failing on a duplicate is deliberate too. A failed
+-- migration stops startup and leaves the schema version dirty, and a deployment that
+-- cannot start cannot be repaired through the product.
+DELETE FROM key_pairs
+ WHERE id NOT IN (SELECT id FROM (SELECT MAX(id) AS id FROM key_pairs GROUP BY state) AS keep);
+
+CREATE UNIQUE INDEX `idx_key_pairs_state` ON `key_pairs`(`state`);

--- a/src/core/data/sqlitedb/schema.sql
+++ b/src/core/data/sqlitedb/schema.sql
@@ -312,6 +312,7 @@ CREATE INDEX `idx_family_name` ON `users`(`family_name`);
 CREATE UNIQUE INDEX `idx_code_hash` ON `codes`(`code_hash`);
 CREATE UNIQUE INDEX `idx_group_identifier` ON `groups`(`group_identifier`);
 CREATE INDEX `idx_state` ON `key_pairs`(`state`);
+CREATE UNIQUE INDEX `idx_key_pairs_state` ON `key_pairs`(`state`);
 CREATE INDEX `idx_pre_reg_email` ON `pre_registrations`(`email`);
 CREATE INDEX idx_users_forgot_password_code_hash ON users(forgot_password_code_hash);
 CREATE UNIQUE INDEX idx_pre_reg_verification_code_hash ON pre_registrations(verification_code_hash);

--- a/src/core/oauth/signing_key_rotator.go
+++ b/src/core/oauth/signing_key_rotator.go
@@ -1,0 +1,177 @@
+package oauth
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/data"
+	"github.com/leodip/goiabada/core/encryption"
+	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/rsautil"
+	"github.com/pkg/errors"
+)
+
+// ErrRotationInProgress means a compare-and-set transitioned no row, so another rotation
+// had already moved the key this one read. The caller lost the race and nothing was
+// committed.
+var ErrRotationInProgress = errors.New("another signing key rotation is in progress")
+
+// ErrKeySetIncomplete means the current or the next key is missing. The rotation refused
+// before writing anything, so the key set is exactly as it was found.
+var ErrKeySetIncomplete = errors.New("expected current and next signing keys to exist")
+
+// SigningKeyRotator performs the current -> previous -> deleted transition of the signing
+// keys, as one transaction whose every refusal happens before the commit.
+//
+// The reason it is a transaction, and the reason each state change is a compare-and-set
+// rather than a plain update: the rotation is five writes, and two rotations running at
+// once used to interleave so that the second deleted the previous key the first had just
+// demoted. That key still signs live tokens, which /certs publishes and the token parser
+// falls back to, so destroying it retires every token it signed. OIDC Core 10.1.1 says the
+// JWK Set SHOULD retain recently decommissioned keys for a smooth transition, which is the
+// entire reason the previous state exists (#251).
+//
+// Undoing either half reopens it. Without the transaction, the loser's delete is already
+// committed by the time it discovers it lost; without the compare-and-set, it never
+// discovers it lost at all and writes over the winner's transition.
+type SigningKeyRotator struct {
+	database data.Database
+	// keySizeBits is unexported and has no setter, so no production caller can lower it.
+	// It exists as a field only because the replacement key is now generated on every
+	// path, including every refusal, and a 4096-bit generation costs about 300ms against
+	// 7ms at 1024: in-package tests set it directly.
+	keySizeBits int
+}
+
+func NewSigningKeyRotator(database data.Database) *SigningKeyRotator {
+	return &SigningKeyRotator{
+		database:    database,
+		keySizeBits: 4096,
+	}
+}
+
+// Rotate demotes the current key to previous, promotes the next key to current, and
+// creates a replacement next key, deleting the key that was previous. It returns
+// ErrKeySetIncomplete when there is no current or no next key, and ErrRotationInProgress
+// when another rotation won the race.
+//
+// The replacement key is generated before the transaction opens. That is deliberate: the
+// generation is the slow step by three orders of magnitude, and holding a transaction open
+// across it is what made the window wide enough to hit.
+func (r *SigningKeyRotator) Rotate() error {
+
+	newNextKey, err := r.generateNextKey()
+	if err != nil {
+		return err
+	}
+
+	tx, err := r.database.BeginTransaction()
+	if err != nil {
+		return err
+	}
+	defer r.database.RollbackTransaction(tx) //nolint:errcheck
+
+	allSigningKeys, err := r.database.GetAllSigningKeys(tx)
+	if err != nil {
+		return err
+	}
+
+	var currentKey *models.KeyPair
+	var nextKey *models.KeyPair
+	var previousKey *models.KeyPair
+	for i := range allSigningKeys {
+		kp := &allSigningKeys[i]
+		keyState, err := enums.KeyStateFromString(kp.State)
+		if err != nil {
+			return err
+		}
+		switch keyState {
+		case enums.KeyStateCurrent:
+			currentKey = kp
+		case enums.KeyStateNext:
+			nextKey = kp
+		case enums.KeyStatePrevious:
+			previousKey = kp
+		}
+	}
+
+	// The guard runs before any write. It used to run after the delete below, so a
+	// deployment with no next key lost its previous key and was then refused (#251).
+	if currentKey == nil || nextKey == nil {
+		return errors.WithStack(ErrKeySetIncomplete)
+	}
+
+	// The delete stays ahead of the demotion. Demoting while the old previous row is still
+	// there would put two rows in the previous state within one statement, which the unique
+	// index on key_pairs (state) refuses on every engine.
+	if previousKey != nil {
+		if err := r.database.DeleteKeyPair(tx, previousKey.Id); err != nil {
+			return err
+		}
+	}
+
+	moved, err := r.database.UpdateKeyPairState(tx, currentKey.Id,
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String())
+	if err != nil {
+		return err
+	}
+	if !moved {
+		return errors.WithStack(ErrRotationInProgress)
+	}
+
+	moved, err = r.database.UpdateKeyPairState(tx, nextKey.Id,
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String())
+	if err != nil {
+		return err
+	}
+	if !moved {
+		return errors.WithStack(ErrRotationInProgress)
+	}
+
+	if err := r.database.CreateKeyPair(tx, newNextKey); err != nil {
+		return err
+	}
+
+	return r.database.CommitTransaction(tx)
+}
+
+// generateNextKey builds the replacement key, already in the next state. It writes nothing.
+func (r *SigningKeyRotator) generateNextKey() (*models.KeyPair, error) {
+
+	privateKey, err := rsautil.GeneratePrivateKey(r.keySizeBits)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to generate a private key")
+	}
+	privateKeyPEM := rsautil.EncodePrivateKeyToPEM(privateKey)
+
+	// Encrypt the private key at rest (issue #83) before storing it.
+	privateKeyPEMEncrypted, err := encryption.EncryptData(string(privateKeyPEM))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to encrypt the private key")
+	}
+
+	publicKeyASN1DER, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal public key to PKIX")
+	}
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: publicKeyASN1DER})
+
+	kid := uuid.New().String()
+	publicKeyJWK, err := rsautil.MarshalRSAPublicKeyToJWK(&privateKey.PublicKey, kid)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal JWK")
+	}
+
+	return &models.KeyPair{
+		State:             enums.KeyStateNext.String(),
+		KeyIdentifier:     kid,
+		Type:              "RSA",
+		Algorithm:         "RS256",
+		PrivateKeyPEM:     privateKeyPEMEncrypted,
+		PublicKeyPEM:      publicKeyPEM,
+		PublicKeyASN1_DER: publicKeyASN1DER,
+		PublicKeyJWK:      publicKeyJWK,
+	}, nil
+}

--- a/src/core/oauth/signing_key_rotator_test.go
+++ b/src/core/oauth/signing_key_rotator_test.go
@@ -1,0 +1,390 @@
+package oauth
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	mocks_data "github.com/leodip/goiabada/core/data/mocks"
+	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests own seam 1 at the unit tier: the order of Rotate's statements, the guard
+// refusing before any write, both compare-and-set refusals, and that a failure at any step
+// commits nothing. They observe the rotator through mocks_data.Database, so what they can
+// see is which calls were made, with which arguments, in which order, and that nothing was
+// committed. What they cannot see is whether the resulting SQL composes against a real
+// engine, which is signing_key_rotator_test.go at the data tier, on all four.
+//
+// mocks_data.NewDatabase(t) fails the test on any call that was not set up, so "the delete
+// never ran" is asserted by the absence of an expectation as much as by AssertNotCalled.
+
+// rotatorTx is an opaque non-nil transaction. The rotator only ever hands it back to the
+// database, so its contents are irrelevant and its identity is the whole point: every call
+// below asserts it was passed this exact transaction rather than nil.
+var rotatorTx = &sql.Tx{}
+
+// newTestRotator builds a rotator at the smallest key size crypto/rsa will still generate.
+// The replacement key is generated on every path now, including every refusal, so at 4096
+// each of the cases below would pay about 300ms for material most of them never store.
+func newTestRotator(database *mocks_data.Database) *SigningKeyRotator {
+	rotator := NewSigningKeyRotator(database)
+	rotator.keySizeBits = 1024
+	return rotator
+}
+
+func keyPairInState(id int64, state string) models.KeyPair {
+	return models.KeyPair{
+		Id:            id,
+		State:         state,
+		KeyIdentifier: "kid-" + state,
+		Type:          "RSA",
+		Algorithm:     "RS256",
+	}
+}
+
+// fullKeySet is the ordinary starting point: one key in each state.
+func fullKeySet() []models.KeyPair {
+	return []models.KeyPair{
+		keyPairInState(1, enums.KeyStateCurrent.String()),
+		keyPairInState(2, enums.KeyStateNext.String()),
+		keyPairInState(3, enums.KeyStatePrevious.String()),
+	}
+}
+
+func TestSigningKeyRotator_Rotate_Success(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+
+	var calls []string
+	record := func(name string) func(mock.Arguments) {
+		return func(mock.Arguments) { calls = append(calls, name) }
+	}
+
+	database.On("BeginTransaction").Return(rotatorTx, nil).Once().
+		Run(record("BeginTransaction"))
+	database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once().
+		Run(record("GetAllSigningKeys"))
+	database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once().
+		Run(record("DeleteKeyPair"))
+	database.On("UpdateKeyPairState", rotatorTx, int64(1),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+		Return(true, nil).Once().Run(record("demote"))
+	database.On("UpdateKeyPairState", rotatorTx, int64(2),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).
+		Return(true, nil).Once().Run(record("promote"))
+
+	var created *models.KeyPair
+	database.On("CreateKeyPair", rotatorTx, mock.Anything).Return(nil).Once().
+		Run(func(args mock.Arguments) {
+			calls = append(calls, "CreateKeyPair")
+			created = args.Get(1).(*models.KeyPair)
+		})
+	database.On("CommitTransaction", rotatorTx).Return(nil).Once().
+		Run(record("CommitTransaction"))
+	database.On("RollbackTransaction", rotatorTx).Return(nil).Maybe()
+
+	err := newTestRotator(database).Rotate()
+	require.NoError(t, err)
+
+	// The delete precedes the demotion, which the unique index on key_pairs (state)
+	// requires: demoting while the old previous row is still there is two previous rows
+	// within one statement. The rest of the order is decision 1's.
+	assert.Equal(t, []string{
+		"BeginTransaction",
+		"GetAllSigningKeys",
+		"DeleteKeyPair",
+		"demote",
+		"promote",
+		"CreateKeyPair",
+		"CommitTransaction",
+	}, calls)
+
+	require.NotNil(t, created)
+	assert.Equal(t, enums.KeyStateNext.String(), created.State)
+	assert.Equal(t, "RSA", created.Type)
+	assert.Equal(t, "RS256", created.Algorithm)
+	assert.NotEmpty(t, created.KeyIdentifier)
+	assert.NotEmpty(t, created.PrivateKeyPEM)
+	assert.NotEmpty(t, created.PublicKeyPEM)
+	assert.NotEmpty(t, created.PublicKeyASN1_DER)
+	assert.NotEmpty(t, created.PublicKeyJWK)
+	// The private key is stored encrypted (#83), so the PEM header must not survive.
+	assert.NotContains(t, string(created.PrivateKeyPEM), "PRIVATE KEY")
+}
+
+// TestSigningKeyRotator_Rotate_SucceedsWithNoPreviousKey covers the first rotation after
+// seeding, where there is nothing to delete.
+func TestSigningKeyRotator_Rotate_SucceedsWithNoPreviousKey(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+
+	database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+	database.On("GetAllSigningKeys", rotatorTx).Return([]models.KeyPair{
+		keyPairInState(1, enums.KeyStateCurrent.String()),
+		keyPairInState(2, enums.KeyStateNext.String()),
+	}, nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(1),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).Return(true, nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(2),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).Return(true, nil).Once()
+	database.On("CreateKeyPair", rotatorTx, mock.Anything).Return(nil).Once()
+	database.On("CommitTransaction", rotatorTx).Return(nil).Once()
+	database.On("RollbackTransaction", rotatorTx).Return(nil).Maybe()
+
+	require.NoError(t, newTestRotator(database).Rotate())
+	database.AssertNotCalled(t, "DeleteKeyPair", mock.Anything, mock.Anything)
+}
+
+// TestSigningKeyRotator_Rotate_GuardRefusesBeforeAnyWrite is the defect this change exists
+// to fix. The guard used to run after the delete, so a deployment with no next key lost the
+// key that signs its live tokens and was then refused anyway (#251).
+func TestSigningKeyRotator_Rotate_GuardRefusesBeforeAnyWrite(t *testing.T) {
+	testCases := []struct {
+		name string
+		keys []models.KeyPair
+	}{
+		{
+			name: "no next key",
+			keys: []models.KeyPair{
+				keyPairInState(1, enums.KeyStateCurrent.String()),
+				keyPairInState(3, enums.KeyStatePrevious.String()),
+			},
+		},
+		{
+			name: "no current key",
+			keys: []models.KeyPair{
+				keyPairInState(2, enums.KeyStateNext.String()),
+				keyPairInState(3, enums.KeyStatePrevious.String()),
+			},
+		},
+		{
+			name: "no keys at all",
+			keys: []models.KeyPair{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			database := mocks_data.NewDatabase(t)
+			database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+			database.On("GetAllSigningKeys", rotatorTx).Return(tc.keys, nil).Once()
+			database.On("RollbackTransaction", rotatorTx).Return(nil).Once()
+
+			err := newTestRotator(database).Rotate()
+
+			assert.ErrorIs(t, err, ErrKeySetIncomplete)
+			// The previous key survives the refusal. This is the assertion the old
+			// handler could not have made.
+			database.AssertNotCalled(t, "DeleteKeyPair", mock.Anything, mock.Anything)
+			database.AssertNotCalled(t, "UpdateKeyPairState",
+				mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			database.AssertNotCalled(t, "CreateKeyPair", mock.Anything, mock.Anything)
+			database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+		})
+	}
+}
+
+// TestSigningKeyRotator_Rotate_LosesTheDemotion is the losing rotation: it read a snapshot
+// another rotation has already acted on, so its compare-and-set transitions nothing. The
+// delete it has already issued rolls back with it, which is the property the whole
+// transaction exists for.
+func TestSigningKeyRotator_Rotate_LosesTheDemotion(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+
+	database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+	database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+	database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(1),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+		Return(false, nil).Once()
+	database.On("RollbackTransaction", rotatorTx).Return(nil).Once()
+
+	err := newTestRotator(database).Rotate()
+
+	assert.ErrorIs(t, err, ErrRotationInProgress)
+	// A false compare-and-set is not an error, so the promotion must not have been
+	// attempted and nothing may commit.
+	database.AssertNotCalled(t, "UpdateKeyPairState", rotatorTx, int64(2),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String())
+	database.AssertNotCalled(t, "CreateKeyPair", mock.Anything, mock.Anything)
+	database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+}
+
+// TestSigningKeyRotator_Rotate_LosesThePromotion is the same refusal one statement later:
+// another rotation promoted the next key between this one's read and its own write.
+func TestSigningKeyRotator_Rotate_LosesThePromotion(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+
+	database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+	database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+	database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(1),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+		Return(true, nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(2),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).
+		Return(false, nil).Once()
+	database.On("RollbackTransaction", rotatorTx).Return(nil).Once()
+
+	err := newTestRotator(database).Rotate()
+
+	assert.ErrorIs(t, err, ErrRotationInProgress)
+	database.AssertNotCalled(t, "CreateKeyPair", mock.Anything, mock.Anything)
+	database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+}
+
+// TestSigningKeyRotator_Rotate_RollsBackOnFailureAtEveryStep injects a failure at each
+// database call in turn and asserts nothing commits. On postgres a failed statement aborts
+// the whole transaction and every later command in it is refused with SQLSTATE 25P02
+// (decision 4), which is why each of these must return at once rather than carry on.
+func TestSigningKeyRotator_Rotate_RollsBackOnFailureAtEveryStep(t *testing.T) {
+	failure := errors.New("engine failure")
+
+	testCases := []struct {
+		name  string
+		setUp func(database *mocks_data.Database)
+	}{
+		{
+			name: "GetAllSigningKeys",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).
+					Return([]models.KeyPair(nil), failure).Once()
+			},
+		},
+		{
+			name: "DeleteKeyPair",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+				database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(failure).Once()
+			},
+		},
+		{
+			name: "UpdateKeyPairState demote",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+				database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+				database.On("UpdateKeyPairState", rotatorTx, int64(1),
+					enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+					Return(false, failure).Once()
+			},
+		},
+		{
+			name: "UpdateKeyPairState promote",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+				database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+				database.On("UpdateKeyPairState", rotatorTx, int64(1),
+					enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+					Return(true, nil).Once()
+				database.On("UpdateKeyPairState", rotatorTx, int64(2),
+					enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).
+					Return(false, failure).Once()
+			},
+		},
+		{
+			name: "CreateKeyPair",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+				database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+				database.On("UpdateKeyPairState", rotatorTx, int64(1),
+					enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).
+					Return(true, nil).Once()
+				database.On("UpdateKeyPairState", rotatorTx, int64(2),
+					enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).
+					Return(true, nil).Once()
+				database.On("CreateKeyPair", rotatorTx, mock.Anything).Return(failure).Once()
+			},
+		},
+		{
+			name: "unparseable key state",
+			setUp: func(database *mocks_data.Database) {
+				database.On("GetAllSigningKeys", rotatorTx).Return([]models.KeyPair{
+					keyPairInState(1, "not-a-state"),
+				}, nil).Once()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			database := mocks_data.NewDatabase(t)
+			database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+			tc.setUp(database)
+			database.On("RollbackTransaction", rotatorTx).Return(nil).Once()
+
+			err := newTestRotator(database).Rotate()
+
+			require.Error(t, err)
+			// A genuine failure is neither refusal: the handler maps anything that is
+			// not a sentinel to a 500, and reporting a race that did not happen would
+			// tell an operator to stop retrying for the wrong reason.
+			assert.NotErrorIs(t, err, ErrRotationInProgress)
+			assert.NotErrorIs(t, err, ErrKeySetIncomplete)
+			database.AssertNotCalled(t, "CommitTransaction", mock.Anything)
+		})
+	}
+}
+
+// TestSigningKeyRotator_Rotate_CommitFailureIsReported closes the last step. There is
+// nothing to roll back that the deferred rollback will not handle, but the error must
+// still reach the caller rather than reporting a rotation that did not land.
+func TestSigningKeyRotator_Rotate_CommitFailureIsReported(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	failure := errors.New("commit failed")
+
+	database.On("BeginTransaction").Return(rotatorTx, nil).Once()
+	database.On("GetAllSigningKeys", rotatorTx).Return(fullKeySet(), nil).Once()
+	database.On("DeleteKeyPair", rotatorTx, int64(3)).Return(nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(1),
+		enums.KeyStateCurrent.String(), enums.KeyStatePrevious.String()).Return(true, nil).Once()
+	database.On("UpdateKeyPairState", rotatorTx, int64(2),
+		enums.KeyStateNext.String(), enums.KeyStateCurrent.String()).Return(true, nil).Once()
+	database.On("CreateKeyPair", rotatorTx, mock.Anything).Return(nil).Once()
+	database.On("CommitTransaction", rotatorTx).Return(failure).Once()
+	database.On("RollbackTransaction", rotatorTx).Return(nil).Once()
+
+	assert.ErrorIs(t, newTestRotator(database).Rotate(), failure)
+}
+
+// TestSigningKeyRotator_Rotate_BeginTransactionFailureIsReported also pins that the key
+// material is generated before the transaction opens: nothing else is called.
+func TestSigningKeyRotator_Rotate_BeginTransactionFailureIsReported(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+	failure := errors.New("cannot begin")
+
+	database.On("BeginTransaction").Return((*sql.Tx)(nil), failure).Once()
+
+	assert.ErrorIs(t, newTestRotator(database).Rotate(), failure)
+	database.AssertNotCalled(t, "RollbackTransaction", mock.Anything)
+	database.AssertNotCalled(t, "GetAllSigningKeys", mock.Anything)
+}
+
+// TestSigningKeyRotator_Rotate_GeneratesTheKeyBeforeOpeningTheTransaction is the only
+// direct observation of §4C's first ordering rule. A key size crypto/rsa refuses makes the
+// generation fail, and BeginTransaction is then never reached: move the generation inside
+// the transaction and this test sees a transaction opened for a rotation that could never
+// have written anything. The rule exists because a 4096-bit generation is the slow step by
+// three orders of magnitude, and holding a transaction open across it is what made the
+// window wide enough to hit (#251).
+func TestSigningKeyRotator_Rotate_GeneratesTheKeyBeforeOpeningTheTransaction(t *testing.T) {
+	database := mocks_data.NewDatabase(t)
+
+	rotator := NewSigningKeyRotator(database)
+	rotator.keySizeBits = 512 // crypto/rsa refuses anything under 1024
+
+	err := rotator.Rotate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to generate a private key")
+	database.AssertNotCalled(t, "BeginTransaction")
+}
+
+// TestNewSigningKeyRotator_UsesFourThousandNinetySixBits pins the production key size,
+// which no exported surface carries. The tests above all lower it, so without this nothing
+// would notice it changing.
+func TestNewSigningKeyRotator_UsesFourThousandNinetySixBits(t *testing.T) {
+	assert.Equal(t, 4096, NewSigningKeyRotator(mocks_data.NewDatabase(t)).keySizeBits)
+}


### PR DESCRIPTION
Fixes #251.

## What this is for

Rotating a signing key is five statements in one handler, each with its own connection and none of
them in a transaction. Two of them are destructive and they run in the wrong order: the existing
`previous` key is **deleted before** the check that a `current` and a `next` key exist at all, so a
deployment missing its `next` row loses the key that signed every token still in flight and is then
refused. Between the promotion of `next` to `current` and the insert of a replacement sits a
4096-bit RSA key generation, seconds wide, and a failure anywhere in the sequence commits whatever
ran before it. A failure at the promotion leaves the deployment with **no row in the `current`
state**, which eight call sites dereference without a nil check, so the server panics on every token
it tries to sign or validate. The admin API is bearer-authenticated and one of those sites is on the
token-validation path, so an operator in that state cannot use the product to repair it.

OpenID Connect Core 1.0 §10.1.1 says the JWK Set at `jwks_uri` "SHOULD retain recently decommissioned
signing keys for a reasonable period of time to facilitate a smooth transition". The `previous` state
exists to satisfy that, and the defect destroys the very key it is retaining.

## The rule this establishes

**Every refusal happens before the transaction commits, so a losing rotation's delete of the previous
key rolls back with it.** The whole transition runs in one transaction, each state change written as
a conditional UPDATE that asserts the state it read and reports through `RowsAffected()` whether it
was the call that made the transition. A second concurrent rotation either succeeds after the first
or is refused having written nothing. The prerequisite check runs before any write. Key generation
moves outside the transaction, so the slow operation is no longer in the critical section.

Alongside it, `GetCurrentSigningKey` returns an error rather than `(nil, nil)` when no key is
current. All eight call sites already check `err` and return, so all eight stop panicking without
being touched, and a ninth cannot be added unguarded.

## What has landed

### Stage 1: the compare-and-set primitive and the current-key contract
`0dc1af61`

Two data-layer primitives, both additive. Nothing calls either one yet.

`UpdateKeyPairState(tx, keyPairId, fromState, toState) (bool, error)` moves one key from an
expected state to a new one and reports whether this call made the transition. It follows
`MarkCodeAsUsed` statement for statement: a conditional `UPDATE` whose `WHERE` carries the id
**and** the from-state, with `RowsAffected() == 1` as the answer. That predicate is the whole
point. Without it two concurrent rotations both write the snapshot they read, and the loser
deletes the previous key the winner had just demoted, retiring every token that key had signed.
A `false` return is not an error, so it leaves the caller's transaction usable, which is what
will let the losing rotation roll its own delete back in stage 2. A zero id is an error rather
than an unfiltered update. Implemented once in `commondb`, with a one-line delegating wrapper in
each of the four dialects, and the `Database` mock regenerated.

`GetCurrentSigningKey` now returns an error when no key is in the `current` state, instead of the
`(nil, nil)` this codebase returns for a lookup that may legitimately miss. All eight production
call sites dereference the result to read key material, so a nil pair was a nil-pointer panic at
each of them rather than a diagnosable failure, and a ninth site could be added unguarded. All
eight already check `err` and return, so all eight became correct without being edited; each was
re-read to confirm none dereferences first, and the 39 mock stubs across the suite were checked
to return a key pair or an error, never `(nil, nil)`.

**Tiers:** unit 3563 pass / 0 fail. Data 1227 pass / 0 fail on **all four engines** locally
(mysql, postgres, mssql, sqlite). Integration is not applicable: no handler, route or schema
moved and nothing calls the new code, so there is no endpoint through which to reach it.

**Mutations:** five, all caught. The one worth naming serialises the new concurrency case's two
goroutines, and the case fails as it should, because the loser then returns in 215µs against the
100ms it requires. Without that check, "exactly one winner" is satisfied by two calls run in
sequence, and the concurrency case would prove nothing about contention.

### Stage 2: the rotator
`05243dd8`

`oauth.SigningKeyRotator` in `src/core/oauth/signing_key_rotator.go`, holding the whole transition
in one transaction. Nothing calls it yet; stage 3 rewires the endpoint onto it.

`Rotate()` generates the replacement key, opens a transaction, reads and classifies the key set
inside it, refuses if `current` or `next` is missing, deletes the previous row, compare-and-sets
the demotion and then the promotion, inserts the new `next`, and commits. **Every refusal happens
before the commit**, so a rotation that cannot proceed leaves the key set exactly as it found it.
That is the whole defect: the delete used to be committed the moment it ran and the refusal
arrived afterwards.

The guard now runs before any write. Reversed, as it was, a deployment with no `next` key lost its
`previous` key and was then refused anyway. That key signed every token still in flight: `/certs`
publishes it and the token parser falls back to it, so deleting it retires those tokens at once,
which is what OIDC Core 10.1.1 asks a JWK Set not to do when it says recently decommissioned keys
SHOULD be retained for a smooth transition.

Two more orderings are load bearing and each is commented at the line it governs. The key material
is generated **before** the transaction opens, because a 4096-bit generation is the slow step by
three orders of magnitude and holding a transaction across it is what made the window wide enough
to hit. The `previous` row is deleted **before** the current one is demoted, since demoting first
puts two rows in the `previous` state within one statement, which stage 4's constraint will refuse
on every engine. Any error returns at once rather than continuing to the next statement: on
postgres a failed statement aborts the whole transaction and every later command in it is refused
with SQLSTATE 25P02. A compare-and-set reporting no rows is not an error, which is why the two
refusals can still roll back cleanly.

Two sentinels, `ErrRotationInProgress` and `ErrKeySetIncomplete`, are what stage 3 maps to a 409
and a 500. Anything else is a genuine engine or crypto failure.

**Tiers:** unit 3582 pass / 0 fail. Data 1655 pass / 0 fail on **all four engines** locally
(mysql, postgres, mssql, sqlite), covering one full rotation against real SQL and the issue's own
"refuses without deleting the previous key" case. Integration is not applicable: nothing routes to
the rotator yet, so no endpoint can reach it.

**Mutations:** six, all caught. The one worth naming reintroduces the defect verbatim by moving
the guard back below the delete; the guard cases fail on it because each asserts the delete never
ran, not merely that the refusal happened. Another moves key generation inside the transaction,
caught by a case that makes generation fail deterministically (`crypto/rsa` refuses a 512-bit key)
and then asserts the transaction was never opened.

**Not asserted, deliberately:** two goroutines calling `Rotate()` concurrently. Generation now runs
before the transaction and takes about 300ms with wide variance, so the two may not overlap, and
when they do not both rotations succeed, which is correct behaviour that would fail such a test.
The race is covered where it is deterministic, at stage 1's data-tier concurrency case, and both
losing branches are driven directly at the unit tier.

### Stage 3: the handler, the admin console, the documented refusal

Landed in `774b3223`.

`HandleAPISettingsKeysRotatePost` loses the five unsynchronised writes and becomes a call to
`oauth.SigningKeyRotator.Rotate()` plus a four-row mapping: `nil` audits and answers 200 as
before, `ErrRotationInProgress` is **409 `ROTATION_IN_PROGRESS`**, `ErrKeySetIncomplete` is 500
`KEY_SET_INCOMPLETE`, anything else is 500 `INTERNAL_ERROR`. 409 rather than 200 for the loser of
a race because it rotated nothing: reporting success would announce one rotation twice and invite
a retry that burns a 4096-bit key generation and rotates a second time. The signature is unchanged
and the rotator is constructed in the factory body, so `routes.go` is untouched.

The admin console makes that legible. `HandleAPIErrorJson` forwards 409 alongside 400, and the
rotate handler routes through it instead of calling `JsonError` directly, so the operator reads
"Another key rotation is in progress" rather than "An unexpected server error has occurred" with
a request id. Three lines of behaviour, no new catalog strings: the API's English description is
surfaced verbatim, which is the position #122 already settled for that helper.

Both documentation surfaces name the 409. `site/src/content/docs/integration/rest-api.mdx` gains a
line saying not to retry it; `src/authserver/web/openapi.yaml` gains a `'409'` on
`rotateSettingsKeys`, which declared only 200 and 401. That file is embedded and served at
`GET /openapi.yaml`, so it is a published contract and a generated client would not have known the
status exists.

**Tests.** The endpoint had no unit coverage at all before this, which is a large part of how the
defect survived since v0.7. `handler_api_settings_keys_test.go` adds 4 cases driving the real
rotator over a mocked database: the mapping, the audit on success and only on success, and by
omission that neither refusal reaches `DeleteKeyPair`, `CreateKeyPair` or `CommitTransaction`, the
last of which is the old defect stated as a test. `api_error_helper_test.go` adds 3 cases and is
the first behavioural test in `src/adminconsole/internal/handlers`; it pins the 400 forwarding
alongside the new 409, so widening that condition cannot silently replace #122's behaviour rather
than join it.

Locally: unit 3589 pass, data 1655 pass on all four engines, integration 1268 pass on sqlite,
0 failures. Five mutations against the new tests, all caught, including `case err == nil:` →
`case true:`, which is what proves the audit entry is written on success and nowhere else.

One deviation: `src/adminconsole/go.mod` gains `github.com/stretchr/objx // indirect`. Using
`testify/mock` in that module for the first time requires it. `go.sum` already carried it and did
not change, so nothing new entered the dependency graph.

### Stage 4: the unique constraint

Landed in `ac4b168c`. Schema only: no production Go changed, because the Go that has to respect the
constraint already did as of stage 2.

Migration **000030** on all four engines adds `idx_key_pairs_state`, a plain `UNIQUE (state)` on
`key_pairs`, preceded by a sweep that keeps the highest `id` per state. Every reader already assumed
one row per state and nothing enforced it: `GetCurrentSigningKey` is a bare `WHERE state = 'current'`
with no `ORDER BY` and no `LIMIT`, so with two `current` rows it returns whichever the driver yields
first; `/certs` assigns `previousKey` in a loop and publishes only the last duplicate it sees; the
admin console offers to revoke "the previous key", singular. This is what makes that single row
provable rather than arbitrary, which is the same defect #249 describes on two other tables.

The sweep exists because existing deployments may already carry duplicates: until stage 2, two
concurrent rotations could both insert a new `next` row. `MAX(id)` is the newest on every engine
(sqlite AUTOINCREMENT, mysql AUTO_INCREMENT, postgres sequence, mssql IDENTITY). The derived table in
the `DELETE` is required for MySQL, which otherwise refuses a subquery naming the table being deleted
from. Sweeping rather than failing on a duplicate is deliberate: a failed migration stops startup and
leaves the version dirty, and a deployment that cannot start cannot be repaired through the product.
Extra `next` rows are the only duplicate the defect can actually produce, and a `next` key has signed
nothing, so in the reachable case the sweep destroys nothing anyone holds a token from. The down
migration drops the index and says in the file that it cannot restore the swept rows. The four
`schema.sql` snapshots are updated in the same commit.

**Tests.** A new migration test runs against an isolated database per dialect: seed 2 `current`, 3
`next` and 2 `previous` at 000029, apply 000030, and assert one row survives per state and that it is
the **highest** id of that state, which is what says `MAX(id)` rather than `MIN(id)`. The index's
shape is read from each engine's catalog through the existing `describeIndex` helper (unique,
covering exactly `[state]`), with `idx_state` used as a polarity control because MySQL reports
uniqueness inverted and an assertion of "unique" would otherwise pass on an engine whose flag was
being read backwards. It then attempts a duplicate insert, because the catalog reporting a shape and
the engine enforcing it are two different claims, and exercises the down/up round trip.
`unique_constraint_test.go` gains `TestUnique_KeyPairState`, taking that file from eleven constraints
to twelve.

Three existing tests are brought under the constraint. `createTestKeyPair` stamped every row
`current` and could no longer be called twice, so it collapses into `createKeyPairInState`, which
clears the destination first; `TestGetAllSigningKeys` held two `current` rows and now holds one
`current` and one `next`, still exercising what the method is for; `TestUpdateKeyPair` moved its
fixture into `previous` without clearing it, which the index refuses whenever a `previous` row
survives in the never-dropped shared test database, and it now clears first, matching the ordering
production observes.

Locally: unit 3589 pass, data 1243 pass on all four engines, integration 957 pass on sqlite, 0
failures. Stage 1's and stage 2's data-tier cases were re-run under the index, since this is the
first moment it could falsify them, and none needed a change. Four mutations of the migration files
were all caught: `MAX` to `MIN`, `UNIQUE` dropped, the sweep neutered, and the down migration
dropping the wrong index.

### Stage 5: the spec reconciled with the handlers, and the lint that keeps it there

Landed in `97cb74df`. The follow-up this run left behind, and everything the same sweep turned up
beside it. No production Go changed: this is the published contract catching up with the code, plus
the instrument that stops it falling behind again.

`src/authserver/web/openapi.yaml` is embedded by `web/embed_fs.go` and served at `GET /openapi.yaml`,
so it is what a caller generates a client from rather than a README. Nothing held it to what the
handlers do. Reconciling its 96 operations against the 106 routes `routes.go` registers moved the
declared statuses like this:

| Status | Before | After | Why |
|---|---|---|---|
| `500` | 0 | 96 | every handler can fail on storage and none said so |
| `400` | 44 | 81 | malformed ids and validation paths |
| `404` | 59 | 72 | 15 added, 2 removed |
| `409` | 1 | 2 | the follow-up: `createUser` |
| `403` | 0 | 2 | the two account ownership checks |
| `201` | 6 | 7 | `addGroupMember` was documented as 200 |

The follow-up itself is the `409` row. `HandleAPIUserCreatePost` answers a duplicate email with 409
`EMAIL_ALREADY_EXISTS` at two sites, one for the email field and one for the derived username path,
and `createUser` declared 201, 400 and 401 only, so the single failure a caller creating users hits
routinely reached a generated client as an unmodelled error. It is now written out in place, naming
the code, alongside a line in `site/src/content/docs/integration/rest-api.mdx`.

Four things the sweep found are worth naming on their own.

**`addGroupMember` answers 201 and the spec said 200.** A client checking for 200 read a successful
add as a failure. The spec follows the handler, since the handler is what is deployed.

**Two operations declared a 404 no handler can produce.** `deleteSettingsKey` answers 400 with
`VALIDATION_ERROR` for an id matching no key, and `getResourcePermissions` never looks its resource
up at all, so an unknown id comes back as 200 with an empty list. Both now say so where it happens
rather than promising a branch that never runs. That the second is arguably a handler defect is not
this change's to settle: the spec's job is to describe what the server does.

**Three 500s are not the JSON envelope.** `getUserConsents`, `deleteUserConsent` and
`getClientLogoImage` fail through `httpHelper.InternalServerError`, which renders the shared HTML
error page. Documenting them with the JSON `ErrorResponse` the other 93 use would have been a false
statement, so those three are written out with `text/html` and say why.

**`rotateSettingsKeys` gained its own 500.** Stage 3 documented this endpoint's 409 and not the 500
beside it. It now names `KEY_SET_INCOMPLETE`, which is an operator problem a retry will not clear,
apart from a transient `INTERNAL_ERROR`, and says nothing was rotated either way.

**The lint.** `src/authserver/internal/server/openapi_contract_lint_test.go` parses `routes.go`, the
non-test handler sources and the embedded spec, and holds them to each other in both directions:
every status a handler can write is declared, every failure declared is one a handler can write, 429
appears exactly where a rate limiter does and nowhere else, and every route under `/api/v1` is either
documented or named in `knownUndocumentedRoutes` with the reason it is not. Eleven routes are on that
list, all needing schemas the document does not have yet (image bytes, multipart uploads, the audit
log query surface); the list is exact in both directions, so documenting one forces its line to go.
Two further tests hold up the ground the first three stand on: that `writeJSONError` is always passed
an `http.Status` constant, without which the lexical scan would have a blind spot it could not see,
and that every `$ref` into `components/responses` resolves and every shared response is used.

The scan is lexical, and the file says so at the top along with what that costs: it reads the
statuses a handler mentions rather than the ones it can be driven to return, so an unreachable branch
is still documented. That is the conservative direction, since a caller told about a failure that
cannot happen loses nothing.

**Tiers:** modules 1102 pass / 0 fail. Data 1247 pass / 0 fail on **all four engines** locally.
Integration 957 pass / 0 fail on sqlite. The data tier is not affected by this stage and was run
anyway, since the stage is the first to touch a file the whole suite embeds.

**Mutations:** sixteen, fourteen caught. The two that survived are accounted for rather than
excused. Dropping the `writeValidationError` to 400 rule changes no result today, because every
handler that calls it also names `http.StatusBadRequest` somewhere else; the rule is kept for the
first handler that validates and does nothing else, and the comment at the line says exactly this.
Restricting the forward check to failures also survives on its own, because the 2xx defect it would
hide is already fixed; running that mutation together with reverting `addGroupMember` to 200 lets
that defect through, which is what proves the branch is load bearing. The fourteen caught include
reintroducing the phantom 404, misspelling a shared `$ref` target, mangling the route prefix,
pointing the handler walk at a tree with no handlers, and removing each of the three extraction
rules that let the scan see a status no constant is written for.

## Tests

Four tiers, and it matters which of them ran where.

**Local, at the final tree `97cb74df`:** `--type modules` 1102 passed / 0 failed, the data tier 1247
passed / 0 failed across **sqlite, mysql, postgres and mssql**, and integration 957 passed / 0 failed
on sqlite. The module count moved from 1097 by the five tests stage 5 adds. Per-stage counts are in
each stage's section above; they were re-run at every gate rather than once at the end.

**Integration ran on sqlite locally**, at the stages that changed a handler, route or schema. Stages
1, 2 and the review's fix round did not, and each says so with its reason: nothing routed to the new
code yet, or only test files moved, so there was no endpoint through which to reach it.

**The four-engine data and integration result is the check suite's**, not a local claim. Green on
`97cb74df`, every job:
[run 32659461759](https://github.com/leodip/goiabada/actions/runs/32659461759), and green on
`aed37751` before stage 5 landed:
[run 32656041739](https://github.com/leodip/goiabada/actions/runs/32656041739). That covers
`Tests / {sqlite,mysql,postgres,mssql}`, `Unit / {core,authserver,adminconsole}`, `Build validation`,
`Lint`, `Vulnerabilities` and `Versions`, the last three of which nothing local runs. Every stage's
suite concluded green on its own commit as well.

**Thirty-six mutations were run against the new tests across the five stages, and thirty-four were
caught.** The ones worth naming: reintroducing the defect verbatim by moving the prerequisite guard
back below the delete; moving key generation inside the transaction; `MAX(id)` to `MIN(id)` in the
sweep; and `case err == nil:` to `case true:`, which is what proves the audit entry is written on a
successful rotation and nowhere else. The two survivors are both stage 5's and both are explained in
its section rather than left as a gap. A test that cannot fail transfers confidence it has not
earned, and this is the evidence these can.

### Review

Reviewed by `gpt-5.6-sol` at effort `xhigh`, 2 rounds over the whole branch, against a maximum of 4.
No stage was reviewed on its own: the whole change was read once, after the last stage landed.

| Round | Findings | Blocking | Outcome |
|---|---|---|---|
| 1 | 2, both significant | 0 | both fixed, `aed37751` |
| 2 | 0 | 0 | **clean** |

- **significant, quality:** the admin console suite did not prove the rotate handler sends its 409
  through `HandleAPIErrorJson`; swapping it back for a direct `JsonError` left the suite green, which
  would have put `ROTATION_IN_PROGRESS` back behind a generic 500. Fixed in `aed37751`: new
  `handler_admin_settings_keys_test.go`, asserting through the real encoder over four statuses. The
  mutation survived before and is caught after.
- **significant, quality:** none of the seven compare-and-set data cases made the statement itself
  fail, so swallowing an `ExecSql` error as `false, nil` survived them all, which would report a
  storage failure to the operator as "another rotation is in progress" — a rotation that never
  happened, described as one that did. Fixed in `aed37751`:
  `TestUpdateKeyPairState_StorageFailureIsAnError`, deterministic on all four engines via
  `sql.ErrTxDone`. The mutation survived before and is caught after.

Nothing was raised on conformance or security in either round, and no finding contested any of the
eight settled decisions. Round 2 ran five mutations of its own and caught all five, which is what
separates a clean verdict from an unexamined one.

Full account, with the evidence, the `unchecked` lists and the tree hashes, in
[this comment](https://github.com/leodip/goiabada/pull/254#issuecomment-5387635844).

## Deviations

One, and it is a build requirement rather than a design change. `src/adminconsole/go.mod` gained
`github.com/stretchr/objx v0.5.3 // indirect`: using `testify/mock` in that module for the first time
requires it. `go.sum` already carried it and did not change, so nothing new entered the dependency
graph. Without the line `go vet` and `go test` in that module refuse with "updates to go.mod needed".

Stage 5 brings a second of the same kind. `src/authserver/go.mod` gained `gopkg.in/yaml.v3 v3.0.1`
as a direct dependency: the lint parses the embedded spec with it rather than with a regular
expression over the document's indentation. It was already in the file as indirect and `go.sum` did
not change, so nothing new entered the dependency graph there either.

Everything else landed as agreed. No decision was opened by the run, no stage deviated from its plan,
and no count the plan asked to be recounted disagreed with the agreement.

## For the release notes

**Migration 000030 deletes duplicate `key_pairs` rows, and cannot restore them.** Before applying the
`UNIQUE (state)` index, it sweeps `key_pairs` down to the highest `id` per state. A deployment that
was bitten by this defect may carry extras, because until this change two concurrent rotations could
both insert a new `next` row. The sweep keeps the newest of each state on every engine, and the only
duplicate the defect can actually produce is an extra `next` key, which has signed nothing, so in the
reachable case nothing anyone holds a token from is destroyed. Sweeping rather than failing is
deliberate: a failed migration stops startup and leaves the version dirty, and a deployment that
cannot start cannot be repaired through the product. The down migration drops the index and says in
the file that it cannot bring the swept rows back.

**`POST /api/v1/admin/settings/keys/rotate` can now answer 409.** It previously answered 200 or 500.
A caller that loses a race with a concurrent rotation now gets 409 `ROTATION_IN_PROGRESS`, and
**should not retry**: the rotation it conflicted with already happened, so a retry burns a 4096-bit
key generation and rotates a second time. Existing scripts and generated clients that treat any
non-2xx as a transient failure worth retrying are the ones to check.

**`POST /api/v1/admin/groups/{id}/members` has always answered 201, and `openapi.yaml` said 200.**
The server's behaviour is unchanged; the document was wrong. A generated client or a script built
from the old spec that treats anything other than 200 as a failure has been reading a successful add
as one, and is the thing to check.

**The spec now declares the failures it always had.** 500 on every operation, 400 and 404 where the
handlers answer them, 403 on the two account endpoints that check ownership, and 409
`EMAIL_ALREADY_EXISTS` on `POST /api/v1/admin/users/create`. No behaviour changed with any of them:
these are statuses the server already returned and the contract did not mention, so a regenerated
client gains branches rather than losing any.

Nothing else asks an operator to do anything. Atomicity, the transaction and the constraint are
invisible to any caller that is not racing itself.

## The closing comments

- [Decisions](https://github.com/leodip/goiabada/pull/254#issuecomment-5387629707) — all eight
  settled before the run, none deferred, none raised by the run.
- [Follow-ups](https://github.com/leodip/goiabada/pull/254#issuecomment-5387631470) — one was
  drafted, and it was solved here in stage 5 rather than filed. Two candidates were considered and
  rejected on purpose.
- [The code review](https://github.com/leodip/goiabada/pull/254#issuecomment-5387635844) — both
  rounds in full, every finding with its evidence and disposition, and all nine `unchecked` entries
  answered.

## Status

**Complete.** All five stages landed, the check suite is green on `97cb74df`, and stages 1 to 4 were
reviewed over two rounds ending clean. The defect is fixed: every refusal now happens before the
transaction commits, so a losing rotation's delete of the previous key rolls back with it, the
prerequisite check runs before any write, and the invariant the transition relies on is enforced by
the database rather than only by its one writer. `GetCurrentSigningKey` returns an error where it
used to return a nil pair into eight unguarded dereferences.

Stage 5 landed after that review and has not been through it. It changes no production Go: the
published contract now names every status the handlers answer, and a lint holds the two together.

Ready for review.

