### PR TITLE
fix(core): the four database engines build the same schema

### DIFF
--- a/src/authserver/tests/data/migration_000036_refresh_tokens_client_id_test.go
+++ b/src/authserver/tests/data/migration_000036_refresh_tokens_client_id_test.go
@@ -1,0 +1,91 @@
+package datatests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshTokensClientIdIndex000036 is the index SQLite was missing, and the name the
+// other three engines have carried since their own 000011.
+const refreshTokensClientIdIndex000036 = "idx_refresh_tokens_client_id"
+
+// TestMigration000036_RefreshTokensClientIdIndex is goal 1 of #282 stated as a test:
+// refresh_tokens(client_id) is indexed on all four engines. It runs against an ISOLATED
+// database of the configured dialect (see migration_testdb_helper.go).
+//
+// The migration file exists on SQLite alone, because the other three already have the
+// index, so this test takes two shapes. On SQLite it is the usual migration shape: absent
+// at 000035, present at 000036, gone again after the down, back after a re-apply. On the
+// other three it asserts the state at 000035 and never calls Migrate past it, since
+// Migrate refuses a target version the engine's source does not carry.
+//
+// Two assertions are worth explaining:
+//
+//  1. The control. idx_refresh_token_jti is UNIQUE on all four engines, so reading it as
+//     unique here is what makes "the client_id index is non-unique" mean something: each
+//     catalog reports uniqueness differently and MySQL reports it inverted, so a
+//     non-unique reading would otherwise pass on an engine whose flag was being read
+//     backwards. This is the polarity guard migration_000030 established, run in the
+//     opposite direction.
+//  2. The key columns, not just the name. An index built on the wrong column would pass a
+//     name check while doing nothing for the scan this exists to remove.
+//
+// Stage 3's rebuild of refresh_tokens has to recreate this index; that is what makes this
+// test worth keeping rather than a one-off check of the migration.
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestMigration000036_RefreshTokensClientIdIndex
+func TestMigration000036_RefreshTokensClientIdIndex(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(35), "migrate to 000035")
+
+	// 1. Control.
+	control := describeIndex(t, h, "refresh_tokens", "idx_refresh_token_jti")
+	require.True(t, control.Exists, "control index idx_refresh_token_jti must exist at 000035")
+	require.True(t, control.Unique,
+		"control index idx_refresh_token_jti is UNIQUE on every engine; reading it as non-unique means the uniqueness flag is being read backwards")
+
+	if !isSQLite000036() {
+		assertRefreshTokensClientIdIndex000036(t, h, "at 000035")
+		return
+	}
+
+	require.False(t, describeIndex(t, h, "refresh_tokens", refreshTokensClientIdIndex000036).Exists,
+		"%s must not exist on SQLite at 000035: that absence is the divergence #282 reports",
+		refreshTokensClientIdIndex000036)
+
+	require.NoError(t, h.Migrator.Migrate(36), "apply 000036")
+	assertRefreshTokensClientIdIndex000036(t, h, "after apply")
+
+	require.NoError(t, h.Migrator.Migrate(35), "roll back 000036")
+	assert.False(t, describeIndex(t, h, "refresh_tokens", refreshTokensClientIdIndex000036).Exists,
+		"%s must be gone after rolling back to 000035", refreshTokensClientIdIndex000036)
+
+	require.NoError(t, h.Migrator.Migrate(36), "re-apply 000036")
+	assertRefreshTokensClientIdIndex000036(t, h, "after down/up round trip")
+}
+
+// assertRefreshTokensClientIdIndex000036 checks the index's shape in the catalog: present,
+// covering exactly client_id, and not unique. Not unique matters as much as present, since
+// a client holds many refresh tokens and a unique index here would refuse the second one.
+func assertRefreshTokensClientIdIndex000036(t *testing.T, h *isolatedDB, phase string) {
+	t.Helper()
+
+	shape := describeIndex(t, h, "refresh_tokens", refreshTokensClientIdIndex000036)
+
+	require.Truef(t, shape.Exists, "[%s] %s is missing on %s",
+		phase, refreshTokensClientIdIndex000036, dbType())
+	assert.Equalf(t, []string{"client_id"}, shape.Columns,
+		"[%s] %s must cover exactly client_id", phase, refreshTokensClientIdIndex000036)
+	assert.Falsef(t, shape.Unique,
+		"[%s] %s must NOT be unique: a client holds many refresh tokens",
+		phase, refreshTokensClientIdIndex000036)
+}
+
+func isSQLite000036() bool {
+	return dbType() == "" || dbType() == "sqlite"
+}

--- a/src/authserver/tests/data/migration_000037_audit_logs_details_default_test.go
+++ b/src/authserver/tests/data/migration_000037_audit_logs_details_default_test.go
@@ -1,0 +1,113 @@
+package datatests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration000037_AuditLogsDetailsDefault is goal 2 of #282 stated as a test:
+// audit_logs.details defaults to '{}' on all four engines. It runs against an ISOLATED
+// database of the configured dialect (see migration_testdb_helper.go).
+//
+// The migration file exists on MySQL alone, which was the engine without the default, so
+// this test takes two shapes: MySQL goes 000035 to 000037 and back, and the other three
+// assert the state they already have at 000035 without calling Migrate past it, since
+// Migrate refuses a target version the engine's source does not carry.
+//
+// What is asserted, and what deliberately is not:
+//
+//   - The default's EFFECT: insert a row naming every column except details, read details
+//     back, expect {}. §5 of the agreement rejects asserting the recorded text, because
+//     MySQL can only carry this default as an expression and stamps it with the DDL
+//     connection's charset, so information_schema reports _utf8mb4'{}' where the other
+//     three report '{}'. An assertion on the text would encode a driver setting rather
+//     than a schema fact.
+//   - The before state as "omission cannot yield {}", capturing both the error and the
+//     value rather than choosing between them. Under STRICT_TRANS_TABLES, which the dev
+//     container's MySQL sets globally and the Go DSN does not override, the insert is
+//     refused outright with ERROR 1364; a non-strict server would store an empty string.
+//     Either way it is not {}, and that is the whole claim.
+//   - The catalog's Default is checked only for EMPTINESS on MySQL, which is the one thing
+//     about it that is engine-independent. That is what distinguishes "the migration added
+//     a default" from "some other write happened to put {} in the column".
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestMigration000037_AuditLogsDetailsDefault
+func TestMigration000037_AuditLogsDetailsDefault(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(35), "migrate to 000035")
+
+	if dbType() != "mysql" {
+		details, err := insertAuditLogWithoutDetails000037(t, h, "already-defaulted")
+		require.NoErrorf(t, err, "on %s, audit_logs.details already carries a default at 000035", dbType())
+		assert.Equalf(t, "{}", details,
+			"on %s, omitting details at 000035 must already yield {}", dbType())
+		return
+	}
+
+	// Before: no default in the catalog, and omission cannot produce {}.
+	assert.Empty(t, dumpTable(t, h, "audit_logs").column(t, "details").Default,
+		"MySQL's audit_logs.details must carry no default at 000035: that absence is the divergence #282 reports")
+	assertDetailsOmissionCannotYieldEmptyObject000037(t, h, "at 000035", "before-migration")
+
+	require.NoError(t, h.Migrator.Migrate(37), "apply 000037")
+
+	assert.NotEmpty(t, dumpTable(t, h, "audit_logs").column(t, "details").Default,
+		"audit_logs.details must carry a default after 000037; its recorded TEXT is deliberately not asserted")
+	assertDetailsOmissionYieldsEmptyObject000037(t, h, "after apply", "after-migration")
+
+	require.NoError(t, h.Migrator.Migrate(35), "roll back 000037")
+	assert.Empty(t, dumpTable(t, h, "audit_logs").column(t, "details").Default,
+		"the default must be gone after rolling back to 000035")
+	assertDetailsOmissionCannotYieldEmptyObject000037(t, h, "after roll back", "after-down")
+
+	require.NoError(t, h.Migrator.Migrate(37), "re-apply 000037")
+	assertDetailsOmissionYieldsEmptyObject000037(t, h, "after down/up round trip", "after-reapply")
+}
+
+func assertDetailsOmissionYieldsEmptyObject000037(t *testing.T, h *isolatedDB, phase, event string) {
+	t.Helper()
+
+	details, err := insertAuditLogWithoutDetails000037(t, h, event)
+	require.NoErrorf(t, err, "[%s] an insert omitting details must be accepted once the default exists", phase)
+	assert.Equalf(t, "{}", details, "[%s] omitting details must yield {}", phase)
+}
+
+func assertDetailsOmissionCannotYieldEmptyObject000037(t *testing.T, h *isolatedDB, phase, event string) {
+	t.Helper()
+
+	details, err := insertAuditLogWithoutDetails000037(t, h, event)
+	if err != nil {
+		return // refused, which is what a strict server does with a NOT NULL column that has no default
+	}
+	assert.NotEqualf(t, "{}", details,
+		"[%s] with no default declared, omitting details must not yield {}; got it from a non-strict server storing ''", phase)
+}
+
+// insertAuditLogWithoutDetails000037 inserts an audit_logs row naming every column except
+// details and reads details back. Literals rather than placeholders because the dialects
+// disagree on placeholder syntax and every value here is test-controlled, following
+// seedKeyPair000030. The timestamp literal parses on all four engines.
+//
+// The insert's error is returned rather than asserted, because whether omission is refused
+// or silently stored is exactly what the caller is deciding about.
+func insertAuditLogWithoutDetails000037(t *testing.T, h *isolatedDB, event string) (string, error) {
+	t.Helper()
+
+	_, err := h.SQL.Exec(fmt.Sprintf(
+		`INSERT INTO audit_logs (created_at, audit_event) VALUES ('2026-01-01 00:00:00', '%s')`, event))
+	if err != nil {
+		return "", err
+	}
+
+	var details string
+	require.NoErrorf(t, h.SQL.QueryRow(fmt.Sprintf(
+		`SELECT details FROM audit_logs WHERE audit_event = '%s'`, event)).Scan(&details),
+		"read back details for audit event %s", event)
+	return details, nil
+}

--- a/src/authserver/tests/data/migration_000038_nvarchar_columns_test.go
+++ b/src/authserver/tests/data/migration_000038_nvarchar_columns_test.go
@@ -1,0 +1,212 @@
+package datatests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oidcClaimsDefaultConstraint000038 is the name the migration gives the default constraint
+// it has to drop and recreate, lowercase df_<table>_<column> like the nine named default
+// constraints mssqldb already carries.
+const oidcClaimsDefaultConstraint000038 = "df_clients_include_open_id_connect_claims_in_id_token"
+
+// nvarcharColumns000038 is the exact set of columns the migration retypes: table, column,
+// the type the catalog reports before, the type it must report after, and whether the
+// column is nullable. The nullability is recorded here because it must be UNCHANGED, which
+// is the trap this migration is written around: ALTER COLUMN with no NULL or NOT NULL
+// keyword makes the column nullable whatever it was.
+var nvarcharColumns000038 = []struct {
+	table    string
+	column   string
+	before   string
+	after    string
+	nullable bool
+}{
+	{"codes", "code_challenge", "varchar(256)", "nvarchar(256)", true},
+	{"codes", "code_challenge_method", "varchar(10)", "nvarchar(10)", true},
+	{"user_profile_pictures", "content_type", "varchar(64)", "nvarchar(64)", false},
+	{"client_logos", "content_type", "varchar(64)", "nvarchar(64)", false},
+	{"clients", "include_open_id_connect_claims_in_id_token", "varchar(10)", "nvarchar(10)", false},
+}
+
+// TestMigration000038_NvarcharColumns is goal 5 of #282 stated as a test: the five SQL
+// Server columns declared VARCHAR become NVARCHAR, and the auto-named default constraint
+// on clients.include_open_id_connect_claims_in_id_token is replaced by a named one. It
+// runs against an ISOLATED database of the configured dialect (see
+// migration_testdb_helper.go).
+//
+// SQL Server only. The other three engines have no non-Unicode string type to migrate away
+// from: SQLite has one TEXT type, MySQL's tables are utf8mb4 throughout, and PostgreSQL's
+// text is Unicode by definition. The migration file exists on mssql alone and Migrate
+// refuses a target version the engine's source does not carry.
+//
+// The assertions, and why each is here:
+//
+//  1. The five columns' type changes and their NULLABILITY DOES NOT. Three of the five are
+//     NOT NULL, and ALTER COLUMN written without the keyword would silently make them
+//     nullable, trading one divergence for another that nothing else in the tree would
+//     notice.
+//  2. Everything else about the four affected tables is byte-identical, computed as a
+//     difference over stage 1's dumps rather than as a hand-written list of what should
+//     have stayed. That catches a column the migration dropped even when the test author
+//     forgot the column existed, which is the property decision 5 exists for, applied here
+//     to an ALTER rather than to a rebuild.
+//  3. The seeded row's value survives. A shape dump cannot tell ALTER COLUMN apart from
+//     DROP COLUMN followed by ADD COLUMN, and the second would silently blank the column
+//     for every existing client.
+//  4. The default constraint's NAME: auto-generated before (SQL Server's DF__ prefix),
+//     the name above after. dumpTable deliberately carries no constraint name, and the
+//     name is the entire reason a later migration can drop this constraint without
+//     repeating the catalog lookup this one has to do.
+//
+// Run via: ./run-tests.sh --type data --db mssql --run TestMigration000038_NvarcharColumns
+func TestMigration000038_NvarcharColumns(t *testing.T) {
+	if dbType() != "mssql" {
+		t.Skipf("SQL Server only: %s has no non-Unicode string type to migrate away from, so it has no 000038 file", dbType())
+	}
+
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(35), "migrate to 000035")
+
+	clientId := seedClient000035(t, h, "mig38-client")
+	setOidcClaimsSetting000038(t, h, clientId, "on")
+
+	before := dumpAffectedTables000038(t, h)
+	assertNvarcharColumnTypes000038(t, h, before, "at 000035", func(c int) string { return nvarcharColumns000038[c].before })
+	assert.Truef(t, strings.HasPrefix(oidcClaimsConstraintName000038(t, h), "DF__"),
+		"at 000035 the default constraint must still be the auto-generated one 000013 left; got %q",
+		oidcClaimsConstraintName000038(t, h))
+
+	require.NoError(t, h.Migrator.Migrate(38), "apply 000038")
+
+	after := dumpAffectedTables000038(t, h)
+	assertNvarcharColumnTypes000038(t, h, after, "after apply", func(c int) string { return nvarcharColumns000038[c].after })
+	assertOnlyTheFiveTypesMoved000038(t, before, after, "after apply")
+	assert.Equalf(t, "on", readOidcClaimsSetting000038(t, h, clientId),
+		"after apply, the seeded client's setting must survive the retype")
+	assert.Equal(t, oidcClaimsDefaultConstraint000038, oidcClaimsConstraintName000038(t, h),
+		"after apply, the default constraint must carry the name a later migration can drop it by")
+
+	require.NoError(t, h.Migrator.Migrate(35), "roll back 000038")
+
+	down := dumpAffectedTables000038(t, h)
+	assertNvarcharColumnTypes000038(t, h, down, "after roll back", func(c int) string { return nvarcharColumns000038[c].before })
+	assertOnlyTheFiveTypesMoved000038(t, before, down, "after roll back")
+	assert.Equalf(t, "on", readOidcClaimsSetting000038(t, h, clientId),
+		"after roll back, the seeded client's setting must survive the retype")
+	assert.Truef(t, strings.HasPrefix(oidcClaimsConstraintName000038(t, h), "DF__"),
+		"the down migration must restore an UNNAMED default, so 000035 is the shape 000013 left")
+
+	require.NoError(t, h.Migrator.Migrate(38), "re-apply 000038")
+
+	reapplied := dumpAffectedTables000038(t, h)
+	assertNvarcharColumnTypes000038(t, h, reapplied, "after down/up round trip", func(c int) string { return nvarcharColumns000038[c].after })
+	assertOnlyTheFiveTypesMoved000038(t, before, reapplied, "after down/up round trip")
+	assert.Equal(t, oidcClaimsDefaultConstraint000038, oidcClaimsConstraintName000038(t, h),
+		"after the round trip, the default constraint must be named again")
+}
+
+// affectedTables000038 is the four tables the migration touches, in a fixed order so the
+// before and after dumps line up.
+var affectedTables000038 = []string{"client_logos", "clients", "codes", "user_profile_pictures"}
+
+func dumpAffectedTables000038(t *testing.T, h *isolatedDB) map[string]tableShape {
+	t.Helper()
+
+	shapes := map[string]tableShape{}
+	for _, table := range affectedTables000038 {
+		shapes[table] = dumpTable(t, h, table)
+	}
+	return shapes
+}
+
+// assertNvarcharColumnTypes000038 checks each of the five columns against the type want
+// returns for it, and checks its nullability against the fixed value in the table, which
+// never changes in either direction.
+func assertNvarcharColumnTypes000038(t *testing.T, h *isolatedDB, shapes map[string]tableShape, phase string, want func(int) string) {
+	t.Helper()
+
+	for i, c := range nvarcharColumns000038 {
+		got := shapes[c.table].column(t, c.column)
+		assert.Equalf(t, want(i), got.Type, "[%s] %s.%s", phase, c.table, c.column)
+		assert.Equalf(t, c.nullable, got.Nullable,
+			"[%s] %s.%s changed nullability: ALTER COLUMN written without an explicit NULL/NOT NULL keyword makes a column nullable",
+			phase, c.table, c.column)
+	}
+}
+
+// assertOnlyTheFiveTypesMoved000038 is the exhaustive half. It compares the before and
+// after dumps of all four tables and requires that the ONLY difference anywhere is the
+// Type of the five listed columns: same columns, same nullability, same defaults, same
+// indexes, same foreign keys.
+func assertOnlyTheFiveTypesMoved000038(t *testing.T, before, after map[string]tableShape, phase string) {
+	t.Helper()
+
+	retyped := map[string]bool{}
+	for _, c := range nvarcharColumns000038 {
+		retyped[c.table+"."+c.column] = true
+	}
+
+	for _, table := range affectedTables000038 {
+		b, a := before[table], after[table]
+
+		require.Lenf(t, a.Columns, len(b.Columns),
+			"[%s] %s gained or lost a column", phase, table)
+		for i := range b.Columns {
+			bc, ac := b.Columns[i], a.Columns[i]
+			require.Equalf(t, bc.Name, ac.Name, "[%s] %s column %d", phase, table, i)
+
+			if !retyped[table+"."+bc.Name] {
+				assert.Equalf(t, bc.Type, ac.Type,
+					"[%s] %s.%s is not one of the five columns 000038 retypes and must not move",
+					phase, table, bc.Name)
+			}
+			assert.Equalf(t, bc.Nullable, ac.Nullable, "[%s] %s.%s nullability", phase, table, bc.Name)
+			assert.Equalf(t, bc.Default, ac.Default, "[%s] %s.%s default", phase, table, bc.Name)
+		}
+
+		assert.Equalf(t, b.Indexes, a.Indexes, "[%s] %s indexes", phase, table)
+		assert.Equalf(t, b.ForeignKeys, a.ForeignKeys, "[%s] %s foreign keys", phase, table)
+	}
+}
+
+// oidcClaimsConstraintName000038 reads the name of the default constraint on
+// clients.include_open_id_connect_claims_in_id_token. dumpTable carries the default's
+// definition and deliberately not its name, so this is read separately; the name is what
+// makes the constraint droppable by a later migration.
+func oidcClaimsConstraintName000038(t *testing.T, h *isolatedDB) string {
+	t.Helper()
+
+	var name string
+	require.NoError(t, h.SQL.QueryRow(
+		`SELECT dc.name FROM sys.default_constraints dc
+		   JOIN sys.columns c ON c.object_id = dc.parent_object_id AND c.column_id = dc.parent_column_id
+		  WHERE dc.parent_object_id = OBJECT_ID('dbo.clients')
+		    AND c.name = 'include_open_id_connect_claims_in_id_token'`).Scan(&name),
+		"read the default constraint name on clients.include_open_id_connect_claims_in_id_token")
+	return name
+}
+
+func setOidcClaimsSetting000038(t *testing.T, h *isolatedDB, clientId int64, value string) {
+	t.Helper()
+
+	_, err := h.SQL.Exec(fmt.Sprintf(
+		`UPDATE clients SET include_open_id_connect_claims_in_id_token = '%s' WHERE id = %d`,
+		value, clientId))
+	require.NoError(t, err, "seed the client's OIDC claims setting")
+}
+
+func readOidcClaimsSetting000038(t *testing.T, h *isolatedDB, clientId int64) string {
+	t.Helper()
+
+	var value string
+	require.NoError(t, h.SQL.QueryRow(fmt.Sprintf(
+		`SELECT include_open_id_connect_claims_in_id_token FROM clients WHERE id = %d`, clientId)).Scan(&value),
+		"read back the client's OIDC claims setting")
+	return value
+}

--- a/src/authserver/tests/data/migration_000039_pkce_nullable_fk_swap_test.go
+++ b/src/authserver/tests/data/migration_000039_pkce_nullable_fk_swap_test.go
@@ -1,0 +1,493 @@
+package datatests
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 000039 carries two of #282's divergences at once, because both need the same SQLite
+// table rebuild: codes.code_challenge and code_challenge_method become nullable there
+// (divergence 3), and refresh_tokens.user_id and client_id come down to ON DELETE NO
+// ACTION on the three engines that still cascade (divergence 5). SQL Server has been at
+// the final state on both counts since its own 000007 and 000011, so it gets no file.
+//
+// predecessor000039 is the version this migration follows ON THIS ENGINE. The histories
+// are sparse and golang-migrate's read() calls versionExists(to) before doing anything,
+// so Migrate(38) fails outright on sqlite, mysql and postgres rather than migrating to
+// the nearest version they do have.
+func predecessor000039() uint {
+	switch dbType() {
+	case "mysql":
+		return 37 // 000037 is MySQL's own, the audit_logs default
+	case "postgres":
+		return 35 // PostgreSQL has none of 000036 to 000038
+	case "mssql":
+		return 38 // 000038 is SQL Server's own, the nvarchar columns; its head
+	default: // sqlite
+		return 36 // 000036 is SQLite's own, the refresh_tokens(client_id) index
+	}
+}
+
+// hasMigration000039 is false on SQL Server alone, which needs no file.
+func hasMigration000039() bool { return dbType() != "mssql" }
+
+func isSQLite000039() bool { return dbType() == "" || dbType() == "sqlite" }
+
+// TestMigration000039_ShapeDifferenceIsExactlyIntended is decision 5's whole purpose. The
+// SQLite half of this migration hand-writes codes (22 columns, 2 foreign keys, 3 indexes)
+// and refresh_tokens (17 columns, 3 foreign keys, 5 indexes) in the up file and again in
+// the down, and a dropped column, a lost index or a changed foreign key action would be
+// silent: PRAGMA foreign_key_check does not see any of them.
+//
+// So the assertion is not a list of things someone remembered to check. It builds the
+// EXPECTED after-shape by applying only the intended edits to the before-shape, and
+// requires the real after-shape to equal it. Anything else that moved fails, including
+// something the test author never thought of.
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestMigration000039_ShapeDifferenceIsExactlyIntended
+func TestMigration000039_ShapeDifferenceIsExactlyIntended(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	pred := predecessor000039()
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "migrate to %06d", pred)
+
+	codesBefore := dumpTable(t, h, "codes")
+	rtBefore := dumpTable(t, h, "refresh_tokens")
+
+	codesWant := intendedCodes000039(codesBefore)
+	rtWant := intendedRefreshTokens000039(rtBefore)
+
+	if !hasMigration000039() {
+		// SQL Server: the intended edit set is empty on both tables, so the shape at its
+		// head IS the final shape. Asserting that here is what stops "no file needed"
+		// being taken on trust.
+		require.Equal(t, codesBefore, codesWant, "the intended edit set must be empty on mssql")
+		require.Equal(t, rtBefore, rtWant, "the intended edit set must be empty on mssql")
+		assertFinalShape000039(t, "at 000038", codesBefore, rtBefore)
+		return
+	}
+
+	require.NoError(t, h.Migrator.Migrate(39), "apply 000039")
+	assertShape000039(t, h, "after apply", codesWant, rtWant)
+	assertFinalShape000039(t, "after apply", dumpTable(t, h, "codes"), dumpTable(t, h, "refresh_tokens"))
+
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "roll back to %06d", pred)
+	assertShape000039(t, h, "after down", codesBefore, rtBefore)
+
+	require.NoError(t, h.Migrator.Migrate(39), "re-apply 000039")
+	assertShape000039(t, h, "after down/up round trip", codesWant, rtWant)
+	assertFinalShape000039(t, "after round trip", dumpTable(t, h, "codes"), dumpTable(t, h, "refresh_tokens"))
+}
+
+// intendedCodes000039 is the before-shape with divergence 3's edit applied and nothing
+// else: both PKCE columns nullable. On the three engines where they already are, the edit
+// changes nothing, which is the correct expectation there rather than a special case.
+func intendedCodes000039(before tableShape) tableShape {
+	want := copyShape000039(before)
+	for i := range want.Columns {
+		switch want.Columns[i].Name {
+		case "code_challenge", "code_challenge_method":
+			want.Columns[i].Nullable = true
+		}
+	}
+	return want
+}
+
+// intendedRefreshTokens000039 is the before-shape with divergence 5's edit applied and
+// nothing else: user_id and client_id move to NO ACTION. code_id is deliberately left
+// alone; its cascade is the one action all four engines already agree on, and a rebuild
+// that dropped it would delete a token's row when its code expired for a different
+// reason than the one intended.
+func intendedRefreshTokens000039(before tableShape) tableShape {
+	want := copyShape000039(before)
+	for i := range want.ForeignKeys {
+		switch want.ForeignKeys[i].Column {
+		case "user_id", "client_id":
+			want.ForeignKeys[i].OnDelete = "NO ACTION"
+		}
+	}
+	return want
+}
+
+// copyShape000039 deep-copies a tableShape so the intended-edit helpers cannot mutate the
+// before-shape they are handed. Without this the down leg would compare the after-shape
+// against itself and pass whatever the down did.
+func copyShape000039(s tableShape) tableShape {
+	out := tableShape{
+		Columns:     append([]columnShape(nil), s.Columns...),
+		Indexes:     append([]indexShape(nil), s.Indexes...),
+		ForeignKeys: append([]foreignKeyShape(nil), s.ForeignKeys...),
+	}
+	for i := range out.Indexes {
+		out.Indexes[i].Columns = append([]string(nil), s.Indexes[i].Columns...)
+	}
+	return out
+}
+
+func assertShape000039(t *testing.T, h *isolatedDB, phase string, codesWant, rtWant tableShape) {
+	t.Helper()
+	assert.Equalf(t, codesWant, dumpTable(t, h, "codes"),
+		"[%s] codes must differ from the previous version by exactly the intended edit on %s", phase, dbType())
+	assert.Equalf(t, rtWant, dumpTable(t, h, "refresh_tokens"),
+		"[%s] refresh_tokens must differ from the previous version by exactly the intended edit on %s", phase, dbType())
+}
+
+// assertFinalShape000039 states goals 3 and 6 in absolute terms rather than as a
+// difference, on all four engines. It is what gives the empty edit set on SQL Server a
+// meaning: that engine is already here, and the other three arrive.
+func assertFinalShape000039(t *testing.T, phase string, codes, rt tableShape) {
+	t.Helper()
+
+	assert.Truef(t, codes.column(t, "code_challenge").Nullable,
+		"[%s] codes.code_challenge must be nullable on %s (goal 3)", phase, dbType())
+	assert.Truef(t, codes.column(t, "code_challenge_method").Nullable,
+		"[%s] codes.code_challenge_method must be nullable on %s (goal 3)", phase, dbType())
+
+	assert.Equalf(t, "NO ACTION", rt.foreignKey(t, "user_id").OnDelete,
+		"[%s] refresh_tokens.user_id must be NO ACTION on %s (goal 6)", phase, dbType())
+	assert.Equalf(t, "NO ACTION", rt.foreignKey(t, "client_id").OnDelete,
+		"[%s] refresh_tokens.client_id must be NO ACTION on %s (goal 6)", phase, dbType())
+	assert.Equalf(t, "CASCADE", rt.foreignKey(t, "code_id").OnDelete,
+		"[%s] refresh_tokens.code_id keeps its cascade on %s: it is the action all four engines already agree on",
+		phase, dbType())
+
+	// The index 000036 added, checked here as well as in its own test, because the
+	// SQLite rebuild recreates all five by hand and dropping this one from that list
+	// would undo the previous migration in the same change without failing anything else.
+	clientIdx := rt.index("idx_refresh_tokens_client_id")
+	require.Truef(t, clientIdx.Exists,
+		"[%s] idx_refresh_tokens_client_id must survive the rebuild on %s", phase, dbType())
+	assert.Equalf(t, []string{"client_id"}, clientIdx.Columns,
+		"[%s] idx_refresh_tokens_client_id must still cover exactly client_id", phase)
+}
+
+// TestMigration000039_RowValuesSurviveTheRebuild covers what a shape dump cannot see. The
+// SQLite rebuild copies both tables through hand-written INSERT ... SELECT column lists,
+// and two columns of the same type swapped between them produces an identical shape and
+// corrupted data. Variant E of the probe proved the ROWS survive; this proves their
+// COLUMNS do.
+//
+// Whole-struct equality against a baseline read back at the predecessor, rather than
+// field-by-field, so a column added to either model later is covered without anyone
+// remembering to extend this.
+//
+//	--run TestMigration000039_RowValuesSurviveTheRebuild
+func TestMigration000039_RowValuesSurviveTheRebuild(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	pred := predecessor000039()
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "migrate to %06d", pred)
+
+	client := seedClient000039(t, h)
+	user := seedUser000039(t, h)
+	code := seedCode000039(t, h, client, user, sql.NullString{String: "challenge-value", Valid: true})
+
+	// The two shapes a refresh token comes in, which are also the two variant E used: one
+	// issued through the authorization code flow, carrying a CodeId and no user or client,
+	// and one ROPC-shaped, carrying a UserId and ClientId and no code.
+	authCodeToken := seedRefreshToken000039(t, h, models.RefreshToken{
+		CodeId: sql.NullInt64{Int64: code.Id, Valid: true},
+	})
+	ropcToken := seedRefreshToken000039(t, h, models.RefreshToken{
+		UserId:   sql.NullInt64{Int64: user.Id, Valid: true},
+		ClientId: sql.NullInt64{Int64: client.Id, Valid: true},
+	})
+
+	baselineCode := readCode000039(t, h, code.Id)
+	baselineAuth := readRefreshToken000039(t, h, authCodeToken.Id)
+	baselineRopc := readRefreshToken000039(t, h, ropcToken.Id)
+
+	assertRows000039 := func(phase string) {
+		t.Helper()
+		assert.Equalf(t, baselineCode, readCode000039(t, h, code.Id),
+			"[%s] every codes column must still hold its own value on %s", phase, dbType())
+		assert.Equalf(t, baselineAuth, readRefreshToken000039(t, h, authCodeToken.Id),
+			"[%s] every refresh_tokens column must still hold its own value (auth code shape) on %s", phase, dbType())
+		assert.Equalf(t, baselineRopc, readRefreshToken000039(t, h, ropcToken.Id),
+			"[%s] every refresh_tokens column must still hold its own value (ROPC shape) on %s", phase, dbType())
+	}
+
+	if !hasMigration000039() {
+		// SQL Server rebuilds nothing, so there is no round trip to run. The baseline
+		// read above is still worth keeping: it is the same seeding path the other three
+		// engines use, so a model or driver problem shows up on all four.
+		assertRows000039("at 000038, no migration to apply")
+		return
+	}
+
+	require.NoError(t, h.Migrator.Migrate(39), "apply 000039")
+	assertRows000039("after apply")
+
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "roll back to %06d", pred)
+	assertRows000039("after down")
+
+	require.NoError(t, h.Migrator.Migrate(39), "re-apply 000039")
+	assertRows000039("after down/up round trip")
+}
+
+// TestMigration000039_ChallengelessCodeIsStorable is the probe's failing insert turned
+// into a test, at seam 3. It is goal 3 stated at the boundary a caller actually crosses:
+// CodeIssuer.CreateAuthCode leaves both NullStrings at Valid:false when the authorization
+// request carried no challenge, and on SQLite that insert has been failing with a 500 at
+// /auth/issue for every confidential client configured for PKCE-optional.
+//
+//	--run TestMigration000039_ChallengelessCodeIsStorable
+func TestMigration000039_ChallengelessCodeIsStorable(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	pred := predecessor000039()
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "migrate to %06d", pred)
+
+	client := seedClient000039(t, h)
+	user := seedUser000039(t, h)
+
+	err := createChallengelessCode000039(t, h, client, user, nil)
+	if isSQLite000039() {
+		require.Errorf(t, err, "at %06d SQLite still holds codes.code_challenge NOT NULL: that failure is the defect", pred)
+	} else {
+		require.NoErrorf(t, err, "the other three engines have accepted a NULL challenge since their own 000007 (%s)", dbType())
+	}
+
+	if !hasMigration000039() {
+		return // SQL Server is already at the final state, asserted above
+	}
+
+	require.NoError(t, h.Migrator.Migrate(39), "apply 000039")
+
+	var applied models.Code
+	require.NoErrorf(t, createChallengelessCode000039(t, h, client, user, &applied),
+		"a challenge-less code must be storable on %s after 000039 (goal 3)", dbType())
+	stored := readCode000039(t, h, applied.Id)
+	assert.False(t, stored.CodeChallenge.Valid, "the stored challenge must be NULL, not an empty string")
+	assert.False(t, stored.CodeChallengeMethod.Valid, "the stored method must be NULL, not an empty string")
+
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "roll back to %06d", pred)
+
+	if isSQLite000039() {
+		// The down's UPDATE, doing its job: the row written while 000039 was applied
+		// survives the rollback as '' rather than blocking it. Lossless for every reader,
+		// since all three tests in ValidateTokenRequest's downgrade mitigation treat ''
+		// and NULL alike.
+		afterDown := readCode000039(t, h, applied.Id)
+		assert.True(t, afterDown.CodeChallenge.Valid, "the down converts NULL to '' rather than losing the row")
+		assert.Equal(t, "", afterDown.CodeChallenge.String, "the down writes an empty string")
+		assert.True(t, afterDown.CodeChallengeMethod.Valid, "the down converts the method column too")
+		assert.Equal(t, "", afterDown.CodeChallengeMethod.String, "the down writes an empty string")
+
+		require.Error(t, createChallengelessCode000039(t, h, client, user, nil),
+			"after the down SQLite must refuse a NULL challenge again: the constraint is back")
+	} else {
+		require.NoError(t, createChallengelessCode000039(t, h, client, user, nil),
+			"the down does not touch nullability on %s, which was never the divergence there", dbType())
+	}
+
+	require.NoError(t, h.Migrator.Migrate(39), "re-apply 000039")
+	require.NoErrorf(t, createChallengelessCode000039(t, h, client, user, nil),
+		"a challenge-less code must be storable again after the round trip on %s", dbType())
+}
+
+// TestMigration000039_RopcTokenBlocksUserDelete is NO ACTION in effect rather than in the
+// catalog, at seam 4. A shape dump reads what the catalog says; this reads what the engine
+// does, which is the assertion the whole change is actually making.
+//
+// It also states the property that makes levelling down unobservable: DeleteUser clears
+// the user's refresh tokens first, so the Go path still succeeds where a raw DELETE is
+// now refused. That is why SQL Server has run this way since 000011 with nobody noticing.
+//
+//	--run TestMigration000039_RopcTokenBlocksUserDelete
+func TestMigration000039_RopcTokenBlocksUserDelete(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	pred := predecessor000039()
+	require.NoErrorf(t, h.Migrator.Migrate(pred), "migrate to %06d", pred)
+
+	client := seedClient000039(t, h)
+
+	if hasMigration000039() {
+		// At the predecessor the cascade is still in force on these three, so a raw
+		// DELETE takes the token with it. Asserting the OLD behaviour is what makes the
+		// assertion after the apply mean the migration did something.
+		doomed := seedUser000039(t, h)
+		token := seedRefreshToken000039(t, h, models.RefreshToken{
+			UserId:   sql.NullInt64{Int64: doomed.Id, Valid: true},
+			ClientId: sql.NullInt64{Int64: client.Id, Valid: true},
+		})
+		_, err := h.SQL.Exec(fmt.Sprintf("DELETE FROM users WHERE id = %d", doomed.Id))
+		require.NoErrorf(t, err, "at %06d the cascade lets a raw user delete through on %s", pred, dbType())
+		assert.Zerof(t, countRefreshTokens000039(t, h, token.Id),
+			"at %06d the cascade removes the token with its user on %s", pred, dbType())
+
+		require.NoError(t, h.Migrator.Migrate(39), "apply 000039")
+	}
+
+	user := seedUser000039(t, h)
+	token := seedRefreshToken000039(t, h, models.RefreshToken{
+		UserId:   sql.NullInt64{Int64: user.Id, Valid: true},
+		ClientId: sql.NullInt64{Int64: client.Id, Valid: true},
+	})
+
+	_, err := h.SQL.Exec(fmt.Sprintf("DELETE FROM users WHERE id = %d", user.Id))
+	require.Errorf(t, err,
+		"a raw user delete must be REFUSED on %s once refresh_tokens.user_id is NO ACTION (goal 6)", dbType())
+	assert.Equalf(t, 1, countRefreshTokens000039(t, h, token.Id),
+		"the refused delete must leave the token in place on %s", dbType())
+
+	// And the invariant that makes all of this unobservable: DeleteUser clears the
+	// user's refresh tokens inside the same transaction, so the supported path still
+	// works. cascade_delete_test.go asserts the same thing across every dependent table.
+	require.NoErrorf(t, h.DB.DeleteUser(nil, user.Id),
+		"DeleteUser clears refresh tokens first, so it must still succeed on %s", dbType())
+	assert.Zerof(t, countRefreshTokens000039(t, h, token.Id),
+		"DeleteUser must have removed the token on %s", dbType())
+}
+
+// --- seeding -------------------------------------------------------------------------
+//
+// Through the repository's own CRUD rather than raw SQL, unlike the older migration tests
+// here: the point of the row-value case is that every column arrives where the Go model
+// says it should, and hand-written INSERTs per dialect would be asserting the test's own
+// column list rather than the migration's.
+
+func seedClient000039(t *testing.T, h *isolatedDB) *models.Client {
+	t.Helper()
+	client := &models.Client{
+		ClientIdentifier:         "c-" + uuid.NewString()[:8],
+		Description:              "seeded by migration 000039's test",
+		Enabled:                  true,
+		AuthorizationCodeEnabled: true,
+		DefaultAcrLevel:          "urn:goiabada:level1",
+	}
+	require.NoError(t, h.DB.CreateClient(nil, client), "seed client")
+	return client
+}
+
+func seedUser000039(t *testing.T, h *isolatedDB) *models.User {
+	t.Helper()
+	user := &models.User{
+		Subject:      uuid.New(),
+		Enabled:      true,
+		Email:        uuid.NewString() + "@example.com",
+		Username:     "u-" + uuid.NewString()[:8],
+		PasswordHash: "x",
+	}
+	require.NoError(t, h.DB.CreateUser(nil, user), "seed user")
+	return user
+}
+
+// seedCode000039 gives every column its own recognisable value, so a copy that crossed two
+// of them is visible in the comparison rather than hidden behind two equal defaults.
+func seedCode000039(t *testing.T, h *isolatedDB, client *models.Client, user *models.User,
+	challenge sql.NullString) *models.Code {
+	t.Helper()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	code := &models.Code{
+		CodeHash:            "hash-" + uuid.NewString(),
+		ClientId:            client.Id,
+		UserId:              user.Id,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: sql.NullString{String: "S256", Valid: challenge.Valid},
+		Scope:               "openid profile scope-value",
+		State:               "state-value",
+		Nonce:               "nonce-value",
+		RedirectURI:         "https://example.com/redirect-uri-value",
+		IpAddress:           "203.0.113.7",
+		UserAgent:           "user-agent-value",
+		ResponseMode:        "form_post",
+		AuthenticatedAt:     now.Add(-3 * time.Minute),
+		SessionIdentifier:   "session-identifier-value",
+		AcrLevel:            "urn:goiabada:level2_mandatory",
+		AuthMethods:         "pwd otp",
+		Used:                true,
+		Revoked:             true,
+		AuthStateGeneration: 7,
+	}
+	require.NoError(t, h.DB.CreateCode(nil, code), "seed code")
+	return code
+}
+
+// seedRefreshToken000039 fills every column that is not part of the caller's chosen shape,
+// for the same reason seedCode000039 does.
+func seedRefreshToken000039(t *testing.T, h *isolatedDB, shape models.RefreshToken) *models.RefreshToken {
+	t.Helper()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	token := shape
+	token.RefreshTokenJti = "jti-" + uuid.NewString()
+	token.PreviousRefreshTokenJti = "previous-jti-value"
+	token.FirstRefreshTokenJti = "first-jti-value"
+	token.SessionIdentifier = "session-identifier-value"
+	token.RefreshTokenType = "Offline"
+	token.Scope = "openid offline_access"
+	token.IssuedAt = sql.NullTime{Time: now.Add(-2 * time.Minute), Valid: true}
+	token.ExpiresAt = sql.NullTime{Time: now.Add(time.Hour), Valid: true}
+	token.MaxLifetime = sql.NullTime{Time: now.Add(24 * time.Hour), Valid: true}
+	token.Revoked = true
+	token.AuthStateGeneration = 11
+
+	require.NoError(t, h.DB.CreateRefreshToken(nil, &token), "seed refresh token")
+	return &token
+}
+
+// createChallengelessCode000039 builds exactly what CodeIssuer.CreateAuthCode builds when
+// the authorization request carried no challenge: both NullStrings at their zero value,
+// which is Valid:false. It returns the error rather than requiring success, because being
+// refused is the assertion on one side of this migration.
+func createChallengelessCode000039(t *testing.T, h *isolatedDB, client *models.Client,
+	user *models.User, out *models.Code) error {
+	t.Helper()
+
+	code := &models.Code{
+		CodeHash:            "hash-" + uuid.NewString(),
+		ClientId:            client.Id,
+		UserId:              user.Id,
+		CodeChallenge:       sql.NullString{},
+		CodeChallengeMethod: sql.NullString{},
+		Scope:               "openid",
+		RedirectURI:         "https://example.com/cb",
+		ResponseMode:        "query",
+		AuthenticatedAt:     time.Now().UTC().Truncate(time.Microsecond),
+		SessionIdentifier:   uuid.NewString(),
+		AcrLevel:            "urn:goiabada:level1",
+		AuthMethods:         "pwd",
+	}
+	err := h.DB.CreateCode(nil, code)
+	if err == nil && out != nil {
+		*out = *code
+	}
+	return err
+}
+
+func readCode000039(t *testing.T, h *isolatedDB, id int64) *models.Code {
+	t.Helper()
+	code, err := h.DB.GetCodeById(nil, id)
+	require.NoErrorf(t, err, "read code %d back", id)
+	require.NotNilf(t, code, "code %d is gone", id)
+	return code
+}
+
+func readRefreshToken000039(t *testing.T, h *isolatedDB, id int64) *models.RefreshToken {
+	t.Helper()
+	token, err := h.DB.GetRefreshTokenById(nil, id)
+	require.NoErrorf(t, err, "read refresh token %d back", id)
+	require.NotNilf(t, token, "refresh token %d is gone", id)
+	return token
+}
+
+func countRefreshTokens000039(t *testing.T, h *isolatedDB, id int64) int {
+	t.Helper()
+	var n int
+	require.NoError(t,
+		h.SQL.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM refresh_tokens WHERE id = %d", id)).Scan(&n),
+		"count refresh tokens")
+	return n
+}

--- a/src/authserver/tests/data/migration_dumptable_test.go
+++ b/src/authserver/tests/data/migration_dumptable_test.go
@@ -1,0 +1,142 @@
+package datatests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDumpTable_ReadsTheCatalog is the control for dumpTable (see
+// migration_testdb_helper.go). The dumper's own failure mode is the one that matters to
+// the migration tests that lean on it: a per-engine branch that silently reports nothing
+// makes a before-and-after comparison read as "nothing changed" and pass. Every
+// assertion below is chosen so that a projection which under-reports, or reports a
+// constant, fails here rather than in the migration test that trusts it.
+//
+// It runs against an ISOLATED database pinned at 000035, never at head. Two reasons:
+//
+//   - The nullability of codes.code_challenge and the on-delete action of
+//     refresh_tokens.user_id are asserted AS THEY STAND TODAY, which is exactly what
+//     issue #282 changes. Read off a moving head, this control would start failing the
+//     moment that change lands, which is the wrong signal from a control.
+//   - Migrate(N) for an N the engine does not have fails outright rather than migrating
+//     to the nearest: golang-migrate's read() calls versionExists(to) first. 000035 is
+//     the last version all four engines share.
+//
+// Run per dialect via: ./run-tests.sh --type data --db <sqlite|mysql|postgres|mssql>
+//
+//	--run TestDumpTable_ReadsTheCatalog
+func TestDumpTable_ReadsTheCatalog(t *testing.T) {
+	h := newIsolatedDB(t)
+
+	require.NoError(t, h.Migrator.Migrate(35), "migrate to 000035")
+
+	refreshTokens := dumpTable(t, h, "refresh_tokens")
+	codes := dumpTable(t, h, "codes")
+
+	// The column projection reaches every column, on every engine. Both counts are the
+	// ones the four schema.sql snapshots record.
+	assert.Lenf(t, refreshTokens.Columns, 17,
+		"refresh_tokens has 17 columns at 000035 on every engine; got %d on %s",
+		len(refreshTokens.Columns), dbType())
+	assert.Lenf(t, codes.Columns, 22,
+		"codes has 22 columns at 000035 on every engine (id, the 19 original columns, "+
+			"auth_state_generation from 000024 and revoked from 000026); got %d on %s",
+		len(codes.Columns), dbType())
+
+	// Nullability, in BOTH polarities, on every engine. A branch that collapses
+	// nullability to either constant passes one of these and fails the other, where
+	// asserting a single column would let it half-pass.
+	assert.False(t, refreshTokens.column(t, "refresh_token_jti").Nullable,
+		"refresh_tokens.refresh_token_jti is NOT NULL on every engine at 000035")
+	assert.True(t, refreshTokens.column(t, "created_at").Nullable,
+		"refresh_tokens.created_at is nullable on every engine at 000035")
+
+	// Type and default, per dialect. These are the only two projections nothing else
+	// here exercises, and a rebuilt table is trusted to preserve both.
+	wantType, wantDefault := authStateGenerationShape(t)
+	gen := refreshTokens.column(t, "auth_state_generation")
+	assert.Equalf(t, wantType, gen.Type,
+		"refresh_tokens.auth_state_generation reads %q on %s", wantType, dbType())
+	assert.Equalf(t, wantDefault, gen.Default,
+		"refresh_tokens.auth_state_generation defaults to %q on %s", wantDefault, dbType())
+	assert.NotEmpty(t, gen.Type, "the type projection returned nothing")
+	assert.NotEmpty(t, gen.Default, "the default projection returned nothing")
+
+	// The index projection, in both uniqueness polarities. Names, uniqueness and key
+	// columns are all three of what indexShape carries.
+	jti := refreshTokens.index("idx_refresh_token_jti")
+	require.Truef(t, jti.Exists, "idx_refresh_token_jti is missing from the dump on %s", dbType())
+	assert.True(t, jti.Unique, "idx_refresh_token_jti is UNIQUE on every engine")
+	assert.Equal(t, []string{"refresh_token_jti"}, jti.Columns,
+		"idx_refresh_token_jti covers exactly refresh_token_jti")
+
+	// idx_refresh_tokens_user_id and not the code_id one: InnoDB creates an index for
+	// every foreign key and names it after the constraint, so MySQL covers code_id under
+	// fk_refresh_tokens_code and has no idx_refresh_tokens_code_id at all. The user_id
+	// index is declared by hand on all four.
+	userID := refreshTokens.index("idx_refresh_tokens_user_id")
+	require.Truef(t, userID.Exists, "idx_refresh_tokens_user_id is missing from the dump on %s", dbType())
+	assert.False(t, userID.Unique, "idx_refresh_tokens_user_id is not unique on any engine")
+	assert.Equal(t, []string{"user_id"}, userID.Columns,
+		"idx_refresh_tokens_user_id covers exactly user_id")
+
+	// The foreign key projection. Exactly three, so a branch returning extra rows (a
+	// join that fans out) fails as loudly as one returning none.
+	require.Lenf(t, refreshTokens.ForeignKeys, 3,
+		"refresh_tokens has exactly three foreign keys on every engine; got %v on %s",
+		refreshTokens.ForeignKeys, dbType())
+
+	assert.Equal(t,
+		foreignKeyShape{Column: "code_id", RefTable: "codes", RefColumn: "id", OnDelete: "CASCADE"},
+		refreshTokens.foreignKey(t, "code_id"),
+		"refresh_tokens.code_id cascades from codes on every engine")
+
+	// This pair is the control that matters most: it is divergence 5 of #282 as it
+	// stands today, read out of four different catalogs. A dumper that could not see the
+	// difference could not be used to prove the difference was removed.
+	wantUserClientAction := "CASCADE"
+	if dbType() == "mssql" {
+		// SQL Server refuses the cascade here: users <- codes <- refresh_tokens(code_id)
+		// alongside users <- refresh_tokens(user_id) is a multiple cascade path (Msg
+		// 1785), so 000011 declared NO ACTION.
+		wantUserClientAction = "NO ACTION"
+	}
+	assert.Equalf(t,
+		foreignKeyShape{Column: "user_id", RefTable: "users", RefColumn: "id", OnDelete: wantUserClientAction},
+		refreshTokens.foreignKey(t, "user_id"),
+		"refresh_tokens.user_id reads %s on %s at 000035", wantUserClientAction, dbType())
+	assert.Equalf(t,
+		foreignKeyShape{Column: "client_id", RefTable: "clients", RefColumn: "id", OnDelete: wantUserClientAction},
+		refreshTokens.foreignKey(t, "client_id"),
+		"refresh_tokens.client_id reads %s on %s at 000035", wantUserClientAction, dbType())
+
+	// And divergence 3 as it stands today, on the other axis the dumper is trusted for:
+	// SQLite still holds codes.code_challenge NOT NULL where the other three do not.
+	wantChallengeNullable := dbType() != "" && dbType() != "sqlite"
+	assert.Equalf(t, wantChallengeNullable, codes.column(t, "code_challenge").Nullable,
+		"codes.code_challenge is NOT NULL on sqlite and nullable on the other three at 000035 (%s)",
+		dbType())
+}
+
+// authStateGenerationShape is the type and default that refresh_tokens
+// .auth_state_generation reads as in this engine's catalog. Per-dialect literals rather
+// than a shared vocabulary, because dumpTable records each engine's own spelling and
+// compares a table only against itself.
+func authStateGenerationShape(t *testing.T) (typ, def string) {
+	t.Helper()
+
+	switch dbType() {
+	case "mysql":
+		return "bigint", "0"
+	case "postgres":
+		return "bigint", "0"
+	case "mssql":
+		// A named default constraint (df_refresh_tokens_auth_state_generation), whose
+		// definition SQL Server renders with its own parentheses.
+		return "bigint", "((0))"
+	default: // sqlite
+		return "INTEGER", "0"
+	}
+}

--- a/src/authserver/tests/data/migration_testdb_helper.go
+++ b/src/authserver/tests/data/migration_testdb_helper.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -115,6 +116,7 @@ func newIsolated(t *testing.T, db migratable, sqlDB *sql.DB) *isolatedDB {
 // Columns rather than counted separately: an index with no key columns is not a thing
 // any of the four engines can produce.
 type indexShape struct {
+	Name    string
 	Exists  bool
 	Unique  bool
 	Columns []string // key columns, in index order
@@ -180,7 +182,7 @@ func describeIndex(t *testing.T, h *isolatedDB, table, index string) indexShape 
 	require.NoErrorf(t, err, "index catalog lookup: %s on %s", index, table)
 	defer func() { _ = rows.Close() }()
 
-	shape := indexShape{}
+	shape := indexShape{Name: index}
 	for rows.Next() {
 		var col, uniqueFlag string
 		require.NoErrorf(t, rows.Scan(&col, &uniqueFlag),
@@ -192,6 +194,317 @@ func describeIndex(t *testing.T, h *isolatedDB, table, index string) indexShape 
 
 	shape.Exists = len(shape.Columns) > 0
 	return shape
+}
+
+// columnShape, foreignKeyShape and tableShape are one table as the engine's catalog
+// reports it. dumpTable fills them; see its comment for why the fields are these.
+type columnShape struct {
+	Name     string
+	Type     string // the engine's own spelling, verbatim
+	Nullable bool
+	Default  string // the engine's own default expression, verbatim; "" when there is none
+}
+
+// foreignKeyShape identifies a foreign key by the tuple every catalog reports, and
+// deliberately not by its constraint name. SQLite's PRAGMA foreign_key_list returns
+// (id, seq, table, from, to, on_update, on_delete, match) and omits the name even when
+// the table declares CONSTRAINT fk_named, so requiring a name would force a parser over
+// sqlite_schema.sql. A composite key would produce one entry per column pair, which the
+// two tables this is used on do not have.
+type foreignKeyShape struct {
+	Column    string
+	RefTable  string
+	RefColumn string
+	OnDelete  string // CASCADE, NO ACTION, RESTRICT, SET NULL or SET DEFAULT
+}
+
+// tableShape holds the three projections sorted, so two dumps of the same table compare
+// directly. Columns are sorted by name rather than left in ordinal order on purpose:
+// column order is not something this change is trying to make equal across engines, and
+// a rebuild that reorders columns is not a defect.
+type tableShape struct {
+	Columns     []columnShape
+	Indexes     []indexShape
+	ForeignKeys []foreignKeyShape
+}
+
+// dumpTable reads a table's columns, indexes and foreign keys out of the configured
+// dialect's catalog, so a migration that rebuilds a table can be checked by comparing
+// the dump before against the dump after. That is the property a hand-written
+// CREATE TABLE cannot otherwise be held to: a dropped column, a lost index or a changed
+// foreign key action are all silent, and PRAGMA foreign_key_check does not see any of
+// them.
+//
+// It compares a table against ITSELF on one engine, never across engines, so it records
+// each engine's own spelling verbatim and makes no attempt to map TEXT, varchar(256) and
+// nvarchar(256) onto a common vocabulary. A four-engine comparison needs that mapping
+// and is #284's job, not this helper's.
+//
+// Every branch normalises in SQL rather than in Go, following describeIndex and for the
+// same reason: nullability is a flag on SQLite, a boolean on PostgreSQL, a bit on SQL
+// Server and a YES/NO string on MySQL, and the on-delete action is a word on three
+// engines and a pg_constraint.confdeltype letter on the fourth. Sorting is the one thing
+// done in Go, so it is one rule rather than four.
+func dumpTable(t *testing.T, h *isolatedDB, table string) tableShape {
+	t.Helper()
+
+	shape := tableShape{
+		Columns:     dumpColumns(t, h, table),
+		Indexes:     dumpIndexes(t, h, table),
+		ForeignKeys: dumpForeignKeys(t, h, table),
+	}
+
+	// A table with no columns is not something any of the four engines can produce, so
+	// it means the branch above read the wrong catalog or the wrong name. Failing here
+	// is what stops an empty dump being compared against another empty dump and read as
+	// "nothing changed".
+	require.NotEmptyf(t, shape.Columns, "dumpTable(%s) read no columns on %s", table, dbType())
+
+	sort.Slice(shape.Columns, func(i, j int) bool { return shape.Columns[i].Name < shape.Columns[j].Name })
+	sort.Slice(shape.Indexes, func(i, j int) bool { return shape.Indexes[i].Name < shape.Indexes[j].Name })
+	sort.Slice(shape.ForeignKeys, func(i, j int) bool {
+		a, b := shape.ForeignKeys[i], shape.ForeignKeys[j]
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		if a.RefTable != b.RefTable {
+			return a.RefTable < b.RefTable
+		}
+		return a.RefColumn < b.RefColumn
+	})
+	return shape
+}
+
+func dumpColumns(t *testing.T, h *isolatedDB, table string) []columnShape {
+	t.Helper()
+
+	var q string
+	switch dbType() {
+	case "mysql":
+		// COLUMN_TYPE rather than DATA_TYPE: it carries the length, so varchar(64)
+		// shrinking to varchar(16) is visible.
+		q = fmt.Sprintf(`SELECT COLUMN_NAME, COLUMN_TYPE,
+			CASE WHEN IS_NULLABLE = 'YES' THEN '1' ELSE '0' END,
+			COALESCE(COLUMN_DEFAULT, '')
+			FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = '%s'`, table)
+	case "postgres":
+		// format_type renders the length the way the DDL spells it; pg_get_expr renders
+		// the default the same way. information_schema would give both in two columns
+		// that then have to be pasted together in Go.
+		q = fmt.Sprintf(`SELECT a.attname, format_type(a.atttypid, a.atttypmod),
+			CASE WHEN a.attnotnull THEN '0' ELSE '1' END,
+			COALESCE(pg_get_expr(d.adbin, d.adrelid), '')
+			FROM pg_attribute a
+			JOIN pg_class c ON c.oid = a.attrelid
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+			WHERE c.relname = '%s' AND n.nspname = current_schema()
+			  AND a.attnum > 0 AND NOT a.attisdropped`, table)
+	case "mssql":
+		// sys.columns.max_length is bytes, so an NVARCHAR's declared length is half of
+		// it, and -1 is the (max) form. sys.default_constraints is joined rather than
+		// reading INFORMATION_SCHEMA.COLUMN_DEFAULT because it is the same value and
+		// this is the catalog the rest of the mssql migrations already work against.
+		q = fmt.Sprintf(`SELECT c.name,
+			ty.name + CASE
+			  WHEN ty.name IN ('nvarchar','nchar') AND c.max_length = -1 THEN '(max)'
+			  WHEN ty.name IN ('nvarchar','nchar') THEN '(' + CAST(c.max_length / 2 AS VARCHAR(10)) + ')'
+			  WHEN ty.name IN ('varchar','char','varbinary','binary') AND c.max_length = -1 THEN '(max)'
+			  WHEN ty.name IN ('varchar','char','varbinary','binary') THEN '(' + CAST(c.max_length AS VARCHAR(10)) + ')'
+			  WHEN ty.name IN ('decimal','numeric') THEN '(' + CAST(c.precision AS VARCHAR(10)) + ',' + CAST(c.scale AS VARCHAR(10)) + ')'
+			  WHEN ty.name IN ('datetime2','time','datetimeoffset') THEN '(' + CAST(c.scale AS VARCHAR(10)) + ')'
+			  ELSE '' END,
+			CASE WHEN c.is_nullable = 1 THEN '1' ELSE '0' END,
+			COALESCE(dc.definition, '')
+			FROM sys.columns c
+			JOIN sys.types ty ON ty.user_type_id = c.user_type_id
+			LEFT JOIN sys.default_constraints dc
+			  ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+			WHERE c.object_id = OBJECT_ID('dbo.%s')`, table)
+	default: // sqlite
+		// pragma_table_info reports the DECLARED type, which is what a rebuild has to
+		// reproduce; SQLite's own storage class would collapse every spelling onto five
+		// values and hide exactly the drift this exists to catch.
+		q = fmt.Sprintf(`SELECT name, type,
+			CASE WHEN "notnull" = 0 THEN '1' ELSE '0' END,
+			COALESCE(dflt_value, '')
+			FROM pragma_table_info('%s')`, table)
+	}
+
+	rows, err := h.SQL.Query(q)
+	require.NoErrorf(t, err, "column catalog lookup on %s", table)
+	defer func() { _ = rows.Close() }()
+
+	var cols []columnShape
+	for rows.Next() {
+		var name, typ, nullable, def string
+		require.NoErrorf(t, rows.Scan(&name, &typ, &nullable, &def), "scan column catalog row on %s", table)
+		cols = append(cols, columnShape{Name: name, Type: typ, Nullable: nullable == "1", Default: def})
+	}
+	require.NoErrorf(t, rows.Err(), "iterate column catalog on %s", table)
+	return cols
+}
+
+func dumpIndexes(t *testing.T, h *isolatedDB, table string) []indexShape {
+	t.Helper()
+
+	// Each query returns one row per key column, ordered by index and then by the
+	// index's own column order, so the loop below can fold them into one indexShape per
+	// name without sorting the columns.
+	var q string
+	switch dbType() {
+	case "mysql":
+		q = fmt.Sprintf(`SELECT INDEX_NAME, CASE WHEN NON_UNIQUE = 0 THEN '1' ELSE '0' END, COLUMN_NAME
+			FROM information_schema.statistics
+			WHERE table_schema = DATABASE() AND table_name = '%s'
+			ORDER BY INDEX_NAME, SEQ_IN_INDEX`, table)
+	case "postgres":
+		q = fmt.Sprintf(`SELECT i.relname, CASE WHEN ix.indisunique THEN '1' ELSE '0' END, a.attname
+			FROM pg_index ix
+			JOIN pg_class i ON i.oid = ix.indexrelid
+			JOIN pg_class tb ON tb.oid = ix.indrelid
+			JOIN pg_namespace n ON n.oid = tb.relnamespace
+			JOIN unnest(ix.indkey::smallint[]) WITH ORDINALITY AS k(attnum, ord) ON true
+			JOIN pg_attribute a ON a.attrelid = tb.oid AND a.attnum = k.attnum
+			WHERE tb.relname = '%s' AND n.nspname = current_schema()
+			  AND k.ord <= ix.indnkeyatts
+			ORDER BY i.relname, k.ord`, table)
+	case "mssql":
+		// i.name IS NULL is the heap, which is not an index and has no shape to record.
+		q = fmt.Sprintf(`SELECT i.name, CASE WHEN i.is_unique = 1 THEN '1' ELSE '0' END, c.name
+			FROM sys.indexes i
+			JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+			JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+			WHERE i.object_id = OBJECT_ID('dbo.%s') AND i.name IS NOT NULL
+			  AND ic.is_included_column = 0
+			ORDER BY i.name, ic.key_ordinal`, table)
+	default: // sqlite
+		q = fmt.Sprintf(`SELECT il.name, CASE WHEN il."unique" = 1 THEN '1' ELSE '0' END, ii.name
+			FROM pragma_index_list('%s') AS il, pragma_index_info(il.name) AS ii
+			ORDER BY il.name, ii.seqno`, table)
+	}
+
+	rows, err := h.SQL.Query(q)
+	require.NoErrorf(t, err, "index catalog sweep on %s", table)
+	defer func() { _ = rows.Close() }()
+
+	var indexes []indexShape
+	byName := map[string]int{}
+	for rows.Next() {
+		var name, uniqueFlag, col string
+		require.NoErrorf(t, rows.Scan(&name, &uniqueFlag, &col), "scan index catalog row on %s", table)
+		pos, seen := byName[name]
+		if !seen {
+			indexes = append(indexes, indexShape{Name: name, Exists: true, Unique: uniqueFlag == "1"})
+			pos = len(indexes) - 1
+			byName[name] = pos
+		}
+		indexes[pos].Columns = append(indexes[pos].Columns, col)
+	}
+	require.NoErrorf(t, rows.Err(), "iterate index catalog on %s", table)
+	return indexes
+}
+
+func dumpForeignKeys(t *testing.T, h *isolatedDB, table string) []foreignKeyShape {
+	t.Helper()
+
+	var q string
+	switch dbType() {
+	case "mysql":
+		q = fmt.Sprintf(`SELECT k.COLUMN_NAME, k.REFERENCED_TABLE_NAME, k.REFERENCED_COLUMN_NAME, r.DELETE_RULE
+			FROM information_schema.KEY_COLUMN_USAGE k
+			JOIN information_schema.REFERENTIAL_CONSTRAINTS r
+			  ON r.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA AND r.CONSTRAINT_NAME = k.CONSTRAINT_NAME
+			WHERE k.TABLE_SCHEMA = DATABASE() AND k.TABLE_NAME = '%s'
+			  AND k.REFERENCED_TABLE_NAME IS NOT NULL`, table)
+	case "postgres":
+		// confdeltype is a single letter; the CASE is what puts it in the same
+		// vocabulary as the other three catalogs. conkey and confkey are parallel
+		// arrays, so they are unnested together on the shared ordinality.
+		q = fmt.Sprintf(`SELECT att.attname, ref.relname, ratt.attname,
+			CASE con.confdeltype
+			  WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT' WHEN 'c' THEN 'CASCADE'
+			  WHEN 'n' THEN 'SET NULL' WHEN 'd' THEN 'SET DEFAULT' ELSE con.confdeltype::text END
+			FROM pg_constraint con
+			JOIN pg_class tb ON tb.oid = con.conrelid
+			JOIN pg_namespace n ON n.oid = tb.relnamespace
+			JOIN pg_class ref ON ref.oid = con.confrelid
+			JOIN unnest(con.conkey) WITH ORDINALITY AS lk(attnum, ord) ON true
+			JOIN unnest(con.confkey) WITH ORDINALITY AS rk(attnum, ord) ON rk.ord = lk.ord
+			JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = lk.attnum
+			JOIN pg_attribute ratt ON ratt.attrelid = con.confrelid AND ratt.attnum = rk.attnum
+			WHERE con.contype = 'f' AND tb.relname = '%s' AND n.nspname = current_schema()`, table)
+	case "mssql":
+		// delete_referential_action_desc spells it NO_ACTION and SET_NULL, so the
+		// underscore is replaced to match the other three.
+		q = fmt.Sprintf(`SELECT pc.name, rt.name, rc.name,
+			REPLACE(fk.delete_referential_action_desc, '_', ' ')
+			FROM sys.foreign_keys fk
+			JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+			JOIN sys.columns pc ON pc.object_id = fkc.parent_object_id AND pc.column_id = fkc.parent_column_id
+			JOIN sys.columns rc ON rc.object_id = fkc.referenced_object_id AND rc.column_id = fkc.referenced_column_id
+			JOIN sys.tables rt ON rt.object_id = fkc.referenced_object_id
+			WHERE fk.parent_object_id = OBJECT_ID('dbo.%s')`, table)
+	default: // sqlite
+		// "to" is NULL when the reference names no column and means the referenced
+		// table's primary key; every foreign key in this schema names one.
+		q = fmt.Sprintf(`SELECT "from", "table", COALESCE("to", ''), UPPER(on_delete)
+			FROM pragma_foreign_key_list('%s')`, table)
+	}
+
+	rows, err := h.SQL.Query(q)
+	require.NoErrorf(t, err, "foreign key catalog lookup on %s", table)
+	defer func() { _ = rows.Close() }()
+
+	var fks []foreignKeyShape
+	for rows.Next() {
+		var col, refTable, refCol, onDelete string
+		require.NoErrorf(t, rows.Scan(&col, &refTable, &refCol, &onDelete),
+			"scan foreign key catalog row on %s", table)
+		fks = append(fks, foreignKeyShape{Column: col, RefTable: refTable, RefColumn: refCol, OnDelete: onDelete})
+	}
+	require.NoErrorf(t, rows.Err(), "iterate foreign key catalog on %s", table)
+	return fks
+}
+
+// column returns the named column, failing the test when the dump does not carry it.
+func (s tableShape) column(t *testing.T, name string) columnShape {
+	t.Helper()
+	for _, c := range s.Columns {
+		if c.Name == name {
+			return c
+		}
+	}
+	require.FailNowf(t, "column not found", "no column %q in the dump (%d columns read on %s)",
+		name, len(s.Columns), dbType())
+	return columnShape{}
+}
+
+// index returns the named index, or a zero indexShape (Exists false) when the table does
+// not carry it, matching describeIndex's contract.
+func (s tableShape) index(name string) indexShape {
+	for _, i := range s.Indexes {
+		if i.Name == name {
+			return i
+		}
+	}
+	return indexShape{Name: name}
+}
+
+// foreignKey returns the foreign key whose LOCAL column is name, failing the test when
+// there is none. Keyed by local column because that is what identifies a foreign key
+// without a constraint name, per foreignKeyShape.
+func (s tableShape) foreignKey(t *testing.T, column string) foreignKeyShape {
+	t.Helper()
+	for _, fk := range s.ForeignKeys {
+		if fk.Column == column {
+			return fk
+		}
+	}
+	require.FailNowf(t, "foreign key not found", "no foreign key on column %q in the dump (%d read on %s)",
+		column, len(s.ForeignKeys), dbType())
+	return foreignKeyShape{}
 }
 
 func dropMySQL(t *testing.T, cfg *config.DatabaseConfig, name string) {

--- a/src/authserver/tests/integration/authorize_public_client_pkce_test.go
+++ b/src/authserver/tests/integration/authorize_public_client_pkce_test.go
@@ -187,8 +187,6 @@ func TestAuthorize_PublicClient_WithPKCE_CompletesAndIssuesTokens(t *testing.T) 
 // challenge-less ceremony to completion, so nothing here has widened into the population #245
 // is not about.
 func TestAuthorize_ConfidentialClient_PKCEOff_WithoutCodeChallenge_Succeeds(t *testing.T) {
-	requireChallengelessCodesAreStorable(t)
-
 	pkceRequired := false
 	_, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
 		authCodeOptions{noPKCE: true, pkceRequired: &pkceRequired})

--- a/src/authserver/tests/integration/token_authcode_public_client_test.go
+++ b/src/authserver/tests/integration/token_authcode_public_client_test.go
@@ -30,8 +30,6 @@ import (
 func challengelessCode(t *testing.T, clientSecret string) (*models.Code, string) {
 	t.Helper()
 
-	requireChallengelessCodesAreStorable(t)
-
 	pkceRequired := false
 	_, code := createAuthCode(t, clientSecret, "openid profile email",
 		authCodeOptions{noPKCE: true, pkceRequired: &pkceRequired})

--- a/src/authserver/tests/integration/token_refresh_public_client_test.go
+++ b/src/authserver/tests/integration/token_refresh_public_client_test.go
@@ -29,8 +29,6 @@ import (
 func challengelessRefreshToken(t *testing.T, clientSecret string) (string, int64, string, string) {
 	t.Helper()
 
-	requireChallengelessCodesAreStorable(t)
-
 	pkceRequired := false
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email",
 		authCodeOptions{noPKCE: true, pkceRequired: &pkceRequired})

--- a/src/authserver/tests/integration/utils_test.go
+++ b/src/authserver/tests/integration/utils_test.go
@@ -739,28 +739,6 @@ type authCodeOptions struct {
 	userAgent string
 }
 
-// requireChallengelessCodesAreStorable skips the calling test on SQLite, where a code carrying
-// no PKCE challenge cannot be persisted at all.
-//
-// This is a defect in the server rather than a limitation of the tests, and it is pre-existing:
-// migration 000007 made codes.code_challenge and codes.code_challenge_method nullable on MySQL,
-// PostgreSQL and SQL Server, and its SQLite file is a no-op whose comment claims "SQLite VARCHAR
-// columns can store NULL regardless of NOT NULL constraint". SQLite does enforce NOT NULL, so
-// /auth/issue answers 500 with "NOT NULL constraint failed: codes.code_challenge" and the
-// PKCE-optional configuration does not work on that engine. Drafted as a follow-up rather than
-// fixed here: relaxing it needs a table rebuild, which is a migration and its own data test.
-//
-// The rows that skip here are NOT losing their coverage. The check suite runs this tier on all
-// four engines, so they execute for real on the other three, which is also the only tier that
-// could have told the two behaviours apart.
-func requireChallengelessCodesAreStorable(t *testing.T) {
-	t.Helper()
-
-	if strings.Trim(config.GetDatabase().Type, `"'`) == "sqlite" {
-		t.Skip("sqlite still has NOT NULL on codes.code_challenge; see the #245 follow-up")
-	}
-}
-
 func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...authCodeOptions) (*http.Client, *models.Code) {
 
 	var opt authCodeOptions

--- a/src/core/data/mssqldb/migrations/000038_nvarchar_columns.down.sql
+++ b/src/core/data/mssqldb/migrations/000038_nvarchar_columns.down.sql
@@ -1,0 +1,23 @@
+-- Back to VARCHAR, which is where SQL Server stood before #282.
+--
+-- This direction can lose characters: under an ASCII-lossy collation such as
+-- SQL_Latin1_General_CP1_CI_AS, every stored character outside the code page is
+-- replaced with '?' on the way down and is not recovered by re-applying the up
+-- migration. Under the Latin1_General_100_CI_AI_SC_UTF8 collation NewMsSQLDatabase
+-- pins, nothing is lost in either direction.
+--
+-- The nullability keyword is restated on every column here for the same reason the up
+-- migration gives: omitting it makes the column nullable.
+
+-- The named constraint has to go before the column can be altered, and it goes back
+-- UNNAMED so the down lands on exactly the shape 000013 left: an auto-generated name.
+ALTER TABLE [clients] DROP CONSTRAINT [df_clients_include_open_id_connect_claims_in_id_token];
+
+ALTER TABLE [clients] ALTER COLUMN [include_open_id_connect_claims_in_id_token] VARCHAR(10) NOT NULL;
+
+ALTER TABLE [clients] ADD DEFAULT 'default' FOR [include_open_id_connect_claims_in_id_token];
+
+ALTER TABLE [client_logos] ALTER COLUMN [content_type] VARCHAR(64) NOT NULL;
+ALTER TABLE [user_profile_pictures] ALTER COLUMN [content_type] VARCHAR(64) NOT NULL;
+ALTER TABLE [codes] ALTER COLUMN [code_challenge_method] VARCHAR(10) NULL;
+ALTER TABLE [codes] ALTER COLUMN [code_challenge] VARCHAR(256) NULL;

--- a/src/core/data/mssqldb/migrations/000038_nvarchar_columns.up.sql
+++ b/src/core/data/mssqldb/migrations/000038_nvarchar_columns.up.sql
@@ -1,0 +1,51 @@
+-- Five columns were declared VARCHAR where every comparable column on this engine is
+-- NVARCHAR (#282). Two of them, codes.code_challenge and codes.code_challenge_method,
+-- are a regression: 000001 created them NVARCHAR and 000007 rewrote them as VARCHAR
+-- while making them nullable. The other three arrived that way in 000008, 000013 and
+-- 000014.
+--
+-- What this does and does not buy. NewMsSQLDatabase creates the database with
+-- COLLATE Latin1_General_100_CI_AI_SC_UTF8, and under a UTF-8 collation VARCHAR stores
+-- the full Unicode range losslessly, so a database Goiabada created was never losing
+-- anything. The creation is IF NOT EXISTS, so an operator who pre-creates the database
+-- gets the server's default collation instead, and on a stock SQL Server that is
+-- SQL_Latin1_General_CP1_CI_AS, under which VARCHAR replaces anything outside the code
+-- page with '?'. That loss is irreversible: a value already stored as 'café-é?' stays
+-- 'café-é?' after this ALTER. So this stops future loss on a badly collated deployment
+-- and repairs nothing.
+--
+-- EVERY ALTER COLUMN BELOW RESTATES ITS NULLABILITY, and that is not decoration.
+-- ALTER TABLE ... ALTER COLUMN c <type> with no NULL or NOT NULL keyword makes the
+-- column NULLABLE whatever it was before, so writing these without the keyword would
+-- quietly drop NOT NULL from three columns while fixing their character set: one
+-- divergence traded for another, and nothing in the tree would notice.
+ALTER TABLE [codes] ALTER COLUMN [code_challenge] NVARCHAR(256) NULL;
+ALTER TABLE [codes] ALTER COLUMN [code_challenge_method] NVARCHAR(10) NULL;
+ALTER TABLE [user_profile_pictures] ALTER COLUMN [content_type] NVARCHAR(64) NOT NULL;
+ALTER TABLE [client_logos] ALTER COLUMN [content_type] NVARCHAR(64) NOT NULL;
+
+-- The fifth carries a default constraint, and SQL Server refuses ALTER COLUMN while one
+-- depends on the column ("ERROR 4922 ... because one or more objects access this
+-- column"). 000013 added it without a name, so SQL Server generated one, and the
+-- generated name differs per database: DF__clients__include__37A5467C in the probe and
+-- DF__clients__include__03F0984C in the dev container's goiabada_data. The name
+-- therefore has to be read from the catalog at run time; a literal would work on
+-- exactly one database.
+--
+-- The replacement is NAMED, for the reason 000024, 000026 and 000029 give: an unnamed
+-- constraint cannot be dropped by a later migration without repeating this lookup.
+DECLARE @df_name sysname = (
+    SELECT dc.[name]
+      FROM sys.default_constraints dc
+      JOIN sys.columns c
+        ON c.[object_id] = dc.[parent_object_id]
+       AND c.[column_id] = dc.[parent_column_id]
+     WHERE dc.[parent_object_id] = OBJECT_ID('dbo.clients')
+       AND c.[name] = 'include_open_id_connect_claims_in_id_token');
+
+EXEC('ALTER TABLE [clients] DROP CONSTRAINT [' + @df_name + ']');
+
+ALTER TABLE [clients] ALTER COLUMN [include_open_id_connect_claims_in_id_token] NVARCHAR(10) NOT NULL;
+
+ALTER TABLE [clients] ADD CONSTRAINT [df_clients_include_open_id_connect_claims_in_id_token]
+    DEFAULT 'default' FOR [include_open_id_connect_claims_in_id_token];

--- a/src/core/data/mssqldb/schema.sql
+++ b/src/core/data/mssqldb/schema.sql
@@ -30,7 +30,7 @@ CREATE TABLE [clients] (
     [pkce_required] BIT NULL DEFAULT (NULL),
     [implicit_grant_enabled] BIT DEFAULT NULL,
     [resource_owner_password_credentials_enabled] BIT DEFAULT NULL,
-    [include_open_id_connect_claims_in_id_token] VARCHAR(10) NOT NULL DEFAULT 'default',
+    [include_open_id_connect_claims_in_id_token] NVARCHAR(10) NOT NULL CONSTRAINT [df_clients_include_open_id_connect_claims_in_id_token] DEFAULT 'default',
     [created_via_dcr] BIT NOT NULL CONSTRAINT [df_clients_created_via_dcr] DEFAULT 0,
     CONSTRAINT [PK_clients] PRIMARY KEY ([id])
 );
@@ -52,8 +52,8 @@ CREATE TABLE [codes] (
     [updated_at] DATETIME2(6) NULL,
     [code_hash] NVARCHAR(64) NOT NULL,
     [client_id] BIGINT NOT NULL,
-    [code_challenge] VARCHAR(256) NULL,
-    [code_challenge_method] VARCHAR(10) NULL,
+    [code_challenge] NVARCHAR(256) NULL,
+    [code_challenge_method] NVARCHAR(10) NULL,
     [scope] NVARCHAR(512) NOT NULL,
     [state] NVARCHAR(512) NOT NULL,
     [nonce] NVARCHAR(512) NOT NULL,
@@ -265,7 +265,7 @@ CREATE TABLE [user_profile_pictures] (
     [updated_at] DATETIME2(6) NULL,
     [user_id] BIGINT NOT NULL,
     [picture] VARBINARY(MAX) NOT NULL,
-    [content_type] VARCHAR(64) NOT NULL,
+    [content_type] NVARCHAR(64) NOT NULL,
     CONSTRAINT [PK_user_profile_pictures] PRIMARY KEY ([id])
 );
 
@@ -276,7 +276,7 @@ CREATE TABLE [client_logos] (
     [updated_at] DATETIME2(6) NULL,
     [client_id] BIGINT NOT NULL,
     [logo] VARBINARY(MAX) NOT NULL,
-    [content_type] VARCHAR(64) NOT NULL,
+    [content_type] NVARCHAR(64) NOT NULL,
     CONSTRAINT [PK_client_logos] PRIMARY KEY ([id])
 );
 

--- a/src/core/data/mysqldb/migrations/000037_audit_logs_details_default.down.sql
+++ b/src/core/data/mysqldb/migrations/000037_audit_logs_details_default.down.sql
@@ -1,0 +1,2 @@
+-- Back to a TEXT column with no default, which is where MySQL stood before #282.
+ALTER TABLE `audit_logs` MODIFY `details` TEXT NOT NULL;

--- a/src/core/data/mysqldb/migrations/000037_audit_logs_details_default.up.sql
+++ b/src/core/data/mysqldb/migrations/000037_audit_logs_details_default.up.sql
@@ -1,0 +1,21 @@
+-- audit_logs.details carries DEFAULT '{}' on SQLite, PostgreSQL and SQL Server and
+-- carried none on MySQL (#282).
+--
+-- Three facts about this statement, each measured rather than assumed:
+--
+-- 1. MySQL refuses a literal default on a TEXT column. ALTER TABLE ... ALTER COLUMN
+--    details SET DEFAULT '{}' fails ERROR 1101 ("BLOB, TEXT, GEOMETRY or JSON column
+--    can't have a default value"), and so does the parenthesised form of SET DEFAULT.
+--    MODIFY with a parenthesised EXPRESSION default is the only accepted spelling.
+-- 2. An expression default is stamped with the DDL connection's character set, so
+--    MySQL records this one as (_utf8mb4'{}') where the other three engines record
+--    '{}'. The four engines therefore agree on the default's EFFECT and not on its
+--    recorded text. Anything comparing catalogs across engines has to carry that.
+-- 3. Nothing exercises the default on any engine. CreateAuditLog inserts through
+--    sqlbuilder.NewStruct, which writes every non-pk column, so every insert supplies
+--    a value. This is catalog parity with no observable behaviour attached.
+--
+-- The MODIFY is metadata-only: it is accepted with both ALGORITHM=INSTANT and
+-- ALGORITHM=INPLACE, so what is typically the largest table in a deployment is not
+-- rebuilt.
+ALTER TABLE `audit_logs` MODIFY `details` TEXT NOT NULL DEFAULT ('{}');

--- a/src/core/data/mysqldb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
+++ b/src/core/data/mysqldb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
@@ -1,0 +1,9 @@
+-- Restore the cascade 000011 declared on both constraints.
+
+ALTER TABLE `refresh_tokens` DROP FOREIGN KEY `fk_refresh_tokens_user`;
+ALTER TABLE `refresh_tokens` DROP FOREIGN KEY `fk_refresh_tokens_client`;
+
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `fk_refresh_tokens_user`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `fk_refresh_tokens_client`
+    FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE CASCADE;

--- a/src/core/data/mysqldb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
+++ b/src/core/data/mysqldb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
@@ -1,0 +1,23 @@
+-- Issue #282 divergence 5: refresh_tokens.user_id and client_id come down to
+-- ON DELETE NO ACTION to match SQL Server, which refuses the cascade outright
+-- (Msg 1785: users <- codes <- refresh_tokens(code_id) alongside
+-- users <- refresh_tokens(user_id) is a multiple cascade path). Parity is only reachable
+-- downward, and it is unobservable: DeleteUser and DeleteClient are the only statements
+-- that delete a user or a client row and both clear that row's refresh tokens first.
+--
+-- Divergence 3, the PKCE columns, needs no file here: MySQL has had
+-- codes.code_challenge and code_challenge_method nullable since its own 000007. SQLite
+-- carries that half of 000039.
+--
+-- InnoDB creates an index for every foreign key, so dropping a constraint could have
+-- taken an index with it and undone 000036's work on this engine. Measured: both
+-- idx_refresh_tokens_user_id and idx_refresh_tokens_client_id survive the swap, and
+-- information_schema.REFERENTIAL_CONSTRAINTS.DELETE_RULE then reads NO ACTION.
+
+ALTER TABLE `refresh_tokens` DROP FOREIGN KEY `fk_refresh_tokens_user`;
+ALTER TABLE `refresh_tokens` DROP FOREIGN KEY `fk_refresh_tokens_client`;
+
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `fk_refresh_tokens_user`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE NO ACTION;
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `fk_refresh_tokens_client`
+    FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE NO ACTION;

--- a/src/core/data/mysqldb/schema.sql
+++ b/src/core/data/mysqldb/schema.sql
@@ -266,11 +266,15 @@ CREATE TABLE `client_logos` (
   CONSTRAINT `fk_client_logos_client_id` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- details' default is an EXPRESSION, which is the only form MySQL accepts on a TEXT
+-- column, and MySQL stamps it with the DDL connection's charset. So its recorded text
+-- differs from the plain '{}' the other three engines record, while the effect is the
+-- same. See migration 000037.
 CREATE TABLE `audit_logs` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `created_at` datetime(6) NOT NULL,
   `audit_event` varchar(128) NOT NULL,
-  `details` text NOT NULL,
+  `details` text NOT NULL DEFAULT (_utf8mb4'{}'),
   PRIMARY KEY (`id`),
   KEY `idx_audit_logs_created_at` (`created_at`),
   KEY `idx_audit_logs_audit_event` (`audit_event`)

--- a/src/core/data/mysqldb/schema.sql
+++ b/src/core/data/mysqldb/schema.sql
@@ -457,8 +457,8 @@ CREATE TABLE `refresh_tokens` (
   KEY `idx_refresh_tokens_client_id` (`client_id`),
   KEY `idx_refresh_tokens_first_refresh_token_jti` (`first_refresh_token_jti`),
   CONSTRAINT `fk_refresh_tokens_code` FOREIGN KEY (`code_id`) REFERENCES `codes` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_refresh_tokens_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_refresh_tokens_client` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_refresh_tokens_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE NO ACTION,
+  CONSTRAINT `fk_refresh_tokens_client` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `browser_sessions` (

--- a/src/core/data/postgresdb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
+++ b/src/core/data/postgresdb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
@@ -1,0 +1,12 @@
+-- Restore the cascade 000011 declared on both constraints.
+
+ALTER TABLE public.refresh_tokens DROP CONSTRAINT fk_refresh_tokens_user;
+ALTER TABLE public.refresh_tokens DROP CONSTRAINT fk_refresh_tokens_client;
+
+ALTER TABLE public.refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_user
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_client
+    FOREIGN KEY (client_id) REFERENCES public.clients(id) ON DELETE CASCADE;

--- a/src/core/data/postgresdb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
+++ b/src/core/data/postgresdb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
@@ -1,0 +1,24 @@
+-- Issue #282 divergence 5: refresh_tokens.user_id and client_id come down to
+-- ON DELETE NO ACTION to match SQL Server, which refuses the cascade outright
+-- (Msg 1785: users <- codes <- refresh_tokens(code_id) alongside
+-- users <- refresh_tokens(user_id) is a multiple cascade path). Parity is only reachable
+-- downward, and it is unobservable: DeleteUser and DeleteClient are the only statements
+-- that delete a user or a client row and both clear that row's refresh tokens first.
+--
+-- Divergence 3, the PKCE columns, needs no file here: PostgreSQL has had
+-- codes.code_challenge and code_challenge_method nullable since its own 000007. SQLite
+-- carries that half of 000039.
+--
+-- Measured alongside MySQL: idx_refresh_tokens_user_id and idx_refresh_tokens_client_id
+-- both survive the swap, and pg_constraint.confdeltype then reads 'a'.
+
+ALTER TABLE public.refresh_tokens DROP CONSTRAINT fk_refresh_tokens_user;
+ALTER TABLE public.refresh_tokens DROP CONSTRAINT fk_refresh_tokens_client;
+
+ALTER TABLE public.refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_user
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE NO ACTION;
+
+ALTER TABLE public.refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_client
+    FOREIGN KEY (client_id) REFERENCES public.clients(id) ON DELETE NO ACTION;

--- a/src/core/data/postgresdb/schema.sql
+++ b/src/core/data/postgresdb/schema.sql
@@ -1601,7 +1601,7 @@ ALTER TABLE ONLY public.refresh_tokens
 --
 
 ALTER TABLE ONLY public.refresh_tokens
-    ADD CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE NO ACTION;
 
 
 --
@@ -1609,7 +1609,7 @@ ALTER TABLE ONLY public.refresh_tokens
 --
 
 ALTER TABLE ONLY public.refresh_tokens
-    ADD CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES public.clients(id) ON DELETE CASCADE;
+    ADD CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES public.clients(id) ON DELETE NO ACTION;
 
 
 --

--- a/src/core/data/sqlitedb/migrations/000007_make_pkce_nullable.up.sql
+++ b/src/core/data/sqlitedb/migrations/000007_make_pkce_nullable.up.sql
@@ -1,8 +1,6 @@
 -- SQLite doesn't support ALTER COLUMN to change NULL constraints directly
--- The columns are already effectively nullable in SQLite (it doesn't enforce NOT NULL strictly for VARCHAR)
--- This migration is a no-op for SQLite but included for consistency
--- If strict enforcement is needed, a table rebuild would be required
+-- This migration is a no-op for SQLite; the constraint is actually dropped by 000039,
+-- which rebuilds the codes table (SQLite enforces NOT NULL on every column type, so
+-- leaving it here left codes.code_challenge NOT NULL on this engine alone until then)
 
--- No operation needed - SQLite VARCHAR columns can store NULL regardless of NOT NULL constraint
--- when inserting via prepared statements that explicitly set NULL
 SELECT 1;

--- a/src/core/data/sqlitedb/migrations/000036_refresh_tokens_client_id_index.down.sql
+++ b/src/core/data/sqlitedb/migrations/000036_refresh_tokens_client_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_refresh_tokens_client_id;

--- a/src/core/data/sqlitedb/migrations/000036_refresh_tokens_client_id_index.up.sql
+++ b/src/core/data/sqlitedb/migrations/000036_refresh_tokens_client_id_index.up.sql
@@ -1,0 +1,9 @@
+-- refresh_tokens(client_id) is indexed on MySQL, PostgreSQL and SQL Server and was
+-- never indexed on SQLite (#282). Migration 000011 rebuilt refresh_tokens and restored
+-- only idx_refresh_token_jti, and 000024 later added idx_refresh_tokens_user_id and not
+-- the client one, so SQLite has run without it since.
+--
+-- What reads it: deleteRefreshTokensByColumn filters on client_id when DeleteClient
+-- clears a client's tokens, which is a full table scan on SQLite and a seek elsewhere.
+-- Nothing is incorrect without it; the divergence is the point.
+CREATE INDEX idx_refresh_tokens_client_id ON refresh_tokens(client_id);

--- a/src/core/data/sqlitedb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
+++ b/src/core/data/sqlitedb/migrations/000039_pkce_nullable_and_fk_no_action.down.sql
@@ -1,0 +1,107 @@
+-- The mirror of 000039's up: codes.code_challenge and code_challenge_method go back to
+-- NOT NULL, and refresh_tokens.user_id and client_id back to ON DELETE CASCADE.
+--
+-- The same parking ordering is required for the same reason: DROP TABLE codes inside
+-- golang-migrate's transaction cascades into refresh_tokens(code_id) and silently
+-- destroys every auth-code-issued token, and PRAGMA foreign_keys cannot be turned off
+-- inside a transaction. So refresh_tokens is parked and dropped before codes is touched.
+--
+-- NULL becomes '' on the way back. That conversion is lossless for every reader: all
+-- three tests in ValidateTokenRequest's PKCE downgrade mitigation already treat an empty
+-- string and NULL alike, reading .Valid && != "" or !.Valid || == "", and the code says
+-- so. Rows written by a challenge-less ceremony while 000039 was applied therefore keep
+-- working rather than blocking this migration.
+
+CREATE TABLE rt_parked AS SELECT * FROM refresh_tokens;
+DROP TABLE refresh_tokens;
+
+UPDATE codes SET code_challenge = '' WHERE code_challenge IS NULL;
+UPDATE codes SET code_challenge_method = '' WHERE code_challenge_method IS NULL;
+
+CREATE TABLE codes_new (
+  `id` integer PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME,
+  updated_at DATETIME,
+  code_hash TEXT NOT NULL,
+  client_id INTEGER NOT NULL,
+  code_challenge TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  `state` TEXT NOT NULL,
+  nonce TEXT NOT NULL,
+  redirect_uri TEXT NOT NULL,
+  user_id INTEGER NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT NOT NULL,
+  response_mode TEXT NOT NULL,
+  authenticated_at DATETIME NOT NULL,
+  session_identifier TEXT NOT NULL,
+  acr_level TEXT NOT NULL,
+  auth_methods TEXT NOT NULL,
+  used numeric NOT NULL,
+  auth_state_generation INTEGER NOT NULL DEFAULT 0,
+  revoked numeric NOT NULL DEFAULT 0,
+  CONSTRAINT fk_codes_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE,
+  CONSTRAINT fk_codes_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+INSERT INTO codes_new (
+  `id`, created_at, updated_at, code_hash, client_id, code_challenge, code_challenge_method,
+  scope, `state`, nonce, redirect_uri, user_id, ip_address, user_agent, response_mode,
+  authenticated_at, session_identifier, acr_level, auth_methods, used, auth_state_generation,
+  revoked)
+SELECT
+  `id`, created_at, updated_at, code_hash, client_id, code_challenge, code_challenge_method,
+  scope, `state`, nonce, redirect_uri, user_id, ip_address, user_agent, response_mode,
+  authenticated_at, session_identifier, acr_level, auth_methods, used, auth_state_generation,
+  revoked
+FROM codes;
+
+DROP TABLE codes;
+ALTER TABLE codes_new RENAME TO codes;
+
+CREATE UNIQUE INDEX `idx_code_hash` ON `codes`(`code_hash`);
+CREATE INDEX idx_codes_session_identifier ON codes(session_identifier);
+CREATE INDEX idx_codes_user_id ON codes(user_id);
+
+CREATE TABLE refresh_tokens (
+  `id` integer PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME,
+  updated_at DATETIME,
+  code_id INTEGER NULL,
+  user_id INTEGER NULL,
+  client_id INTEGER NULL,
+  refresh_token_jti TEXT NOT NULL,
+  previous_refresh_token_jti TEXT NOT NULL,
+  first_refresh_token_jti TEXT NOT NULL,
+  session_identifier TEXT NOT NULL,
+  refresh_token_type TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  issued_at DATETIME,
+  expires_at DATETIME,
+  max_lifetime DATETIME,
+  revoked numeric NOT NULL,
+  auth_state_generation INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT fk_refresh_tokens_code FOREIGN KEY (code_id) REFERENCES codes (id) ON DELETE CASCADE,
+  CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+  CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE
+);
+
+INSERT INTO refresh_tokens (
+  `id`, created_at, updated_at, code_id, user_id, client_id, refresh_token_jti,
+  previous_refresh_token_jti, first_refresh_token_jti, session_identifier, refresh_token_type,
+  scope, issued_at, expires_at, max_lifetime, revoked, auth_state_generation)
+SELECT
+  `id`, created_at, updated_at, code_id, user_id, client_id, refresh_token_jti,
+  previous_refresh_token_jti, first_refresh_token_jti, session_identifier, refresh_token_type,
+  scope, issued_at, expires_at, max_lifetime, revoked, auth_state_generation
+FROM rt_parked;
+
+DROP TABLE rt_parked;
+
+CREATE UNIQUE INDEX idx_refresh_token_jti ON refresh_tokens (refresh_token_jti);
+CREATE INDEX idx_refresh_tokens_code_id ON refresh_tokens(code_id);
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_client_id ON refresh_tokens(client_id);
+CREATE INDEX idx_refresh_tokens_first_refresh_token_jti
+    ON refresh_tokens(first_refresh_token_jti);

--- a/src/core/data/sqlitedb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
+++ b/src/core/data/sqlitedb/migrations/000039_pkce_nullable_and_fk_no_action.up.sql
@@ -1,0 +1,132 @@
+-- Two of issue #282's divergences, in one file, because both need the same rebuild.
+--
+-- 1. codes.code_challenge and code_challenge_method are still NOT NULL on SQLite. 000007
+--    was a no-op here, justified by a comment claiming SQLite does not enforce NOT NULL;
+--    it does, on every column type. CodeIssuer.CreateAuthCode leaves both sql.NullString
+--    values at Valid:false when the authorization request carried no challenge, so the
+--    insert sends NULL and fails. A confidential client configured for PKCE-optional
+--    therefore runs the whole ceremony and gets a 500 at /auth/issue on the default
+--    engine. The other three have been nullable since their own 000007.
+--
+-- 2. refresh_tokens.user_id and client_id are ON DELETE CASCADE here, on MySQL and on
+--    PostgreSQL, and ON DELETE NO ACTION on SQL Server, which refuses the cascade
+--    outright: users <- codes <- refresh_tokens(code_id) alongside
+--    users <- refresh_tokens(user_id) is a multiple cascade path (Msg 1785). Parity is
+--    only reachable downward. It is unobservable: DeleteUser and DeleteClient are the
+--    only statements in the codebase that delete a user or a client row, and both clear
+--    that row's refresh tokens first, which is why SQL Server has run this way since
+--    000011 without anyone noticing.
+--
+-- ORDERING, and why it is not the obvious one. golang-migrate's sqlite driver runs this
+-- inside a transaction, and PRAGMA foreign_keys cannot be changed inside one. So
+-- DROP TABLE codes fires an implicit DELETE that CASCADEs into refresh_tokens(code_id)
+-- and destroys every refresh token issued through the authorization code flow. Nothing
+-- reports it: PRAGMA foreign_key_check is clean afterwards. PRAGMA defer_foreign_keys,
+-- PRAGMA legacy_alter_table and PRAGMA foreign_keys = OFF were each measured and none
+-- prevents it. What works is parking refresh_tokens in a constraint-free copy and
+-- dropping it BEFORE codes is touched, so codes is childless when it goes.
+--
+-- Both tables are integer PRIMARY KEY AUTOINCREMENT, so refilling with explicit ids
+-- leaves sqlite_sequence at the highest surviving id. A high-water mark above that, left
+-- by deleting the newest row before this migration ran, is lost and that id becomes
+-- reusable. Nothing depends on it: both ids are internal surrogates, every lookup goes
+-- through code_hash or a jti, and 000011 already did exactly this to refresh_tokens.
+
+-- 1. Park refresh_tokens. CREATE TABLE AS carries no constraints, which is the point:
+--    the parked copy holds no foreign key into codes.
+CREATE TABLE rt_parked AS SELECT * FROM refresh_tokens;
+DROP TABLE refresh_tokens;
+
+-- 2. Rebuild codes with both PKCE columns nullable. Every other column, both foreign keys
+--    and all three indexes are reproduced as the migrated catalog reports them.
+CREATE TABLE codes_new (
+  `id` integer PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME,
+  updated_at DATETIME,
+  code_hash TEXT NOT NULL,
+  client_id INTEGER NOT NULL,
+  code_challenge TEXT NULL,
+  code_challenge_method TEXT NULL,
+  scope TEXT NOT NULL,
+  `state` TEXT NOT NULL,
+  nonce TEXT NOT NULL,
+  redirect_uri TEXT NOT NULL,
+  user_id INTEGER NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT NOT NULL,
+  response_mode TEXT NOT NULL,
+  authenticated_at DATETIME NOT NULL,
+  session_identifier TEXT NOT NULL,
+  acr_level TEXT NOT NULL,
+  auth_methods TEXT NOT NULL,
+  used numeric NOT NULL,
+  auth_state_generation INTEGER NOT NULL DEFAULT 0,
+  revoked numeric NOT NULL DEFAULT 0,
+  CONSTRAINT fk_codes_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE,
+  CONSTRAINT fk_codes_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+INSERT INTO codes_new (
+  `id`, created_at, updated_at, code_hash, client_id, code_challenge, code_challenge_method,
+  scope, `state`, nonce, redirect_uri, user_id, ip_address, user_agent, response_mode,
+  authenticated_at, session_identifier, acr_level, auth_methods, used, auth_state_generation,
+  revoked)
+SELECT
+  `id`, created_at, updated_at, code_hash, client_id, code_challenge, code_challenge_method,
+  scope, `state`, nonce, redirect_uri, user_id, ip_address, user_agent, response_mode,
+  authenticated_at, session_identifier, acr_level, auth_methods, used, auth_state_generation,
+  revoked
+FROM codes;
+
+DROP TABLE codes;
+ALTER TABLE codes_new RENAME TO codes;
+
+CREATE UNIQUE INDEX `idx_code_hash` ON `codes`(`code_hash`);
+CREATE INDEX idx_codes_session_identifier ON codes(session_identifier);
+CREATE INDEX idx_codes_user_id ON codes(user_id);
+
+-- 3. Rebuild refresh_tokens. code_id keeps its cascade, which is the one the engines
+--    already agree on; user_id and client_id come down to NO ACTION to meet SQL Server.
+CREATE TABLE refresh_tokens (
+  `id` integer PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME,
+  updated_at DATETIME,
+  code_id INTEGER NULL,
+  user_id INTEGER NULL,
+  client_id INTEGER NULL,
+  refresh_token_jti TEXT NOT NULL,
+  previous_refresh_token_jti TEXT NOT NULL,
+  first_refresh_token_jti TEXT NOT NULL,
+  session_identifier TEXT NOT NULL,
+  refresh_token_type TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  issued_at DATETIME,
+  expires_at DATETIME,
+  max_lifetime DATETIME,
+  revoked numeric NOT NULL,
+  auth_state_generation INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT fk_refresh_tokens_code FOREIGN KEY (code_id) REFERENCES codes (id) ON DELETE CASCADE,
+  CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE NO ACTION,
+  CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE NO ACTION
+);
+
+INSERT INTO refresh_tokens (
+  `id`, created_at, updated_at, code_id, user_id, client_id, refresh_token_jti,
+  previous_refresh_token_jti, first_refresh_token_jti, session_identifier, refresh_token_type,
+  scope, issued_at, expires_at, max_lifetime, revoked, auth_state_generation)
+SELECT
+  `id`, created_at, updated_at, code_id, user_id, client_id, refresh_token_jti,
+  previous_refresh_token_jti, first_refresh_token_jti, session_identifier, refresh_token_type,
+  scope, issued_at, expires_at, max_lifetime, revoked, auth_state_generation
+FROM rt_parked;
+
+DROP TABLE rt_parked;
+
+-- All five indexes, idx_refresh_tokens_client_id included: 000036 added it minutes before
+-- this file in the same change, and a recreate list that forgot it would silently undo it.
+CREATE UNIQUE INDEX idx_refresh_token_jti ON refresh_tokens (refresh_token_jti);
+CREATE INDEX idx_refresh_tokens_code_id ON refresh_tokens(code_id);
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_client_id ON refresh_tokens(client_id);
+CREATE INDEX idx_refresh_tokens_first_refresh_token_jti
+    ON refresh_tokens(first_refresh_token_jti);

--- a/src/core/data/sqlitedb/schema.sql
+++ b/src/core/data/sqlitedb/schema.sql
@@ -405,3 +405,5 @@ CREATE TABLE browser_sessions (
 );
 CREATE UNIQUE INDEX idx_browser_sessions_owner_hash ON browser_sessions(owner, session_id_hash);
 CREATE INDEX idx_browser_sessions_expires_at ON browser_sessions(expires_at);
+
+CREATE INDEX idx_refresh_tokens_client_id ON refresh_tokens(client_id);

--- a/src/core/data/sqlitedb/schema.sql
+++ b/src/core/data/sqlitedb/schema.sql
@@ -110,8 +110,8 @@ CREATE TABLE codes (
   updated_at DATETIME,
   code_hash TEXT NOT NULL,
   client_id INTEGER NOT NULL,
-  code_challenge TEXT NOT NULL,
-  code_challenge_method TEXT NOT NULL,
+  code_challenge TEXT NULL,
+  code_challenge_method TEXT NULL,
   scope TEXT NOT NULL,
   `state` TEXT NOT NULL,
   nonce TEXT NOT NULL,
@@ -124,9 +124,9 @@ CREATE TABLE codes (
   session_identifier TEXT NOT NULL,
   acr_level TEXT NOT NULL,
   auth_methods TEXT NOT NULL,
-  used numeric NOT NULL,  
-  revoked numeric NOT NULL DEFAULT 0,
+  used numeric NOT NULL,
   auth_state_generation INTEGER NOT NULL DEFAULT 0,
+  revoked numeric NOT NULL DEFAULT 0,
   CONSTRAINT fk_codes_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE,
   CONSTRAINT fk_codes_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
@@ -215,8 +215,8 @@ CREATE TABLE refresh_tokens (
   revoked numeric NOT NULL,
   auth_state_generation INTEGER NOT NULL DEFAULT 0,
   CONSTRAINT fk_refresh_tokens_code FOREIGN KEY (code_id) REFERENCES codes (id) ON DELETE CASCADE,
-  CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
-  CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE
+  CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE NO ACTION,
+  CONSTRAINT fk_refresh_tokens_client FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE NO ACTION
 );
 
 CREATE TABLE user_attributes (


### PR DESCRIPTION
Closes #282. Also strikes section 2 of #259, which is the same defect and is folded in here.

Goiabada's four migration sets are written by hand, four times, and nothing compares the result.
Diffing four fully migrated catalogs turns up five structural divergences. This change closes all
five, so the four engines build the same schema with two named and reasoned exceptions, and it
removes a live 500 that one of them causes on SQLite.

**The rule this establishes:** a migration is not finished until all four engines end up in the same
shape, and where an engine physically cannot reach that shape, the exception is named in the
migration file that creates it rather than discovered later by a diff.

## The five divergences

| | What diverges | Reaching parity |
|---|---|---|
| D1 | `refresh_tokens(client_id)` has no index on SQLite | additive `CREATE INDEX`, SQLite only |
| D2 | `audit_logs.details` has no `'{}'` default on MySQL | `MODIFY`, MySQL only. Parity on the default's effect, not on its recorded text: MySQL can only store a TEXT default as the expression `(_utf8mb4'{}')` where the others store `'{}'`. First named exception |
| D3 | `codes.code_challenge` and `code_challenge_method` are still `NOT NULL` on SQLite | relax SQLite, via a table rebuild |
| D4 | five columns are non-Unicode `varchar` on SQL Server | `ALTER COLUMN`, SQL Server only |
| D5 | `refresh_tokens` does not cascade on SQL Server | only downward. SQL Server refuses the CASCADE (`Msg 1785`, multiple cascade paths through `users <- codes <- refresh_tokens`), so the other three come down to `NO ACTION`. Second named exception: the invariant lives in Go on all four rather than in the schema on three |

**D3 is a live defect, not a latent one, and the issue is wrong about it.** #282 says nothing ever
writes NULL there and recommends restoring `NOT NULL` on all four. `models.Code` declares both
columns as `sql.NullString` and `oauth.CreateAuthCode` leaves them at `Valid:false` when the request
carried no challenge, so the insert does send NULL. On SQLite, the default engine, a confidential
client configured for PKCE-optional runs the whole ceremony and gets a 500 at `/auth/issue`. Six
integration tests skip on SQLite because of it. RFC 9700 section 2.1.1 makes PKCE RECOMMENDED rather
than required for confidential clients, so PKCE-optional is a configuration worth keeping, and
relaxing SQLite is the only direction that reaches parity without breaking it.

**D5 levels down, and that is unobservable.** The only two statements in the tree that delete a user
or a client row live inside `DeleteUser` and `DeleteClient`, and both clear that row's refresh tokens
first. That is why SQL Server has run without the cascade since migration 000011 without anyone
noticing.

## What has landed

### Stage 1: the shape dumper, and proving it reads each engine's catalog
`9a641d46`

`dumpTable(t, h, table)` in `src/authserver/tests/data/migration_testdb_helper.go` reads a table's
columns, indexes and foreign keys out of the configured dialect's catalog into a comparable
structure, so stage 3's hand-written SQLite rebuild can be held to a before-and-after comparison
instead of to an expectation somebody typed. That matters because a dropped column, a lost index or
a changed foreign key action are all silent: `PRAGMA foreign_key_check` sees none of them.

It compares a table against itself on one engine, never across engines, so it records each engine's
own spelling verbatim rather than mapping `TEXT`, `varchar(256)` and `nvarchar(256)` onto a common
vocabulary. Foreign keys are keyed by (local column, referenced table, referenced column, on-delete)
and not by constraint name, because SQLite's `pragma_foreign_key_list` omits the name even when the
table declares `CONSTRAINT fk_named`.

`TestDumpTable_ReadsTheCatalog` is the control: a helper that silently returns nothing would make a
before-and-after comparison read as "nothing changed" and pass. It runs against an isolated database
pinned at 000035 rather than at head, so it keeps asserting today's shape after this change alters
it, and it pins nullability and uniqueness in both polarities, the per-dialect type and default of
`auth_state_generation`, and the two divergences themselves: `codes.code_challenge` NOT NULL on
sqlite alone, `refresh_tokens.user_id` NO ACTION on mssql alone.

Seven mutations against the sqlite branches, all caught. Tiers: unit 4144 pass; data 1421 pass on
mysql, postgres, mssql and sqlite. Integration not applicable, no production code and no schema
change.

One departure from the plan, found by running it: the non-unique index control is
`idx_refresh_tokens_user_id` and not `idx_refresh_tokens_code_id`, because InnoDB indexes every
foreign key under the constraint's own name, so MySQL has no index by the latter name.

### Stage 2: the three single-engine additive fixes (D1, D2, D4)
`5b9a4e92`

Three migrations, one per engine that is out of step, no shared file between them.

**000036, sqlite:** `CREATE INDEX idx_refresh_tokens_client_id ON refresh_tokens(client_id)`. D1.

**000037, mysql:** ``ALTER TABLE `audit_logs` MODIFY `details` TEXT NOT NULL DEFAULT ('{}')``. D2.
`SET DEFAULT` fails `ERROR 1101` on a TEXT column in both spellings, so `MODIFY` with a
parenthesised expression is the only form MySQL accepts, and the result is metadata-only:
accepted with both `ALGORITHM=INSTANT` and `ALGORITHM=INPLACE`, so what is typically the largest
table in a deployment is not rebuilt.

**000038, mssql:** the five `VARCHAR` columns become `NVARCHAR`. D4. Every `ALTER COLUMN` restates
its nullability, because SQL Server makes a column nullable when the keyword is omitted whatever it
was before, and three of the five are `NOT NULL`; written without it this would have traded one
divergence for another that nothing in the tree would notice.
`clients.include_open_id_connect_claims_in_id_token` carries a default constraint whose
auto-generated name differs per database, so the name is read from `sys.default_constraints` at run
time and the replacement is named `df_clients_include_open_id_connect_claims_in_id_token`, so a
later migration can drop it without repeating the lookup.

D4's severity is narrower than #282 states. `NewMsSQLDatabase` pins
`COLLATE Latin1_General_100_CI_AI_SC_UTF8`, and under a UTF-8 collation `VARCHAR` stores Unicode
losslessly, so a database Goiabada created was never losing anything. The creation is
`IF NOT EXISTS`, so this protects a database an operator pre-created under the server's default
collation, and it repairs nothing already transcoded: a value stored as `café-é?` stays that way.

One migration test each, all four engines. Each takes two shapes, because each file exists on one
engine and `Migrate` refuses a target version the engine's source does not carry: the engine with
the file does the full 000035 → N → 000035 → N round trip, and the other three assert the state
they already have at 000035. 000036's checks the index's key columns and non-uniqueness rather than
its name, with `idx_refresh_token_jti` as the uniqueness-polarity control. 000037's asserts the
default's **effect**, inserting a row that omits `details` and reading back `{}`, and never asserts
its recorded text, which would encode a driver's charset setting rather than a schema fact. 000038's
compares before-and-after catalog dumps of all four affected tables and requires the only difference
anywhere to be the five columns' type, which catches a column dropped in passing even when nobody
thought to look for it.

Three `schema.sql` snapshots updated; `postgresdb/schema.sql` is untouched, since no divergence here
is PostgreSQL's. Seven mutations against the three migrations, all caught. Tiers: unit 4334 pass;
data 1886 pass on mysql, postgres, mssql and sqlite; integration 1325 pass on sqlite, which is what
proves 000036 applies on the real startup path rather than only under the test harness.

One departure from the plan, presentational: MySQL's snapshot carries its note about the expression
default above the `CREATE TABLE` rather than on the column line, because every other comment in that
file is a top-level one.

### Stage 3: the shared rebuild (D3 and D5)
`6c6f0416`

One migration, `000039`, on sqlite, mysql and postgres. D3 and D5 land together because both need
the same SQLite table rebuild, and doing them in one pass costs less than doing either alone. SQL
Server gets no file: it has been `ON DELETE NO ACTION` since its own 000011 and nullable on both
PKCE columns since its own 000007, so it is already where the other three are going.

**D3 is a live defect, and #282 has it backwards.** The issue says nothing reaches the column
because `models.Code` holds the challenge as a plain `string`; it holds `sql.NullString`, and
`CodeIssuer.CreateAuthCode` leaves it at `Valid:false` when the authorization request carried no
challenge, so the insert sends NULL. On SQLite, the default engine, a confidential client
configured for PKCE-optional therefore ran the whole ceremony and got a 500 at `/auth/issue`.
Restoring `NOT NULL` on all four, which the issue recommends, would have taken a one-engine failure
to four. RFC 9700 2.1.1 makes PKCE for confidential clients RECOMMENDED rather than required, so
PKCE-optional is a configuration worth keeping, and SQLite is relaxed to meet the other three.

**D5 can only be levelled down.** SQL Server refuses the cascade outright: `users <- codes <-
refresh_tokens(code_id)` alongside `users <- refresh_tokens(user_id)` is a multiple cascade path
(`Msg 1785`), reproduced on the real table shape. So `refresh_tokens.user_id` and `client_id` come
down to `NO ACTION` on the other three. It is unobservable: `DeleteUser` and `DeleteClient` are the
only statements in the codebase that delete a user or a client row, and both clear that row's
refresh tokens first, which is why SQL Server has run this way since 000011 with nobody noticing.
The invariant now lives in Go on all four engines rather than in the schema on three, which is a
named exception in this change's goal rather than an oversight.

**The SQLite ordering is not the obvious one.** golang-migrate runs each migration inside a
transaction and `PRAGMA foreign_keys` cannot be changed inside one, so `DROP TABLE codes` fires an
implicit `DELETE` that cascades into `refresh_tokens(code_id)` and destroys every refresh token
issued through the authorization code flow. Nothing reports it: `PRAGMA foreign_key_check` is clean
afterwards, so in a deployment that is every `offline_access` grant revoked with no error.
`PRAGMA defer_foreign_keys`, `PRAGMA legacy_alter_table` and `PRAGMA foreign_keys = OFF` were each
measured and none prevents it. What works is parking `refresh_tokens` in a constraint-free
`CREATE TABLE AS` copy and dropping it *before* `codes` is touched, then rebuilding it from the
parked copy with the foreign key actions wanted. Both the up and the down do that, and the down
converts NULL to `''` before restoring `NOT NULL`, which is lossless because every reader in
`ValidateTokenRequest`'s PKCE downgrade mitigation already treats the two alike.

On mysql and postgres the swap is two `DROP CONSTRAINT` / `ADD CONSTRAINT` pairs. Measured
beforehand that both explicit indexes survive it, which matters because InnoDB indexes every
foreign key and losing `idx_refresh_tokens_client_id` here would have undone stage 2 on MySQL
inside the same change.

Four migration tests, all four engines. The first is the one the rebuild's risk actually needs: it
reads both tables out of the catalog before the migration, builds the expected after-shape by
applying **only** the intended edits to it, and requires the real after-shape to equal that. Stated
as a difference rather than a checklist, it fails on a dropped column, a lost index, a changed type
spelling or a third foreign key action moving, including ones nobody thought to check. The second
covers what a shape dump cannot see, two preserved columns of the same type whose values were
swapped by the hand-written refill: it seeds through the repository's own `CreateCode` and
`CreateRefreshToken` and compares whole structs across the apply, the down and the re-apply. The
third is the challenge-less insert that used to fail, at the same boundary the diagnosis used. The
fourth is `NO ACTION` in effect rather than in the catalog: a raw `DELETE FROM users` is refused
with a ROPC-shaped token present, while `DeleteUser` still succeeds, which is the invariant above
asserted directly.

Also here: the false comment in `000007_make_pkce_nullable.up.sql`, which claimed SQLite does not
enforce `NOT NULL` (it does, on every column type), and three `schema.sql` snapshots. Six mutations
of the migration SQL, five caught by the case meant to catch them. The sixth is the value swap run
against the shape test alone, which survives on purpose: that is the argument for keeping both
tests, recorded so the row-value case is not later read as redundant.

### Stage 4: the three integration tests stop skipping on SQLite

Commit `48b4fb80`. Deletes `requireChallengelessCodesAreStorable` from
`src/authserver/tests/integration/utils_test.go`, along with its doc comment describing the SQLite
defect, and its three call sites. No production file moves.

The guard existed only because `codes.code_challenge` was NOT NULL on SQLite; stage 3's 000039
rebuild removed that, so it had nothing left to guard.

**Three was the number of call sites, not tests.** Two of the three sit inside fixture helpers
(`challengelessRefreshToken`, `challengelessCode`) rather than inside a test, so **six** tests were
skipping on SQLite and now run there:

| Was gated by | Tests |
|---|---|
| `challengelessRefreshToken` | `TestToken_Refresh_ChallengelessGrant_RefusedOnceTheClientIsPublic`, `TestToken_Refresh_ChallengelessGrant_ConfidentialClientStillRefreshes` |
| `challengelessCode` | `TestToken_AuthCode_ChallengelessCode_RefusedAfterClientBecomesPublic`, `TestToken_AuthCode_ChallengelessCode_ConfidentialClientStillSucceeds`, `TestToken_AuthCode_ChallengelessCode_SurvivesTurningPKCEOnForAConfidentialClient` |
| itself | `TestAuthorize_ConfidentialClient_PKCEOff_WithoutCodeChallenge_Succeeds` |

Tiers: unit 1246 pass; data 1446 pass on all four engines; **integration on sqlite 1010 pass with
zero skips**, where six rows reported `--- SKIP` before. mysql, postgres and mssql are the check
suite's for `48b4fb80`.

The stage adds no test, so the mutation targets what the six cover instead: setting
`authorize_validator.go`'s `if input.PKCERequired` to `if true` makes PKCE unconditional, and **all
six fail**. They really do drive a challenge-less authorization to completion on SQLite rather than
passing vacuously on a newly available engine.

## Tests

Every stage ran unit and data locally on all four engines, and integration locally on sqlite only.
Those per-stage numbers are in each stage's entry above. **The four-engine integration result exists
nowhere but the check suite**, so no local run in this branch ever produced it and none is reported
as having done so.

**The check suite is green on the final commit `48b4fb80`**, run
[33130052885](https://github.com/leodip/goiabada/actions/runs/33130052885): `Tests / sqlite`,
`Tests / mysql`, `Tests / postgres` and `Tests / mssql`, each running the data and integration tiers
on that engine, plus the three unit jobs and `Build validation`, `Lint`, `Vulnerabilities` and
`Versions`, none of which any local tier runs.

Last local run, at stage 4: unit 1246 pass; data 1446 pass on mysql, postgres, mssql and sqlite;
integration on sqlite 1010 pass **with zero skips**, where six rows reported `--- SKIP` before this
branch.

**26 mutations, 25 caught.** 21 across the four stages and 5 more run independently by the reviewer
at the final gate. The one survivor is deliberate: stage 3's value swap, run against the shape test
alone, survives on purpose to show why the row-value test is not redundant, and the same swap is
caught by the row-value test. The reviewer's five closed the last gap in that argument, so all four
of the SQLite rebuild's copy blocks are now exercised by a test that fails when their column
mappings are wrong.

### Review

Reviewed by `gpt-5.6-sol` at effort `xhigh`, 1 round over the whole branch. No stage was reviewed on
its own; the plan was reviewed separately before any code existed.

| Gate | Round | Findings | Blocking | Outcome |
|---|---|---|---|---|
| plan | 1 | 4 | 0 | all fixed in `plan.md`, no code existed yet |
| final, whole branch | 1 | 0 | 0 | clean, `static-review-exhausted`, zero `unchecked` |

- **significant, quality:** stage 1's control required 21 `codes` columns; the table has 22. Fixed in the plan: `auth_state_generation` and `revoked` are the two it omitted.
- **significant, conformance:** stage 1 required exact foreign-key constraint names on all four engines, and SQLite cannot report one. Fixed in the plan: foreign keys are keyed by local column, referenced table, referenced column and delete action instead.
- **significant, quality:** the control asserted no column type or default and had no nullable-polarity arm on SQLite, so a stub returning nothing would have passed. Fixed in the plan: both polarities on every engine, per-dialect type and default, and five mutations instead of one.
- **significant, quality:** the tests were anchored to migration versions that do not exist on every engine, and `golang-migrate` fails outright on an absent target. Fixed in the plan: pinned at 000035, the last version all four share.

The final gate found nothing, and one `unchecked` entry at the plan gate was a real gap that changed
the plan: a shape dump cannot see two preserved columns whose *values* were swapped by the
hand-written refill. The row-value test that answered it went on to catch three of the reviewer's
five independent mutations.

Full account, with the evidence and the coverage a clean verdict rests on, in
[this comment](https://github.com/leodip/goiabada/pull/286#issuecomment-5447058635).

## For the release notes

**Deleting a `users` or `clients` row by hand-written SQL now fails if refresh tokens reference it,
on SQLite, MySQL and PostgreSQL.** Those three cascaded before; SQL Server has behaved this way
since its own migration 000011. Goiabada itself is unaffected, because `DeleteUser` and
`DeleteClient` are the only code paths that delete such a row and both clear the row's refresh
tokens first. If you have your own cleanup or GDPR-erasure SQL that deletes these rows directly,
delete from `refresh_tokens` first or it will now stop with a foreign key violation instead of
silently taking the tokens with it.

**A confidential client configured for PKCE-optional now works on SQLite.** It previously ran the
whole authorization ceremony and returned a 500 at `/auth/issue`. No action; the fix is the
migration.

**SQL Server: five columns become `nvarchar`, and this does not repair data already damaged.** A
database Goiabada created was never at risk, because it pins a UTF-8 collation. If you pre-created
your database under the server's default collation, this migration stops further loss but cannot
recover a value that was already transcoded: a name stored as `caf?-?` stays that way. Check those
five columns for replacement characters if that describes your deployment.

**Take a backup before upgrading.** On SQLite, migration 000039 rebuilds `codes` and
`refresh_tokens` rather than altering them in place, which is the only way SQLite can relax a `NOT
NULL`. The down migration is written and tested in both directions, and it converts `NULL` PKCE
values back to `''`, which every existing reader already treats alike.

## The run's record

Three comments on this PR carry what the diff cannot:

- [Deferred decisions](https://github.com/leodip/goiabada/pull/286#issuecomment-5447050962): there are none, and all six decisions are listed with the two named exceptions worth revisiting.
- [Follow-ups](https://github.com/leodip/goiabada/pull/286#issuecomment-5447053565): none filed, and **#259 needs your edit** to strike its section 2, which this change closes with the opposite fix to the one it recommends.
- [The review](https://github.com/leodip/goiabada/pull/286#issuecomment-5447058635): both gates in full, with the mutation evidence.

**Deviations from the plan, all four minor and all recorded above** with the stage that hit them:
stage 1's non-unique index control had to change name, because InnoDB indexes every foreign key
under the constraint's own name; stage 2 put MySQL's snapshot comment above the `CREATE TABLE`
rather than on the column line, to match every other comment in that file; and the sealed agreement
carried two counting errors, `codes` at 21 columns rather than 22 and a dump anchored at a migration
version SQL Server does not have, both caught by the plan review before any code was written and
both fixed in the plan rather than by editing sealed text.

One correction the record should carry: this change was written against "three integration tests
skip on SQLite". Three was the number of *call sites*, and two of them sit inside fixture helpers,
so **six** tests were skipping and six now run. The goal is met more widely than it was written.

## Status

**Ready for review.** All four stages landed, the whole branch was reviewed once at the end and the
reviewer found nothing, and the check suite is green on the final commit `48b4fb80` across all four
engines. All five divergences reported in #282 are closed, and the live 500 that divergence 3 caused
on the default engine is gone.

Migrations 000036 to 000039 are reserved by this branch; #249, #259 and #268 are all open and all
want a migration number, so whichever lands second renumbers. Note that the long-lived
`goiabada_data` and `goiabada_integration` test databases make a reused migration number fail
silently, so the run that renumbers has to drop them.

<!-- leo-drive:run -->
