### PR TITLE
fix(core): startup can be told the database exists, and stops racing when it creates one

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
 					label: 'Production deployment',
 					items: [
 						{ label: 'Overview', slug: 'production-deployment' },
+						{ label: 'Database setup', slug: 'production-deployment/database' },
 						{ label: 'Cloudflare Tunnel', slug: 'production-deployment/cloudflare-tunnel' },
 						{ label: 'Cloudflare + Nginx', slug: 'production-deployment/cloudflare-nginx' },
 						{ label: 'Reverse proxy (no Cloudflare)', slug: 'production-deployment/reverse-proxy' },

--- a/site/src/content/docs/production-deployment/database.mdx
+++ b/site/src/content/docs/production-deployment/database.mdx
@@ -1,0 +1,50 @@
+---
+title: Database setup
+description: Pre-create the Goiabada database and run with a least-privilege database user.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+By default Goiabada creates its database at startup if it is not already there, which requires a
+login allowed to create databases on the server. Set `GOIABADA_DB_CREATE=false` when you have
+created the database yourself, or when the login is not allowed to: Goiabada then issues no
+`CREATE DATABASE` and opens no connection to `master` or `postgres`.
+
+Create the database with the statement for your engine, then give the login full rights inside it.
+
+## PostgreSQL
+
+```sql
+CREATE DATABASE goiabada ENCODING 'UTF8';
+```
+
+Make the login the owner, or grant it full rights in the database. It needs no `CREATEDB`
+attribute and no access to the `postgres` database.
+
+## MySQL
+
+```sql
+CREATE DATABASE goiabada CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;
+```
+
+`GRANT ALL PRIVILEGES ON goiabada.* TO 'goiabada'@'%';` is enough. No server-wide privilege is
+needed.
+
+## SQL Server
+
+```sql
+CREATE DATABASE goiabada COLLATE Latin1_General_100_CS_AS_KS_WS_SC_UTF8;
+```
+
+Map the login into the database and add it to `db_owner`. It needs no access to `master`.
+
+<Aside type="caution">
+On SQL Server, spell the `COLLATE` clause. A database default cannot be changed afterwards, because
+`ALTER DATABASE ... COLLATE` blocks while the application is connected, and every text column a
+future Goiabada migration adds inherits it.
+</Aside>
+
+## SQLite
+
+There is nothing to pre-create, and `GOIABADA_DB_CREATE` does not apply: the driver creates the file.
+To refuse an absent file instead of creating one, put `mode=rw` in `GOIABADA_DB_DSN`.

--- a/site/src/content/docs/production-deployment/database.mdx
+++ b/site/src/content/docs/production-deployment/database.mdx
@@ -21,6 +21,10 @@ CREATE DATABASE goiabada ENCODING 'UTF8';
 Make the login the owner, or grant it full rights in the database. It needs no `CREATEDB`
 attribute and no access to the `postgres` database.
 
+Quote the name if `GOIABADA_DB_NAME` is not all lower case. PostgreSQL folds an unquoted
+identifier, so `CREATE DATABASE Goiabada` makes a database called `goiabada`, which is not the one
+Goiabada connects to.
+
 ## MySQL
 
 ```sql

--- a/site/src/content/docs/production-deployment/production-checklist.mdx
+++ b/site/src/content/docs/production-deployment/production-checklist.mdx
@@ -52,7 +52,7 @@ Only enable `TRUST_PROXY_HEADERS=true` if Goiabada is actually behind a trusted 
 ## Database
 
 - [ ] **Production database** - Use MySQL or PostgreSQL for production (not SQLite)
-- [ ] **Dedicated database user** - Don't use root/admin accounts
+- [ ] **Dedicated database user** - Don't use root/admin accounts; see [database setup](/production-deployment/database/)
 - [ ] **Database backups configured** - Regular automated backups with tested restore procedures
 - [ ] **Database encryption** - Enable TLS for database connections if over network
 

--- a/site/src/content/docs/reference/environment-variables.mdx
+++ b/site/src/content/docs/reference/environment-variables.mdx
@@ -87,6 +87,11 @@ Used only on first startup:
       <td>Database name</td>
     </tr>
     <tr>
+      <td style="white-space: nowrap;"><code>GOIABADA_DB_CREATE</code><br/><code>--db-create</code></td>
+      <td><code>true</code></td>
+      <td>Create the database if it does not exist (server engines only). Set to <code>false</code> for a <a href="/production-deployment/database/">pre-created database</a></td>
+    </tr>
+    <tr>
       <td style="white-space: nowrap;"><code>GOIABADA_DB_DSN</code><br/><code>--db-dsn</code></td>
       <td><code>file::memory:</code></td>
       <td>SQLite DSN (only for sqlite)</td>

--- a/src/authserver/tests/data/database_create_test.go
+++ b/src/authserver/tests/data/database_create_test.go
@@ -618,3 +618,136 @@ func dropServerDatabase(t *testing.T, cfg *config.DatabaseConfig, name string) {
 		dropMsSQL(t, cfg, name)
 	}
 }
+
+// TestNewDatabase_CreateTrue_TheNameItCreatesIsTheNameItConnectsTo is the case the identifier
+// quoting exists for.
+//
+// GOIABADA_DB_NAME reaches two places that have to agree: the create statement and the
+// connection string. On PostgreSQL they did not. CREATE DATABASE folds an unquoted identifier,
+// so GOIABADA_DB_NAME=Goiabada created `goiabada`, while the same string sits in the connection
+// URL's path as a literal connection parameter and is not folded, so the handle then asked for
+// `Goiabada`. The deployment could never start, it never self-corrected, and the database it did
+// create sat on the server next to the one the operator asked for.
+//
+// The constructor did NOT return an error for it, which is why the assertion has to go through
+// the handle. sql.Open only parses the URL, and the creating arm has no Ping (the create
+// statement is what forces first use there, and on this path the create succeeded, against the
+// wrong name). So NewPostgresDatabase returned a nil error and a handle that failed on its first
+// query with `database "Goiabada" does not exist (SQLSTATE 3D000)`, inside the migrator, as
+// somebody else's problem.
+//
+// Two names, because they fail differently and on different engines. A mixed-case name is the
+// reported defect and is PostgreSQL's alone: MySQL does not fold an unquoted identifier and SQL
+// Server was already bracketing. A hyphenated name was a plain syntax error on PostgreSQL and
+// MySQL both, so it is what makes MySQL's backticks load-bearing here rather than only in the
+// unit tier. SQL Server needed neither and is here to stay unbroken.
+//
+// What this tier cannot witness is the doubling inside the quoting, a name carrying a double
+// quote, a backtick or a `]`. Those live in each engine package's own unit test, because a
+// database named that way is not a deployment anybody has and building the fixture would be the
+// only thing the case proved.
+//
+// SQLite is skipped: it has no create statement and no name, only a path.
+func TestNewDatabase_CreateTrue_TheNameItCreatesIsTheNameItConnectsTo(t *testing.T) {
+	if dbType() == "sqlite" || dbType() == "" {
+		t.Skip("sqlite has no database name, only a DSN path, so there is no identifier to quote")
+	}
+
+	for _, tc := range []struct {
+		label string
+		name  string
+	}{
+		// Mixed case on purpose, and unmistakably so: isolatedDBName is all lower case, which is
+		// exactly the shape that hid this for as long as it was hidden.
+		{"mixed case", "Goiabada_MixedCase_" + strings.TrimPrefix(isolatedDBName(), "goiabada_mig_")},
+		{"a hyphen", "goiabada-hyphen-" + strings.TrimPrefix(isolatedDBName(), "goiabada_mig_")},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			cfg := config.GetDatabase()
+			name := tc.name
+
+			var sqlDB *sql.DB
+			var currentDatabase string
+			switch dbType() {
+			case "mysql":
+				db, err := mysqldb.NewMySQLDatabase(&mysqldb.DatabaseConfig{
+					Type: "mysql", Username: cfg.Username, Password: cfg.Password,
+					Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+				}, false)
+				require.NoErrorf(t, err, "NewMySQLDatabase at %s", name)
+				t.Cleanup(func() { _ = db.DB.Close(); dropMySQL(t, cfg, name) })
+				sqlDB, currentDatabase = db.DB, "SELECT DATABASE()"
+			case "postgres":
+				db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
+					Type: "postgres", Username: cfg.Username, Password: cfg.Password,
+					Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+				}, false)
+				require.NoErrorf(t, err, "NewPostgresDatabase at %s", name)
+				t.Cleanup(func() { _ = db.DB.Close(); dropPostgres(t, cfg, name) })
+				sqlDB, currentDatabase = db.DB, "SELECT current_database()"
+			case "mssql":
+				db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+					Type: "mssql", Username: cfg.Username, Password: cfg.Password,
+					Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+				}, false)
+				require.NoErrorf(t, err, "NewMsSQLDatabase at %s", name)
+				t.Cleanup(func() { _ = db.DB.Close(); dropMsSQL(t, cfg, name) })
+				sqlDB, currentDatabase = db.DB, "SELECT DB_NAME()"
+			default:
+				t.Fatalf("unsupported db type %q", dbType())
+			}
+
+			// The load-bearing assertion, and it has to be a query rather than the constructor's
+			// error, because on the broken path there was no error. This is the first use of the
+			// handle, which is where PostgreSQL used to answer `database "..." does not exist`.
+			var got string
+			require.NoError(t, sqlDB.QueryRow(currentDatabase).Scan(&got),
+				"first use of the handle the constructor returned: this is where an unquoted CREATE DATABASE surfaced, as the migrator's problem rather than the constructor's")
+			require.Equal(t, name, got,
+				"the handle must be connected to the database the constructor created, spelled the way the operator spelled it")
+
+			// And the other half of the symptom: the deployment must not be left with a database
+			// it did not ask for sitting next to the one it did. Counted case-insensitively,
+			// because that is the only comparison that can see both at once, and because on
+			// PostgreSQL, the one engine where the two are distinct rows, it is the only one that
+			// would have caught the pair.
+			require.Equal(t, 1, serverDatabasesMatchingFold(t, name),
+				"exactly one database on the server may answer to this name; two means the create statement and the connection string spelled it differently")
+		})
+	}
+}
+
+// serverDatabasesMatchingFold counts the databases whose name matches name ignoring case.
+//
+// serverDatabaseExists above cannot answer this. Its predicate is the engine's own comparison,
+// which folds case on MySQL and SQL Server and does not on PostgreSQL, so on those two it cannot
+// distinguish one database from a folded pair and on PostgreSQL it would only ever see one of
+// them. Folding explicitly on all three asks the same question everywhere: how many databases on
+// this server answer to this name (#293).
+func serverDatabasesMatchingFold(t *testing.T, name string) int {
+	t.Helper()
+	cfg := config.GetDatabase()
+
+	var dsn, driver, query string
+	switch dbType() {
+	case "mysql":
+		driver, dsn = "mysql", mySQLServerDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM information_schema.SCHEMATA WHERE LOWER(SCHEMA_NAME) = LOWER(?)"
+	case "postgres":
+		driver, dsn = "pgx", postgresMaintenanceDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM pg_database WHERE LOWER(datname) = LOWER($1)"
+	case "mssql":
+		driver, dsn = "sqlserver", msSQLMasterDSN(cfg)
+		query = "SELECT COUNT(*) FROM sys.databases WHERE LOWER(name) = LOWER(@p1)"
+	default:
+		t.Fatalf("%s has no server catalog of databases", dbType())
+	}
+
+	sqlDB, err := sql.Open(driver, dsn)
+	require.NoError(t, err, "open the server to read its catalog")
+	defer func() { _ = sqlDB.Close() }()
+
+	var n int
+	require.NoError(t, sqlDB.QueryRow(query, name).Scan(&n), "count databases matching %s", name)
+	return n
+}

--- a/src/authserver/tests/data/database_create_test.go
+++ b/src/authserver/tests/data/database_create_test.go
@@ -1,0 +1,224 @@
+package datatests
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/data/mssqldb"
+	"github.com/leodip/goiabada/core/data/mysqldb"
+	"github.com/leodip/goiabada/core/data/postgresdb"
+	"github.com/leodip/goiabada/core/data/sqlitedb"
+	"github.com/stretchr/testify/require"
+)
+
+// The three engine constructors that open a maintenance connection and issue a create
+// statement. GOIABADA_DB_CREATE decides whether they do, and these tests own both answers at
+// the constructor boundary (#293).
+//
+// Why the boundary and not data.NewDatabase: the factory also migrates and runs the startup
+// data tasks, so a failure there could be any of three things. The constructor's contract is
+// "given a config, return a usable handle or an error", and that is what an operator's
+// deployment either satisfies or does not.
+
+// TestNewDatabase_CreateFalse_StartsUnderALeastPrivilegeLogin is the case #293 exists for, and
+// the one that cannot be faked.
+//
+// This tier connects as root, sa or postgres, so a test that pre-created the database and set
+// Create: false would pass with the maintenance connection still opened and the create still
+// issued: a superuser can do both. The restricted login is what observes their absence from
+// outside, which is why the fixture goes to the trouble of building one per engine.
+//
+// PostgreSQL is where this used to be a hard failure rather than a nicety: with the database
+// present and the role owning it but holding no CREATEDB, the old unconditional CREATE DATABASE
+// gave "permission denied to create database (SQLSTATE 42501)", which the constructor's
+// "already exists" tolerance does not match, so the server would not start. The production
+// checklist's "don't use root/admin accounts" was advice a PostgreSQL reader could not follow.
+func TestNewDatabase_CreateFalse_StartsUnderALeastPrivilegeLogin(t *testing.T) {
+	if dbType() == "sqlite" || dbType() == "" {
+		t.Skip("sqlite has no login and no create statement, so there is nothing to restrict")
+	}
+
+	r := newRestrictedLoginDB(t)
+	db, sqlDB := r.constructRestricted(t)
+
+	if dbType() == "mysql" {
+		// Read before anything else touches the server. MySQL cannot deny the maintenance DSN
+		// to a login it allows the application DSN to, so the privilege above proves nothing
+		// here and this counter is what does: one connection is the skipping path, two is a
+		// constructor that still opened the no-database DSN.
+		require.Equal(t, 1, r.connectionCount(t),
+			"with Create false the constructor must open exactly one connection, to the application database; a second means the maintenance DSN was still opened")
+	}
+
+	// Migrating the full chain and then reading through the handle is the rest of the claim:
+	// the restricted login does not merely connect, it can do everything Goiabada needs.
+	h := newIsolated(t, db, sqlDB)
+	require.NoError(t, h.Migrator.Up(), "migrate the full chain as the restricted login")
+
+	var clients int
+	require.NoError(t, h.SQL.QueryRow("SELECT COUNT(*) FROM clients").Scan(&clients),
+		"read through the handle the constructor returned")
+	require.Equal(t, 0, clients, "the chain migrates an empty database, it does not seed one")
+}
+
+// TestNewDatabase_CreateFalse_AbsentDatabaseIsTheConstructorsError holds seam 1's third case:
+// the operator said the database was there and it is not.
+//
+// Decision 7 chose to let the engine's own error stand rather than detect the case, so what is
+// pinned here is that the error arrives AT THE CONSTRUCTOR carrying that text. Two of the three
+// engines needed a change for that to be true: sql.Open only parses a DSN, so NewMySQLDatabase
+// and NewPostgresDatabase used to return a usable-looking handle and a nil error, and the
+// failure surfaced later inside the migrator as somebody else's problem.
+func TestNewDatabase_CreateFalse_AbsentDatabaseIsTheConstructorsError(t *testing.T) {
+	if dbType() == "sqlite" || dbType() == "" {
+		t.Skip("sqlite has no create statement to skip; an absent file is decided by the DSN's mode")
+	}
+
+	cfg := config.GetDatabase()
+	name := isolatedDBName()
+
+	var err error
+	var wantText string
+	switch dbType() {
+	case "mysql":
+		_, err = mysqldb.NewMySQLDatabase(&mysqldb.DatabaseConfig{
+			Type: "mysql", Username: cfg.Username, Password: cfg.Password,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: false,
+		}, false)
+		wantText = "Unknown database"
+	case "postgres":
+		_, err = postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
+			Type: "postgres", Username: cfg.Username, Password: cfg.Password,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: false,
+		}, false)
+		wantText = "does not exist"
+	case "mssql":
+		_, err = mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+			Type: "mssql", Username: cfg.Username, Password: cfg.Password,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: false,
+		}, false)
+		wantText = "Cannot open database"
+	default:
+		t.Fatalf("unsupported db type %q", dbType())
+	}
+
+	require.Error(t, err, "Create false against an absent database must not return a usable handle")
+	require.Containsf(t, err.Error(), wantText,
+		"the engine's own missing-database error is what decision 7 chose to let stand, and it must reach the caller intact")
+
+	// And nothing was created on the way to that error, which is the other half of the claim:
+	// the whole point of the setting is that a deployment which forbids creating a database is
+	// not asked to.
+	require.False(t, serverDatabaseExists(t, name), "Create false must create nothing")
+}
+
+// TestNewMsSQLDatabase_CreateTrue_LeavesAPreCreatedDatabaseAlone keeps IF NOT EXISTS pinned.
+//
+// newPreCreatedMsSQLDB used to be what held it: it constructed over an operator's database and
+// asserted the collation survived. It now passes Create: false, so its assertion is trivially
+// true, no statement having run that could have changed anything. This is the same assertion on
+// the arm where the statement DOES run, which is the one goal 4 is about: an operator who sets
+// nothing still gets today's behaviour, and today's behaviour leaves their database alone.
+//
+// SQL Server only, because it is the only engine where the operator's choice is permanent:
+// ALTER DATABASE ... COLLATE blocks against a live connection pool, so no migration can repair
+// a database default, and every string column a future migration adds without spelling COLLATE
+// inherits it (#283 decision 4).
+func TestNewMsSQLDatabase_CreateTrue_LeavesAPreCreatedDatabaseAlone(t *testing.T) {
+	if dbType() != "mssql" {
+		t.Skipf("%s has no database default collation an operator's CREATE DATABASE could fix in place", dbType())
+	}
+
+	// The container's stock server default: case-insensitive, accent-sensitive and not UTF-8,
+	// so it is neither the collation Goiabada pinned before #283 nor the one it pins after, and
+	// a database that came out at it cannot be mistaken for one the constructor created.
+	const operatorCollation = "SQL_Latin1_General_CP1_CI_AS"
+
+	cfg := config.GetDatabase()
+	name := isolatedDBName()
+
+	master, err := sql.Open("sqlserver", msSQLMasterDSN(cfg))
+	require.NoError(t, err, "open master to pre-create the database")
+	defer func() { _ = master.Close() }()
+	mustExec(t, master, "CREATE DATABASE ["+name+"] COLLATE "+operatorCollation)
+	t.Cleanup(func() { dropMsSQL(t, cfg, name) })
+
+	db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+		Type: "mssql", Username: cfg.Username, Password: cfg.Password,
+		Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+	}, false)
+	require.NoError(t, err, "NewMsSQLDatabase on the creating arm over a database that is already there")
+	t.Cleanup(func() { _ = db.DB.Close() })
+
+	require.Equal(t, operatorCollation, readDatabaseDefaultCollation(t, db.DB),
+		"the creating arm's CREATE DATABASE is IF NOT EXISTS, so an operator's database and its collation stand")
+}
+
+// TestSQLiteConfigHasNoCreateField is seam 2, and it is a test rather than a comment because
+// the compiler is otherwise the only witness and it would stop being one the moment somebody
+// added the field for symmetry.
+//
+// Decision 4: GOIABADA_DB_CREATE does not apply to SQLite. There is no create statement and no
+// maintenance connection, and what decides whether an absent file is created is the operator's
+// own DSN. Giving the config a field would promise a control that does nothing.
+func TestSQLiteConfigHasNoCreateField(t *testing.T) {
+	_, found := reflect.TypeOf(sqlitedb.DatabaseConfig{}).FieldByName("Create")
+	require.False(t, found,
+		"sqlitedb.DatabaseConfig must carry no Create field: SQLite has no create statement for it to govern, and mode=rw in the DSN is the equivalent (#293 decision 4)")
+}
+
+// TestNewSQLiteDatabase_ModeRWDoesNotCreateTheFile is the other half of decision 4: the thing
+// an operator who set GOIABADA_DB_CREATE=false globally actually wants on SQLite is in the DSN,
+// and it works. modernc.org/sqlite honours SQLite's own mode=rw, so an absent file is an error
+// rather than a new empty database.
+//
+// Not engine-specific: it constructs a SQLite database directly, so it is worth running in
+// every engine's job.
+func TestNewSQLiteDatabase_ModeRWDoesNotCreateTheFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "absent.db")
+
+	_, err := sqlitedb.NewSQLiteDatabase(&sqlitedb.DatabaseConfig{
+		Type: "sqlite", DSN: "file:" + path + "?mode=rw",
+	}, false)
+	require.Error(t, err, "mode=rw against an absent file must fail rather than create it")
+
+	_, statErr := os.Stat(path)
+	require.Truef(t, os.IsNotExist(statErr),
+		"mode=rw must not have created %s, but stat says %v", path, statErr)
+}
+
+// serverDatabaseExists asks the server's own catalog, through the tier's privileged
+// credential, whether a database is there. Used to show that the skipping path created nothing
+// on its way to failing.
+func serverDatabaseExists(t *testing.T, name string) bool {
+	t.Helper()
+	cfg := config.GetDatabase()
+
+	var dsn, driver, query string
+	switch dbType() {
+	case "mysql":
+		driver, dsn = "mysql", mySQLServerDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?"
+	case "postgres":
+		driver, dsn = "pgx", postgresMaintenanceDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM pg_database WHERE datname = $1"
+	case "mssql":
+		driver, dsn = "sqlserver", msSQLMasterDSN(cfg)
+		query = "SELECT COUNT(*) FROM sys.databases WHERE name = @p1"
+	default:
+		t.Fatalf("%s has no server catalog of databases", dbType())
+	}
+
+	sqlDB, err := sql.Open(driver, dsn)
+	require.NoError(t, err, "open the server to read its catalog")
+	defer func() { _ = sqlDB.Close() }()
+
+	var n int
+	require.NoError(t, sqlDB.QueryRow(query, name).Scan(&n), "count databases named %s", name)
+	return n > 0
+}

--- a/src/authserver/tests/data/database_create_test.go
+++ b/src/authserver/tests/data/database_create_test.go
@@ -1,6 +1,7 @@
 package datatests
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -414,6 +415,164 @@ func raceConstructors(t *testing.T, cfg *config.DatabaseConfig, names []string) 
 	wg.Wait()
 
 	return handles, errs
+}
+
+// TestNewDatabase_CreateTrue_AnUnrelatedLockHolderDoesNotBlockAnOrdinaryRestart is what stands
+// between the creation lock and every restart of every default deployment.
+//
+// The lock lives in a database Goiabada does not own: `postgres` on PostgreSQL, `master` on SQL
+// Server. Both share one lock space with every session on the server, so the resource can be
+// held by a principal that has no rights inside Goiabada's database at all: a PostgreSQL role
+// with neither CREATEDB nor a grant on it, a SQL Server login holding nothing but public. Reach
+// for the lock before asking whether the database is there and that stranger can stall every
+// start, indefinitely, of a deployment whose database was created years ago. #293 decision 5
+// accepted that a stuck holder blocks startup rather than failing it; it did not accept putting
+// an unrelated principal on the ordinary restart path for the life of the deployment.
+//
+// So the catalog check comes first and the lock is reached only when there is something to
+// create. This holds the resource from another session and requires that a constructor with
+// Create true, against a database that already exists, still returns.
+//
+// The holder here is the tier's own privileged credential, because the constructor cannot tell
+// who holds the resource and so the holder's identity is not what this case pins. What makes it
+// a security fact rather than an operational one is the lock space being shared server-wide,
+// which is recorded on createDatabaseUnderAppLock and createDatabaseUnderAdvisoryLock.
+//
+// Not a test of the lock itself. TestNewDatabase_CreateTrue_ConcurrentConstructorsAgainstAn-
+// AbsentDatabase owns that and must keep passing, because a pre-check that let a second creator
+// through would buy this case at the cost of goal 1.
+func TestNewDatabase_CreateTrue_AnUnrelatedLockHolderDoesNotBlockAnOrdinaryRestart(t *testing.T) {
+	switch dbType() {
+	case "mysql":
+		t.Skip("MySQL takes no database-creation lock: CREATE DATABASE IF NOT EXISTS is serialised by the engine itself (#293 decision 6)")
+	case "sqlite", "":
+		t.Skip("SQLite has no maintenance database, so there is no shared lock space and no lock")
+	case "postgres", "mssql":
+	default:
+		t.Fatalf("unsupported db type %q", dbType())
+	}
+
+	cfg := config.GetDatabase()
+	name := isolatedDBName()
+	t.Cleanup(func() { dropServerDatabase(t, cfg, name) })
+
+	// Put the deployment in the state every start after the first is in: the database is there.
+	first, err := constructCreating(cfg, name)
+	require.NoError(t, err, "the first construction is the one that creates the database")
+	if first != nil {
+		_ = first.Close()
+	}
+	require.True(t, serverDatabaseExists(t, name),
+		"the first construction must have created the database, or the restart below is not the case under test")
+
+	holdCreationLock(t, cfg, name)
+
+	// A constructor that reaches for the lock never returns, so this is a bounded wait rather
+	// than a plain call: the regression has to fail the test rather than hang the tier. The
+	// budget is far above what the path costs, which is one catalog read and one connection.
+	const restartBudget = 30 * time.Second
+
+	done := make(chan error, 1)
+	go func() {
+		h, err := constructCreating(cfg, name)
+		if h != nil {
+			_ = h.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a restart against a database that already exists must construct, lock held or not")
+	case <-time.After(restartBudget):
+		t.Fatalf("the constructor did not return within %s while another session held the database-creation lock. It is reaching for the lock before checking whether the database exists, so any principal that can connect to the maintenance database can stall every default start (#293)", restartBudget)
+	}
+}
+
+// constructCreating builds one constructor on the configured engine with Create true, which is
+// the path an operator who sets nothing takes.
+//
+// Takes no *testing.T, deliberately: it is called from a goroutine that may be blocked when the
+// test fails, and t.Fatalf off the test goroutine is undefined.
+func constructCreating(cfg *config.DatabaseConfig, name string) (io.Closer, error) {
+	switch dbType() {
+	case "postgres":
+		db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
+			Type: "postgres", Username: cfg.Username, Password: cfg.Password,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+		}, false)
+		if db == nil {
+			return nil, err
+		}
+		return db.DB, err
+	case "mssql":
+		db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+			Type: "mssql", Username: cfg.Username, Password: cfg.Password,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+		}, false)
+		if db == nil {
+			return nil, err
+		}
+		return db.DB, err
+	default:
+		return nil, fmt.Errorf("constructCreating does not run on %s", dbType())
+	}
+}
+
+// holdCreationLock takes the exact resource the creating path serialises on, from a session that
+// has nothing to do with any constructor, and releases it when the test ends.
+//
+// The identity comes from the production symbols, postgresdb.AdvisoryLockKey and
+// mssqldb.CreateDatabaseResource, rather than from literals restated here. A restated key would
+// be a second definition free to drift, and a test holding the WRONG lock passes no matter what
+// the constructor does.
+//
+// Both locks are session-scoped, so each is taken on one connection pinned out of the pool and
+// released on that same connection. Released through t.Cleanup rather than at the end of the
+// body, so a failing assertion still frees whatever the constructor under test is waiting on.
+func holdCreationLock(t *testing.T, cfg *config.DatabaseConfig, name string) {
+	t.Helper()
+	ctx := context.Background()
+
+	var driver, dsn string
+	switch dbType() {
+	case "postgres":
+		driver, dsn = "pgx", postgresMaintenanceDSN(cfg.Username, cfg.Password, cfg)
+	case "mssql":
+		driver, dsn = "sqlserver", msSQLMasterDSN(cfg)
+	default:
+		t.Fatalf("%s has no database-creation lock to hold", dbType())
+	}
+
+	pool, err := sql.Open(driver, dsn)
+	require.NoError(t, err, "open the maintenance database to hold the creation lock")
+	conn, err := pool.Conn(ctx)
+	require.NoError(t, err, "pin a connection for the creation lock")
+
+	switch dbType() {
+	case "postgres":
+		_, err = conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", postgresdb.AdvisoryLockKey(name))
+		require.NoError(t, err, "take the advisory lock the creating path serialises on")
+	case "mssql":
+		const takeLock = `DECLARE @lockResult int;
+			EXEC @lockResult = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = -1;
+			SELECT @lockResult;`
+		var status int
+		require.NoError(t, conn.QueryRowContext(ctx, takeLock, mssqldb.CreateDatabaseResource).Scan(&status),
+			"take the application lock the creating path serialises on")
+		require.GreaterOrEqual(t, status, 0, "sp_getapplock refused the lock, so nothing below is held")
+	}
+
+	t.Cleanup(func() {
+		switch dbType() {
+		case "postgres":
+			_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", postgresdb.AdvisoryLockKey(name))
+		case "mssql":
+			_, _ = conn.ExecContext(ctx, `EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'`, mssqldb.CreateDatabaseResource)
+		}
+		_ = conn.Close()
+		_ = pool.Close()
+	})
 }
 
 // countServerDatabases is serverDatabaseExists with the number kept, which the case-variant case

--- a/src/authserver/tests/data/database_create_test.go
+++ b/src/authserver/tests/data/database_create_test.go
@@ -2,10 +2,15 @@ package datatests
 
 import (
 	"database/sql"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/data/mssqldb"
@@ -221,4 +226,236 @@ func serverDatabaseExists(t *testing.T, name string) bool {
 	var n int
 	require.NoError(t, sqlDB.QueryRow(query, name).Scan(&n), "count databases named %s", name)
 	return n > 0
+}
+
+// concurrentConstructors is how many constructors the race cases start at once. Eight is what
+// probe/mssql_concurrent_create.go and probe/pg_mysql_concurrent_create.go measured the defect
+// at, and it reproduced every round: 5 of 8 SQL Server racers and 7 of 8 PostgreSQL racers
+// failed against an absent database before #293.
+const concurrentConstructors = 8
+
+// TestNewDatabase_CreateTrue_ConcurrentConstructorsAgainstAnAbsentDatabase is goal 1, and it is
+// seam 1's first table.
+//
+// Two Goiabada instances starting at the same moment against a server where the application
+// database does not exist is an ordinary topology: two replicas, a rolling deploy, a compose file
+// bringing both modules up together. Before #293 the losers did not start. On SQL Server the
+// check-then-create is not atomic and most losers get no error number and no message, only
+// "Request failed but didn't provide reason"; on PostgreSQL the bare CREATE DATABASE fails with
+// SQLSTATE 23505 on pg_database_datname_index, whose text does not contain "already exists" and
+// so is not tolerated.
+//
+// What the constructors now do instead is serialise: an exclusive lock, held on one connection
+// pinned out of the maintenance pool, spans the existence check and the create, so at most one
+// process ever issues CREATE DATABASE (decision 5).
+//
+// Deliberately at the CONSTRUCTOR and not at data.NewDatabase, per §5: the factory also migrates,
+// and a race measured through it would be measuring migration concurrency too, against a lock the
+// migrator already takes for itself.
+func TestNewDatabase_CreateTrue_ConcurrentConstructorsAgainstAnAbsentDatabase(t *testing.T) {
+	switch dbType() {
+	case "mysql":
+		t.Skip("MySQL is immune structurally, not by luck: it serialises on the schema metadata lock and demotes the duplicate to Note 1007, which the driver never raises. 288 full sequences at 24-way concurrency, 0 failures (#293 decision 6)")
+	case "sqlite", "":
+		t.Skip("SQLite has no create statement to race: the driver creates the file")
+	case "postgres", "mssql":
+	default:
+		t.Fatalf("unsupported db type %q", dbType())
+	}
+
+	cfg := config.GetDatabase()
+	name := isolatedDBName()
+	require.False(t, serverDatabaseExists(t, name), "the race has to start against an ABSENT database, which is the only case that is not already serialised by the database being there")
+	t.Cleanup(func() { dropServerDatabase(t, cfg, name) })
+
+	handles, errs := raceConstructors(t, cfg, namesRepeated(name, concurrentConstructors))
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "constructor %d of %d started at the same instant against an absent database; every one of them must start, because two replicas coming up together is an ordinary topology and before #293 the losers did not (#293 goal 1)", i+1, concurrentConstructors)
+	}
+	for _, h := range handles {
+		if h != nil {
+			_ = h.Close()
+		}
+	}
+
+	require.True(t, serverDatabaseExists(t, name), "the winner must have created the database")
+
+	if dbType() == "mssql" {
+		// The lock must not have cost the collation: a database Goiabada creates is created at
+		// the collation #283 pinned, whichever racer created it.
+		db, err := sql.Open("sqlserver", msSQLDatabaseDSN(cfg.Username, cfg.Password, name, cfg))
+		require.NoError(t, err, "open the database the race created")
+		defer func() { _ = db.Close() }()
+		require.Equal(t, mssqlCollationAfter000040, readDatabaseDefaultCollation(t, db),
+			"the racing constructors must still create at the collation #283 pinned")
+	}
+}
+
+// TestNewMsSQLDatabase_CreateTrue_CaseVariantNamesRaceToOneDatabase is why the SQL Server lock
+// resource carries no database name.
+//
+// sp_getapplock compares its resource as binary. sys.databases.name is compared under master's
+// collation, which on a stock instance folds case. So a resource of
+// "goiabada:create-database:" + name gives two instances configured `goiabada` and `Goiabada`
+// two DIFFERENT locks, while the IF NOT EXISTS check they each run treats the two names as ONE
+// database: both pass the check and both run CREATE DATABASE, which is the original defect with
+// a lock bolted on. Partial normalization in Go cannot close that family, because the
+// equivalences are whatever the instance's collation says they are.
+//
+// The constant resource is strictly wider than the thing it guards, which is the safe direction,
+// and this case is what holds it in place: without it the file compiles, every other test passes,
+// and the narrower resource looks like an improvement.
+//
+// SQL Server only. PostgreSQL compares pg_database.datname byte-exact, so there is no fold for a
+// name-derived key to disagree with, which is exactly why it keeps one.
+func TestNewMsSQLDatabase_CreateTrue_CaseVariantNamesRaceToOneDatabase(t *testing.T) {
+	if dbType() != "mssql" {
+		t.Skipf("%s does not compare database names case-insensitively, so there are no case variants to collide", dbType())
+	}
+
+	cfg := config.GetDatabase()
+	lower := isolatedDBName()
+	upper := strings.ToUpper(lower)
+	require.NotEqual(t, lower, upper, "the two spellings have to actually differ for this to test anything")
+
+	require.False(t, serverDatabaseExists(t, lower), "the race has to start against an absent database")
+	t.Cleanup(func() {
+		dropServerDatabase(t, cfg, lower)
+		dropServerDatabase(t, cfg, upper)
+	})
+
+	// Alternating spellings rather than one of each: the broken form only fails when two racers
+	// are inside the unguarded window together, and eight give that far more chances than two.
+	names := make([]string, concurrentConstructors)
+	for i := range names {
+		if i%2 == 0 {
+			names[i] = lower
+		} else {
+			names[i] = upper
+		}
+	}
+
+	handles, errs := raceConstructors(t, cfg, names)
+	for i, err := range errs {
+		require.NoErrorf(t, err, "constructor %d configured %q raced against the other spelling; both spellings name ONE database on SQL Server, so both must start", i+1, names[i])
+	}
+	for _, h := range handles {
+		if h != nil {
+			_ = h.Close()
+		}
+	}
+
+	require.Equal(t, 1, countServerDatabases(t, lower),
+		"the two spellings must have produced exactly ONE database: master compares names case-insensitively, so a second CREATE DATABASE means the racers held different locks")
+}
+
+// namesRepeated is n copies of one database name, which is what the plain race case configures
+// every racer with.
+func namesRepeated(name string, n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = name
+	}
+	return names
+}
+
+// raceConstructors starts one constructor per name at the same instant on the configured engine,
+// with Create true, and returns each one's handle and error positionally.
+//
+// The handles come back rather than being closed here because a caller may want to read through
+// one, and the errors come back rather than being asserted here because which of them is allowed
+// to be non-nil is the caller's claim, not this helper's.
+//
+// The barrier is a closed channel rather than a WaitGroup countdown: every goroutine is already
+// parked on the receive when it opens, so they leave together instead of in creation order. The
+// pause before it is what the probes used, and it is there to let the runtime actually schedule
+// all of them onto the receive first.
+func raceConstructors(t *testing.T, cfg *config.DatabaseConfig, names []string) ([]io.Closer, []error) {
+	t.Helper()
+
+	start := make(chan struct{})
+	handles := make([]io.Closer, len(names))
+	errs := make([]error, len(names))
+
+	var wg sync.WaitGroup
+	for i, name := range names {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			<-start
+			switch dbType() {
+			case "postgres":
+				db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
+					Type: "postgres", Username: cfg.Username, Password: cfg.Password,
+					Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+				}, false)
+				errs[i] = err
+				if db != nil {
+					handles[i] = db.DB
+				}
+			case "mssql":
+				db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+					Type: "mssql", Username: cfg.Username, Password: cfg.Password,
+					Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
+				}, false)
+				errs[i] = err
+				if db != nil {
+					handles[i] = db.DB
+				}
+			default:
+				errs[i] = fmt.Errorf("raceConstructors does not run on %s", dbType())
+			}
+		}(i, name)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(start)
+	wg.Wait()
+
+	return handles, errs
+}
+
+// countServerDatabases is serverDatabaseExists with the number kept, which the case-variant case
+// needs: "exactly one" and "at least one" are the passing and failing answers there.
+func countServerDatabases(t *testing.T, name string) int {
+	t.Helper()
+	cfg := config.GetDatabase()
+
+	var dsn, driver, query string
+	switch dbType() {
+	case "mysql":
+		driver, dsn = "mysql", mySQLServerDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?"
+	case "postgres":
+		driver, dsn = "pgx", postgresMaintenanceDSN(cfg.Username, cfg.Password, cfg)
+		query = "SELECT COUNT(*) FROM pg_database WHERE datname = $1"
+	case "mssql":
+		driver, dsn = "sqlserver", msSQLMasterDSN(cfg)
+		query = "SELECT COUNT(*) FROM sys.databases WHERE name = @p1"
+	default:
+		t.Fatalf("%s has no server catalog of databases", dbType())
+	}
+
+	sqlDB, err := sql.Open(driver, dsn)
+	require.NoError(t, err, "open the server to read its catalog")
+	defer func() { _ = sqlDB.Close() }()
+
+	var n int
+	require.NoError(t, sqlDB.QueryRow(query, name).Scan(&n), "count databases named %s", name)
+	return n
+}
+
+// dropServerDatabase is the configured engine's drop, so a case that runs on more than one engine
+// registers one cleanup rather than switching on the dialect itself.
+func dropServerDatabase(t *testing.T, cfg *config.DatabaseConfig, name string) {
+	t.Helper()
+	switch dbType() {
+	case "mysql":
+		dropMySQL(t, cfg, name)
+	case "postgres":
+		dropPostgres(t, cfg, name)
+	case "mssql":
+		dropMsSQL(t, cfg, name)
+	}
 }

--- a/src/authserver/tests/data/migration_testdb_helper.go
+++ b/src/authserver/tests/data/migration_testdb_helper.go
@@ -301,7 +301,10 @@ func dropMySQL(t *testing.T, cfg *config.DatabaseConfig, name string) {
 		return
 	}
 	defer func() { _ = sqlDB.Close() }()
-	if _, err := sqlDB.Exec("DROP DATABASE IF EXISTS " + name); err != nil {
+	// Backticked, like the constructor's own CREATE DATABASE: a fixture at a mixed-case or
+	// otherwise quote-needing name has to be droppable by the same spelling it was created at
+	// (#293).
+	if _, err := sqlDB.Exec("DROP DATABASE IF EXISTS `" + strings.ReplaceAll(name, "`", "``") + "`"); err != nil {
 		t.Logf("dropMySQL exec: %v", err)
 	}
 }
@@ -315,8 +318,11 @@ func dropPostgres(t *testing.T, cfg *config.DatabaseConfig, name string) {
 		return
 	}
 	defer func() { _ = sqlDB.Close() }()
-	// FORCE terminates lingering connections (PostgreSQL 13+).
-	if _, err := sqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)", name)); err != nil {
+	// FORCE terminates lingering connections (PostgreSQL 13+). Quoted, like the constructor's
+	// own CREATE DATABASE: unquoted, this folds the name and would silently drop nothing for a
+	// mixed-case fixture, leaving it on the server for every later run (#293).
+	if _, err := sqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)",
+		postgresdb.QuoteIdentifier(name))); err != nil {
 		t.Logf("dropPostgres exec: %v", err)
 	}
 }

--- a/src/authserver/tests/data/migration_testdb_helper.go
+++ b/src/authserver/tests/data/migration_testdb_helper.go
@@ -365,11 +365,16 @@ func newPreCreatedMsSQLDB(t *testing.T, collation string) *isolatedDB {
 	require.NoError(t, err, "NewMsSQLDatabase over a pre-created database")
 	t.Cleanup(func() { _ = db.DB.Close(); dropMsSQL(t, cfg, name) })
 
-	// The point of the helper, asserted rather than assumed: if IF NOT EXISTS ever stopped
-	// being IF NOT EXISTS, every test built on this would go on passing for the wrong
-	// reason.
+	// Asserted rather than assumed: with Create false nothing in the constructor may touch
+	// the database at all, so one that started creating or altering one would be caught here
+	// rather than leaving every test built on this fixture passing for the wrong reason.
+	//
+	// That IF NOT EXISTS on the CREATING arm still leaves an operator's database alone is a
+	// different claim and it has its own case, in database_create_test.go: this fixture used
+	// to be what held it, and once it stopped issuing the statement it stopped being evidence
+	// about it (#293).
 	require.Equal(t, collation, readDatabaseDefaultCollation(t, db.DB),
-		"NewMsSQLDatabase must leave a database it did not create alone; its CREATE DATABASE is IF NOT EXISTS")
+		"NewMsSQLDatabase with Create false must leave the operator's database exactly as it found it")
 
 	return newIsolated(t, db, db.DB)
 }
@@ -402,4 +407,246 @@ func dropMsSQL(t *testing.T, cfg *config.DatabaseConfig, name string) {
 	if _, err := sqlDB.Exec(stmt); err != nil {
 		t.Logf("dropMsSQL exec: %v", err)
 	}
+}
+
+// restrictedLoginDB is the deployment goals 2 and 3 of #293 are about: the database already
+// exists, and the credential Goiabada connects with holds only the rights it needs INSIDE it.
+// No CREATEDB on PostgreSQL, no server-wide CREATE on MySQL, no access to master on SQL Server.
+//
+// It is the load-bearing fixture for the skipping path, and the reason is that this tier
+// connects as root/sa/postgres. A test that merely pre-created the database and set
+// Create: false would pass with the maintenance connection still opened and the create
+// statement still issued, because a superuser can do both. A restricted login is what observes
+// their absence from outside the constructor, which is why §5 of the agreement rejects counting
+// connections and decision 8 chose this instead.
+//
+// MySQL is the one engine where that is not enough, and the shortfall is measured rather than
+// assumed: MySQL has no per-schema CONNECT privilege, so a login granted ALL PRIVILEGES ON
+// <db>.* connects with no database selected AND its CREATE DATABASE IF NOT EXISTS <db>
+// succeeds, the engine short-circuiting because the database is there. No credential can deny
+// the maintenance DSN while allowing the application one. connectionCount below is what covers
+// MySQL instead.
+type restrictedLoginDB struct {
+	// name is the pre-created application database.
+	name string
+	// username and password are the restricted credential. The account is created for one
+	// test and dropped with it, on a throwaway container, and on MySQL it is also the key
+	// the connection counter reads, so it must belong to no other test.
+	username string
+	password string
+	// admin is this tier's own privileged handle, kept open for the life of the test so
+	// assertions can read the server's catalogs from outside the restricted login.
+	admin *sql.DB
+}
+
+// restrictedLoginPassword satisfies SQL Server's password rules without CHECK_POLICY, which the
+// fixture turns off anyway. It authenticates nothing outside the test container.
+const restrictedLoginPassword = "goiabadaRestricted123!"
+
+// restrictedLoginName is a login name unique to this process and call: lowercase so PostgreSQL
+// takes it unquoted, and short enough for MySQL's 32-character limit.
+func restrictedLoginName() string {
+	return fmt.Sprintf("goiabada_lp_%d_%d", os.Getpid(), isolatedDBCounter.Add(1))
+}
+
+// mySQLServerDSN is a connection to the server with no database selected, which is both what
+// the fixture administers through and what NewMySQLDatabase's maintenance connection uses.
+func mySQLServerDSN(username, password string, cfg *config.DatabaseConfig) string {
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&parseTime=True&loc=UTC",
+		username, password, cfg.Host, cfg.Port)
+}
+
+// postgresMaintenanceDSN is a connection to the postgres database, which is both what the
+// fixture administers through and what NewPostgresDatabase's maintenance connection uses.
+func postgresMaintenanceDSN(username, password string, cfg *config.DatabaseConfig) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/postgres", username, password, cfg.Host, cfg.Port)
+}
+
+// newRestrictedLoginDB pre-creates an isolated database and a credential that cannot create
+// one, registering the drop of both on t. Built from probe/least_privilege_startup.go, which
+// measured what each engine actually allows. SQL Server and MySQL get the database at the
+// collation their constructor would have used, so nothing downstream reads a different one.
+func newRestrictedLoginDB(t *testing.T) *restrictedLoginDB {
+	t.Helper()
+	cfg := config.GetDatabase()
+	r := &restrictedLoginDB{
+		name:     isolatedDBName(),
+		username: restrictedLoginName(),
+		password: restrictedLoginPassword,
+	}
+
+	switch dbType() {
+	case "mysql":
+		admin, err := sql.Open("mysql", mySQLServerDSN(cfg.Username, cfg.Password, cfg))
+		require.NoError(t, err, "open mysql as the tier's own login")
+		r.admin = admin
+
+		mustExec(t, admin, fmt.Sprintf(
+			"CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE %s", r.name, mysqlCollationAfter000040))
+		mustExec(t, admin, fmt.Sprintf(
+			"CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", r.username, r.password))
+		// Everything inside the one schema, including the DDL the migrations need, and
+		// nothing server-wide: no CREATE, so this account could not create a database it was
+		// not already granted on.
+		mustExec(t, admin, fmt.Sprintf(
+			"GRANT ALL PRIVILEGES ON %s.* TO '%s'@'%%'", r.name, r.username))
+		mustExec(t, admin, "FLUSH PRIVILEGES")
+
+		t.Cleanup(func() {
+			_, _ = admin.Exec("DROP DATABASE IF EXISTS " + r.name)
+			_, _ = admin.Exec(fmt.Sprintf("DROP USER IF EXISTS '%s'@'%%'", r.username))
+			_ = admin.Close()
+		})
+
+	case "postgres":
+		admin, err := sql.Open("pgx", postgresMaintenanceDSN(cfg.Username, cfg.Password, cfg))
+		require.NoError(t, err, "open postgres as the tier's own role")
+		r.admin = admin
+
+		// NOCREATEDB spelled out rather than left to the default, because it is the whole
+		// point of the fixture: this is exactly the attribute whose absence made startup fail
+		// on this engine (#293 defect 2).
+		mustExec(t, admin, fmt.Sprintf(
+			"CREATE ROLE %s LOGIN NOCREATEDB NOSUPERUSER PASSWORD '%s'", r.username, r.password))
+		mustExec(t, admin, fmt.Sprintf("CREATE DATABASE %s OWNER %s", r.name, r.username))
+
+		t.Cleanup(func() {
+			_, _ = admin.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)", r.name))
+			_, _ = admin.Exec("DROP ROLE IF EXISTS " + r.username)
+			_ = admin.Close()
+		})
+
+	case "mssql":
+		admin, err := sql.Open("sqlserver", msSQLMasterDSN(cfg))
+		require.NoError(t, err, "open master as the tier's own login")
+		r.admin = admin
+
+		mustExec(t, admin, fmt.Sprintf("CREATE DATABASE [%s] COLLATE %s", r.name, mssqlCollationAfter000040))
+		mustExec(t, admin, fmt.Sprintf(
+			"CREATE LOGIN [%s] WITH PASSWORD = '%s', CHECK_POLICY = OFF, DEFAULT_DATABASE = [%s]",
+			r.username, r.password, r.name))
+
+		appAsAdmin, err := sql.Open("sqlserver", msSQLDatabaseDSN(cfg.Username, cfg.Password, r.name, cfg))
+		require.NoError(t, err, "open the pre-created database to map the login into it")
+		mustExec(t, appAsAdmin, fmt.Sprintf(
+			"CREATE USER [%s] FOR LOGIN [%s]; ALTER ROLE db_owner ADD MEMBER [%s];",
+			r.username, r.username, r.username))
+		_ = appAsAdmin.Close()
+
+		// The restriction that makes this fixture observe anything on SQL Server. A login
+		// mapped into the application database can reach master through guest AND sees the
+		// database in sys.databases from there, so the constructor's IF NOT EXISTS would find
+		// it, create nothing and succeed: §1 of the agreement measured exactly that, and a
+		// constructor that ignored Create would go undetected here.
+		//
+		// DENY VIEW ANY DATABASE takes the catalog away instead, and then the whole creating
+		// path fails the way a least-privilege deployment fails: the check reads 0 rows, the
+		// CREATE DATABASE inside the batch runs, and the server answers "CREATE DATABASE
+		// permission denied in database 'master'". Connecting to the application database is
+		// unaffected, which is the point.
+		//
+		// Not DENY CONNECT in master, which looks like the more direct statement of "no access
+		// to master" and is not usable: it denies the login every database, the application's
+		// own included, with "Login failed for user". Measured in
+		// probe/mssql_deny_connect_master.go.
+		mustExec(t, admin, fmt.Sprintf("DENY VIEW ANY DATABASE TO [%s]", r.username))
+
+		t.Cleanup(func() {
+			dropMsSQL(t, cfg, r.name)
+			_, _ = admin.Exec(fmt.Sprintf("IF SUSER_ID(N'%s') IS NOT NULL DROP LOGIN [%s]", r.username, r.username))
+			_ = admin.Close()
+		})
+
+	default:
+		t.Fatalf("newRestrictedLoginDB has nothing to restrict on %s", dbType())
+	}
+
+	return r
+}
+
+// constructRestricted runs the engine's own constructor as the restricted login with
+// Create false, and returns the dialect DB with its raw handle.
+//
+// Deliberately stops short of building a migrator, unlike newIsolatedDB: the MySQL case has to
+// read the server's connection counter at the exact instant the constructor returned, and
+// anything that opened a connection in between would make the number unreadable.
+func (r *restrictedLoginDB) constructRestricted(t *testing.T) (migratable, *sql.DB) {
+	t.Helper()
+	cfg := config.GetDatabase()
+
+	switch dbType() {
+	case "mysql":
+		db, err := mysqldb.NewMySQLDatabase(&mysqldb.DatabaseConfig{
+			Type: "mysql", Username: r.username, Password: r.password,
+			Host: cfg.Host, Port: cfg.Port, Name: r.name, Create: false,
+		}, false)
+		require.NoError(t, err, "NewMySQLDatabase as a login that cannot create a database")
+		t.Cleanup(func() { _ = db.DB.Close() })
+		return db, db.DB
+
+	case "postgres":
+		db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
+			Type: "postgres", Username: r.username, Password: r.password,
+			Host: cfg.Host, Port: cfg.Port, Name: r.name, Create: false,
+		}, false)
+		require.NoError(t, err, "NewPostgresDatabase as a role holding no CREATEDB")
+		t.Cleanup(func() { _ = db.DB.Close() })
+		return db, db.DB
+
+	case "mssql":
+		db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
+			Type: "mssql", Username: r.username, Password: r.password,
+			Host: cfg.Host, Port: cfg.Port, Name: r.name, Create: false,
+		}, false)
+		require.NoError(t, err, "NewMsSQLDatabase as a login that cannot create a database in master")
+		t.Cleanup(func() { _ = db.DB.Close() })
+		return db, db.DB
+
+	default:
+		t.Fatalf("constructRestricted has no restricted login on %s", dbType())
+		return nil, nil
+	}
+}
+
+// connectionCount is how many connections the fixture account has made to the server since it
+// was created, read from MySQL's own counter through the admin handle.
+//
+// This is the MySQL substitute for a privilege the engine does not have. The account is created
+// for one test and dropped with it, so every connection counted is one the constructor made:
+// the skipping path makes exactly one, to the application database, and a constructor that
+// still opened the maintenance DSN would make two.
+func (r *restrictedLoginDB) connectionCount(t *testing.T) int {
+	t.Helper()
+	require.Equal(t, "mysql", dbType(), "connectionCount reads MySQL's performance_schema")
+
+	var total sql.NullInt64
+	require.NoError(t, r.admin.QueryRow(
+		"SELECT SUM(TOTAL_CONNECTIONS) FROM performance_schema.accounts WHERE `USER` = ?",
+		r.username).Scan(&total),
+		"read performance_schema.accounts for the fixture account")
+	require.True(t, total.Valid,
+		"performance_schema.accounts has no row for %s, so the counter cannot say anything", r.username)
+	return int(total.Int64)
+}
+
+// msSQLDatabaseDSN is the connection string for a named database rather than master.
+func msSQLDatabaseDSN(username, password, name string, cfg *config.DatabaseConfig) string {
+	q := url.Values{}
+	q.Add("database", name)
+	q.Add("encrypt", "disable")
+	u := url.URL{
+		Scheme:   "sqlserver",
+		User:     url.UserPassword(username, password),
+		Host:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		RawQuery: q.Encode(),
+	}
+	return u.String()
+}
+
+// mustExec runs a fixture statement and fails the test with the statement in the message when
+// it does not work. Fixture setup only: a failure here is a broken fixture, not a finding.
+func mustExec(t *testing.T, sqlDB *sql.DB, stmt string) {
+	t.Helper()
+	_, err := sqlDB.Exec(stmt)
+	require.NoErrorf(t, err, "fixture statement failed: %s", stmt)
 }

--- a/src/authserver/tests/data/migration_testdb_helper.go
+++ b/src/authserver/tests/data/migration_testdb_helper.go
@@ -82,7 +82,7 @@ func newIsolatedDB(t *testing.T) *isolatedDB {
 		name := isolatedDBName()
 		db, err := mysqldb.NewMySQLDatabase(&mysqldb.DatabaseConfig{
 			Type: "mysql", Username: cfg.Username, Password: cfg.Password,
-			Host: cfg.Host, Port: cfg.Port, Name: name,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
 		}, false)
 		require.NoError(t, err, "NewMySQLDatabase")
 		t.Cleanup(func() { _ = db.DB.Close(); dropMySQL(t, cfg, name) })
@@ -93,7 +93,7 @@ func newIsolatedDB(t *testing.T) *isolatedDB {
 		name := isolatedDBName()
 		db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
 			Type: "postgres", Username: cfg.Username, Password: cfg.Password,
-			Host: cfg.Host, Port: cfg.Port, Name: name,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
 		}, false)
 		require.NoError(t, err, "NewPostgresDatabase")
 		t.Cleanup(func() { _ = db.DB.Close(); dropPostgres(t, cfg, name) })
@@ -103,7 +103,7 @@ func newIsolatedDB(t *testing.T) *isolatedDB {
 		name := isolatedDBName()
 		db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
 			Type: "mssql", Username: cfg.Username, Password: cfg.Password,
-			Host: cfg.Host, Port: cfg.Port, Name: name,
+			Host: cfg.Host, Port: cfg.Port, Name: name, Create: true,
 		}, false)
 		require.NoError(t, err, "NewMsSQLDatabase")
 		t.Cleanup(func() { _ = db.DB.Close(); dropMsSQL(t, cfg, name) })
@@ -358,6 +358,9 @@ func newPreCreatedMsSQLDB(t *testing.T, collation string) *isolatedDB {
 	db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
 		Type: "mssql", Username: cfg.Username, Password: cfg.Password,
 		Host: cfg.Host, Port: cfg.Port, Name: name,
+		// The operator created this one, so the constructor must not: that is what the
+		// collation assertion below is checking (#293).
+		Create: false,
 	}, false)
 	require.NoError(t, err, "NewMsSQLDatabase over a pre-created database")
 	t.Cleanup(func() { _ = db.DB.Close(); dropMsSQL(t, cfg, name) })

--- a/src/core/cmd/schemadump/main.go
+++ b/src/core/cmd/schemadump/main.go
@@ -196,7 +196,7 @@ func open(t target, name string) (migratable, *sql.DB, func(), error) {
 	case schemadump.MySQL:
 		db, err := mysqldb.NewMySQLDatabase(&mysqldb.DatabaseConfig{
 			Type: "mysql", Username: t.username, Password: t.password,
-			Host: t.host, Port: t.port, Name: name,
+			Host: t.host, Port: t.port, Name: name, Create: true,
 		}, false)
 		if err != nil {
 			return nil, nil, nil, err
@@ -211,7 +211,7 @@ func open(t target, name string) (migratable, *sql.DB, func(), error) {
 	case schemadump.Postgres:
 		db, err := postgresdb.NewPostgresDatabase(&postgresdb.DatabaseConfig{
 			Type: "postgres", Username: t.username, Password: t.password,
-			Host: t.host, Port: t.port, Name: name,
+			Host: t.host, Port: t.port, Name: name, Create: true,
 		}, false)
 		if err != nil {
 			return nil, nil, nil, err
@@ -227,7 +227,7 @@ func open(t target, name string) (migratable, *sql.DB, func(), error) {
 	case schemadump.MSSQL:
 		db, err := mssqldb.NewMsSQLDatabase(&mssqldb.DatabaseConfig{
 			Type: "mssql", Username: t.username, Password: t.password,
-			Host: t.host, Port: t.port, Name: name,
+			Host: t.host, Port: t.port, Name: name, Create: true,
 		}, false)
 		if err != nil {
 			return nil, nil, nil, err

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -91,6 +91,7 @@ type DatabaseConfig struct {
 	Port     int
 	Name     string
 	DSN      string
+	Create   bool
 }
 
 type Config struct {
@@ -177,6 +178,7 @@ func load() {
 			Port:     getEnvAsInt("GOIABADA_DB_PORT", 3306),
 			Name:     getEnv("GOIABADA_DB_NAME", "goiabada"),
 			DSN:      getEnv("GOIABADA_DB_DSN", "file::memory:?cache=shared"),
+			Create:   getEnvAsBoolDefault("GOIABADA_DB_CREATE", true),
 		},
 		AdminEmail:               getEnv("GOIABADA_ADMIN_EMAIL", "admin"),
 		AdminPassword:            getEnv("GOIABADA_ADMIN_PASSWORD", "changeme"),
@@ -231,6 +233,7 @@ func load() {
 	flag.IntVar(&cfg.Database.Port, "db-port", cfg.Database.Port, "Database port")
 	flag.StringVar(&cfg.Database.Name, "db-name", cfg.Database.Name, "Database name")
 	flag.StringVar(&cfg.Database.DSN, "db-dsn", cfg.Database.DSN, "Database DSN (only for sqlite)")
+	flag.BoolVar(&cfg.Database.Create, "db-create", cfg.Database.Create, "Create the database if it does not exist (only for mysql, postgres, mssql)")
 
 	// Initial setup
 	flag.StringVar(&cfg.AdminEmail, "admin-email", cfg.AdminEmail, "Default admin email")
@@ -366,6 +369,16 @@ func getEnvAsBool(key string) bool {
 		return value
 	}
 	return false
+}
+
+// getEnvAsBoolDefault is getEnvAsBool with a caller-supplied default, for a setting whose
+// default is true: getEnvAsBool can only ever express default-false (#293).
+func getEnvAsBoolDefault(key string, defaultVal bool) bool {
+	valueStr := getEnv(key, "")
+	if value, err := strconv.ParseBool(strings.TrimSpace(valueStr)); err == nil {
+		return value
+	}
+	return defaultVal
 }
 
 func getEnvAsStringSlice(key string) []string {

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -116,6 +117,57 @@ func TestGetEnvAsStringSlice(t *testing.T) {
 			t.Errorf("getEnvAsStringSlice = %#v, want %#v", got, want)
 		}
 	})
+}
+
+func TestGetEnvAsBoolDefault(t *testing.T) {
+	const key = "GOIABADA_TEST_DB_CREATE"
+
+	// Every case is run against both defaults, so the default is observed rather than assumed:
+	// a case that only ever ran with defaultVal=false could not tell the fallback apart from
+	// a parsed false.
+	tests := []struct {
+		name string
+		// set is false for the unset case, which is the one the helper exists for.
+		set          bool
+		value        string
+		wantTrueDef  bool
+		wantFalseDef bool
+	}{
+		{name: "unset returns the default", set: false, wantTrueDef: true, wantFalseDef: false},
+		{name: `"true"`, set: true, value: "true", wantTrueDef: true, wantFalseDef: true},
+		{name: `"1"`, set: true, value: "1", wantTrueDef: true, wantFalseDef: true},
+		{name: `"T"`, set: true, value: "T", wantTrueDef: true, wantFalseDef: true},
+		{name: `"TRUE"`, set: true, value: "TRUE", wantTrueDef: true, wantFalseDef: true},
+		{name: `"false"`, set: true, value: "false", wantTrueDef: false, wantFalseDef: false},
+		{name: `"0"`, set: true, value: "0", wantTrueDef: false, wantFalseDef: false},
+		{name: `"f"`, set: true, value: "f", wantTrueDef: false, wantFalseDef: false},
+		{name: "whitespace is trimmed", set: true, value: " false ", wantTrueDef: false, wantFalseDef: false},
+		// strconv.ParseBool rejects all four, so each falls back to the default. Keep the
+		// "no" case: it reads as false and is not, and against defaultVal=true it returns true.
+		{name: `"yes" is not parseable`, set: true, value: "yes", wantTrueDef: true, wantFalseDef: false},
+		{name: `"no" is not parseable`, set: true, value: "no", wantTrueDef: true, wantFalseDef: false},
+		{name: "empty is not parseable", set: true, value: "", wantTrueDef: true, wantFalseDef: false},
+		{name: `"maybe" is not parseable`, set: true, value: "maybe", wantTrueDef: true, wantFalseDef: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv cannot unset, but it registers the restore, so setting then
+			// unsetting leaves the variable absent for this subtest only.
+			t.Setenv(key, tt.value)
+			if !tt.set {
+				if err := os.Unsetenv(key); err != nil {
+					t.Fatalf("os.Unsetenv(%s) = %v", key, err)
+				}
+			}
+			if got := getEnvAsBoolDefault(key, true); got != tt.wantTrueDef {
+				t.Errorf("getEnvAsBoolDefault(%s=%q, true) = %v, want %v", key, tt.value, got, tt.wantTrueDef)
+			}
+			if got := getEnvAsBoolDefault(key, false); got != tt.wantFalseDef {
+				t.Errorf("getEnvAsBoolDefault(%s=%q, false) = %v, want %v", key, tt.value, got, tt.wantFalseDef)
+			}
+		})
+	}
 }
 
 func TestIsCookieSecure(t *testing.T) {

--- a/src/core/data/database.go
+++ b/src/core/data/database.go
@@ -520,6 +520,7 @@ func NewDatabase(dbConfig *config.DatabaseConfig, logSQL bool) (Database, error)
 			Port:     dbConfig.Port,
 			Name:     dbConfig.Name,
 			DSN:      dbConfig.DSN,
+			Create:   dbConfig.Create,
 		}
 		database, err = mysqldb.NewMySQLDatabase(mysqlConfig, logSQL)
 	case "sqlite":
@@ -544,6 +545,7 @@ func NewDatabase(dbConfig *config.DatabaseConfig, logSQL bool) (Database, error)
 			Port:     dbConfig.Port,
 			Name:     dbConfig.Name,
 			DSN:      dbConfig.DSN,
+			Create:   dbConfig.Create,
 		}
 		database, err = postgresdb.NewPostgresDatabase(postgresConfig, logSQL)
 	case "mssql":
@@ -556,6 +558,7 @@ func NewDatabase(dbConfig *config.DatabaseConfig, logSQL bool) (Database, error)
 			Port:     dbConfig.Port,
 			Name:     dbConfig.Name,
 			DSN:      dbConfig.DSN,
+			Create:   dbConfig.Create,
 		}
 		database, err = mssqldb.NewMsSQLDatabase(mssqlConfig, logSQL)
 	default:

--- a/src/core/data/mssqldb/db.go
+++ b/src/core/data/mssqldb/db.go
@@ -119,7 +119,7 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 	return &mssqlDb, nil
 }
 
-// createDatabaseResource is the sp_getapplock resource createDatabaseUnderAppLock serializes on.
+// CreateDatabaseResource is the sp_getapplock resource createDatabaseUnderAppLock serializes on.
 // It carries NO database name, deliberately.
 //
 // A name-bearing resource looks tighter and is broken. sp_getapplock compares its resource as
@@ -135,12 +135,19 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 // stated so nobody has to rediscover it: creating two DIFFERENT Goiabada databases on one
 // instance now serializes against each other, and with an untimed lock a stuck holder blocks
 // both rather than one. That is bounded, because the lock spans a catalog check and one
-// CREATE DATABASE and is taken once per database in the life of a deployment.
+// CREATE DATABASE and is taken once per database in the life of a deployment. That last clause
+// is true only because createDatabaseUnderAppLock checks the catalog BEFORE reaching for the
+// lock. See the note there.
 //
 // Deliberately distinct from database.GenerateAdvisoryLockId, which ensureSchemaMigrationsTable
 // takes below: that guards the schema_migrations table INSIDE an existing database, a different
 // thing one layer down, and the two must not share a resource (#293).
-const createDatabaseResource = "goiabada:create-database"
+//
+// Exported because the resource is an inter-process contract rather than an implementation
+// detail: anything that has to interoperate with a starting Goiabada, a test holding the lock
+// from outside included, needs the identity itself and cannot restate it without becoming a
+// second definition that is free to drift.
+const CreateDatabaseResource = "goiabada:create-database"
 
 // createDatabaseUnderAppLock runs the check-then-create batch with an exclusive application lock
 // held across it, so that at most one process ever issues CREATE DATABASE.
@@ -163,8 +170,33 @@ const createDatabaseResource = "goiabada:create-database"
 //
 // LockTimeout = -1 blocks until the lock is free rather than failing, which is what the migration
 // lock already does: the holder is another process's create, and it is short.
+//
+// That is affordable only because the lock is reached ONLY when the database is absent. An
+// application lock taken in master is shared with every session on the instance, so ANY login
+// that can reach master (ordinary public access is enough, and it needs no rights at all
+// inside Goiabada's database) can hold this resource indefinitely. Reaching for it
+// unconditionally would put that stranger on the path of every ordinary restart for the life of
+// the deployment, which is not the cost #293 decision 5 weighed. The unlocked pre-check below
+// keeps the exposure inside the window where the database really is absent, which is the one
+// start that has to create it.
+//
+// The pre-check cannot let a second creator through. It only returns early when the database is
+// already there, and what decides whether CREATE DATABASE runs is still the IF NOT EXISTS inside
+// the batch, under the lock. It is also no weaker than that check: both compare
+// sys.databases.name against an nvarchar value under master's collation, so both fold case,
+// trailing space, normalization form and width identically. Two instances configured `goiabada`
+// and `Goiabada` against an absent database therefore both find nothing here, both take the
+// constant resource, and the batch collapses them to one database exactly as before (#293).
 func createDatabaseUnderAppLock(masterDB *sql.DB, name string) error {
 	ctx := context.Background()
+
+	exists, err := databaseExists(ctx, masterDB, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
 
 	// Create database if it doesn't exist.
 	//
@@ -201,20 +233,35 @@ func createDatabaseUnderAppLock(masterDB *sql.DB, name string) error {
 		EXEC @lockResult = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = -1;
 		SELECT @lockResult;`
 	var status int
-	if err := conn.QueryRowContext(ctx, takeLock, createDatabaseResource).Scan(&status); err != nil {
+	if err := conn.QueryRowContext(ctx, takeLock, CreateDatabaseResource).Scan(&status); err != nil {
 		return errors.Wrap(err, "unable to take the database creation lock")
 	}
 	if status < 0 {
 		return errors.Errorf("unable to take the database creation lock: sp_getapplock returned %d", status)
 	}
 	defer func() {
-		_, _ = conn.ExecContext(ctx, `EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'`, createDatabaseResource)
+		_, _ = conn.ExecContext(ctx, `EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'`, CreateDatabaseResource)
 	}()
 
 	if _, err := conn.ExecContext(ctx, createDatabaseCommand); err != nil {
 		return errors.Wrap(err, "unable to create database")
 	}
 	return nil
+}
+
+// databaseExists asks sys.databases whether name is there, through master.
+//
+// The comparison is master's collation, which on a stock instance folds case and more. That is
+// the same comparison the IF NOT EXISTS inside createDatabaseUnderAppLock's batch makes, and it
+// has to be: this check stands in front of the lock, so anything it treats as present must be
+// something the batch would also treat as present (#293).
+func databaseExists(ctx context.Context, masterDB *sql.DB, name string) (bool, error) {
+	var found int
+	if err := masterDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sys.databases WHERE name = @p1", name).Scan(&found); err != nil {
+		return false, errors.Wrap(err, "unable to check whether the database exists")
+	}
+	return found > 0, nil
 }
 
 func (d *MsSQLDatabase) BeginTransaction() (*sql.Tx, error) {

--- a/src/core/data/mssqldb/db.go
+++ b/src/core/data/mssqldb/db.go
@@ -35,6 +35,9 @@ type DatabaseConfig struct {
 	Port     int
 	Name     string
 	DSN      string
+	// Create decides whether the constructor may create the database when it is absent. It is
+	// positive-sense, so the zero value does not create: every literal has to set it (#293).
+	Create bool
 }
 
 func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, error) {

--- a/src/core/data/mssqldb/db.go
+++ b/src/core/data/mssqldb/db.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 
 	gomigrate "github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -214,13 +215,13 @@ func createDatabaseUnderAppLock(masterDB *sql.DB, name string) error {
 	// explicitly, naming the collation below, rather than relying on this line, and why a data
 	// test migrates the whole chain into a hostile database and asserts all 92 columns.
 	createDatabaseCommand := fmt.Sprintf(`
-        IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'%s')
+        IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N%s)
         BEGIN
-            CREATE DATABASE [%s]
+            CREATE DATABASE %s
             COLLATE Latin1_General_100_CS_AS_KS_WS_SC_UTF8
         END`,
-		name,
-		name,
+		quoteLiteral(name),
+		quoteIdentifier(name),
 	)
 
 	conn, err := masterDB.Conn(ctx)
@@ -398,4 +399,30 @@ func (d *MsSQLDatabase) Migrate() error {
 
 func (d *MsSQLDatabase) IsEmpty() (bool, error) {
 	return d.CommonDB.IsEmpty()
+}
+
+// quoteIdentifier wraps name in the brackets SQL Server spells an identifier with, doubling any
+// closing bracket inside it, and quoteLiteral wraps it in the single quotes of a string literal,
+// doubling any single quote inside it.
+//
+// The batch above needs both, because it names the database twice in two different syntaxes: as
+// an identifier in CREATE DATABASE and as an nvarchar value compared against sys.databases.name.
+// It was already bracketed, so SQL Server was never broken the way PostgreSQL was, where an
+// unquoted CREATE DATABASE folds the name and the connection string does not. What these close
+// is the rest of the class: a name carrying `]` used to escape the brackets and one carrying `'`
+// used to end the literal early, and the name reaches both places by interpolation because an
+// identifier cannot be a bind parameter and the literal sits inside a batch that is executed as
+// one statement. GOIABADA_DB_NAME is operator-supplied configuration rather than user input, so
+// this is hardening and not a live hole. Kept in the same shape on all three server engines
+// (#293).
+//
+// Neither of these makes the check any narrower than it was. sys.databases.name is still
+// compared under master's collation, which folds case and more, which is why CreateDatabaseResource
+// above carries no name.
+func quoteIdentifier(name string) string {
+	return "[" + strings.ReplaceAll(name, "]", "]]") + "]"
+}
+
+func quoteLiteral(name string) string {
+	return "'" + strings.ReplaceAll(name, "'", "''") + "'"
 }

--- a/src/core/data/mssqldb/db.go
+++ b/src/core/data/mssqldb/db.go
@@ -74,35 +74,8 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 			return nil, errors.Wrap(err, "unable to connect to master database")
 		}
 
-		// Create database if it doesn't exist.
-		//
-		// The collation is case-, accent-, width- and kanatype-SENSITIVE, so a value that
-		// differs in case is a different value here exactly as it is on SQLite and PostgreSQL.
-		// RFC 6749 section 1.9 requires that of client_id, section 3.3 of scope and OpenID
-		// Connect Core section 2 of sub; the previous CI_AI collation folded all three, so
-		// client_id=myapp resolved a client registered as MyApp (#283). Migration 000040
-		// converts an existing database's 92 string columns to the same collation.
-		//
-		// IF NOT EXISTS, so a database an OPERATOR pre-created keeps their collation: the
-		// database default cannot be moved from a migration, because ALTER DATABASE ...
-		// COLLATE blocks until it times out with a second session attached, which is what a
-		// running application is. That is why every string column a future migration adds must
-		// spell its own COLLATE clause explicitly, naming the collation below, rather than
-		// relying on this line, and why a data test migrates the whole chain into a hostile
-		// database and asserts all 92 columns.
-		createDatabaseCommand := fmt.Sprintf(`
-        IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'%s')
-        BEGIN
-            CREATE DATABASE [%s]
-            COLLATE Latin1_General_100_CS_AS_KS_WS_SC_UTF8
-        END`,
-			dbConfig.Name,
-			dbConfig.Name,
-		)
-
-		_, err = masterDB.Exec(createDatabaseCommand)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to create database")
+		if err := createDatabaseUnderAppLock(masterDB, dbConfig.Name); err != nil {
+			return nil, err
 		}
 	} else {
 		// The operator says the database is already there, so nothing is created and master is
@@ -144,6 +117,104 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 		dbConfig: dbConfig,
 	}
 	return &mssqlDb, nil
+}
+
+// createDatabaseResource is the sp_getapplock resource createDatabaseUnderAppLock serializes on.
+// It carries NO database name, deliberately.
+//
+// A name-bearing resource looks tighter and is broken. sp_getapplock compares its resource as
+// binary, while sys.databases.name is compared under master's collation, which on a stock
+// instance folds case, trailing space, Unicode normalization form and character width. Two
+// Goiabada instances configured `goiabada` and `Goiabada` would take two DIFFERENT locks, both
+// see zero rows from the IF NOT EXISTS check, and both run CREATE DATABASE: exactly the defect
+// the lock exists to close, with a lock bolted on. Normalizing the name in Go cannot close it,
+// because the equivalences are whatever the instance's collation says they are and any instance
+// may be running a different one.
+//
+// So the lock is strictly wider than the thing it guards, which is the safe direction. The cost,
+// stated so nobody has to rediscover it: creating two DIFFERENT Goiabada databases on one
+// instance now serializes against each other, and with an untimed lock a stuck holder blocks
+// both rather than one. That is bounded, because the lock spans a catalog check and one
+// CREATE DATABASE and is taken once per database in the life of a deployment.
+//
+// Deliberately distinct from database.GenerateAdvisoryLockId, which ensureSchemaMigrationsTable
+// takes below: that guards the schema_migrations table INSIDE an existing database, a different
+// thing one layer down, and the two must not share a resource (#293).
+const createDatabaseResource = "goiabada:create-database"
+
+// createDatabaseUnderAppLock runs the check-then-create batch with an exclusive application lock
+// held across it, so that at most one process ever issues CREATE DATABASE.
+//
+// SQL Server has no atomic CREATE DATABASE IF NOT EXISTS, so the batch below is a check followed
+// by a create and racing processes can all pass the check. Measured: 5 of 8 concurrent starts
+// against an absent database failed. That is also why this serializes rather than tolerating the
+// error and re-checking, which is what the issue proposed: most losers carry no error number and
+// no message at all, only "Request failed but didn't provide reason", so there is frequently
+// nothing to recognise. Two replicas against one fresh server is an ordinary topology (#293).
+//
+// sp_getapplock at LockOwner = 'Session' is scoped to one session, so the lock has to be taken,
+// used and released on a single connection pinned out of the pool. Issued against the pooled
+// *sql.DB, the release could land on a different session and leave the lock held for the life of
+// the process, blocking every later start against this instance. Same hazard, same remedy, as
+// ensureSchemaMigrationsTable below.
+//
+// Application locks are scoped to the database the session is in, and every racer is in master,
+// so they do share one lock space. That is the whole reason this works.
+//
+// LockTimeout = -1 blocks until the lock is free rather than failing, which is what the migration
+// lock already does: the holder is another process's create, and it is short.
+func createDatabaseUnderAppLock(masterDB *sql.DB, name string) error {
+	ctx := context.Background()
+
+	// Create database if it doesn't exist.
+	//
+	// The collation is case-, accent-, width- and kanatype-SENSITIVE, so a value that differs
+	// in case is a different value here exactly as it is on SQLite and PostgreSQL. RFC 6749
+	// section 1.9 requires that of client_id, section 3.3 of scope and OpenID Connect Core
+	// section 2 of sub; the previous CI_AI collation folded all three, so client_id=myapp
+	// resolved a client registered as MyApp (#283). Migration 000040 converts an existing
+	// database's 92 string columns to the same collation.
+	//
+	// IF NOT EXISTS, so a database an OPERATOR pre-created keeps their collation: the database
+	// default cannot be moved from a migration, because ALTER DATABASE ... COLLATE blocks until
+	// it times out with a second session attached, which is what a running application is. That
+	// is why every string column a future migration adds must spell its own COLLATE clause
+	// explicitly, naming the collation below, rather than relying on this line, and why a data
+	// test migrates the whole chain into a hostile database and asserts all 92 columns.
+	createDatabaseCommand := fmt.Sprintf(`
+        IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'%s')
+        BEGIN
+            CREATE DATABASE [%s]
+            COLLATE Latin1_General_100_CS_AS_KS_WS_SC_UTF8
+        END`,
+		name,
+		name,
+	)
+
+	conn, err := masterDB.Conn(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unable to pin a connection for the database creation lock")
+	}
+	defer func() { _ = conn.Close() }()
+
+	const takeLock = `DECLARE @lockResult int;
+		EXEC @lockResult = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = -1;
+		SELECT @lockResult;`
+	var status int
+	if err := conn.QueryRowContext(ctx, takeLock, createDatabaseResource).Scan(&status); err != nil {
+		return errors.Wrap(err, "unable to take the database creation lock")
+	}
+	if status < 0 {
+		return errors.Errorf("unable to take the database creation lock: sp_getapplock returned %d", status)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, `EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'`, createDatabaseResource)
+	}()
+
+	if _, err := conn.ExecContext(ctx, createDatabaseCommand); err != nil {
+		return errors.Wrap(err, "unable to create database")
+	}
+	return nil
 }
 
 func (d *MsSQLDatabase) BeginTransaction() (*sql.Tx, error) {

--- a/src/core/data/mssqldb/db.go
+++ b/src/core/data/mssqldb/db.go
@@ -53,55 +53,63 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 	queryParams.Add("database", "master") // Connect to master first to create DB
 	queryParams.Add("encrypt", "disable") // Disable encryption requirement
 
-	connStringMaster := url.URL{
-		Scheme:   "sqlserver",
-		User:     url.UserPassword(dbConfig.Username, dbConfig.Password),
-		Host:     fmt.Sprintf("%s:%d", dbConfig.Host, dbConfig.Port),
-		RawQuery: queryParams.Encode(),
-	}
+	if dbConfig.Create {
+		connStringMaster := url.URL{
+			Scheme:   "sqlserver",
+			User:     url.UserPassword(dbConfig.Username, dbConfig.Password),
+			Host:     fmt.Sprintf("%s:%d", dbConfig.Host, dbConfig.Port),
+			RawQuery: queryParams.Encode(),
+		}
 
-	// Connect to master database first
-	masterDB, err := sql.Open("sqlserver", connStringMaster.String())
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to open master database")
-	}
-	defer func() { _ = masterDB.Close() }() // Ensure we close the master connection
+		// Connect to master database first
+		masterDB, err := sql.Open("sqlserver", connStringMaster.String())
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to open master database")
+		}
+		defer func() { _ = masterDB.Close() }() // Ensure we close the master connection
 
-	// Test the connection
-	err = masterDB.Ping()
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to connect to master database")
-	}
+		// Test the connection
+		err = masterDB.Ping()
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to connect to master database")
+		}
 
-	// Create database if it doesn't exist.
-	//
-	// The collation is case-, accent-, width- and kanatype-SENSITIVE, so a value that
-	// differs in case is a different value here exactly as it is on SQLite and PostgreSQL.
-	// RFC 6749 section 1.9 requires that of client_id, section 3.3 of scope and OpenID
-	// Connect Core section 2 of sub; the previous CI_AI collation folded all three, so
-	// client_id=myapp resolved a client registered as MyApp (#283). Migration 000040
-	// converts an existing database's 92 string columns to the same collation.
-	//
-	// IF NOT EXISTS, so a database an OPERATOR pre-created keeps their collation: the
-	// database default cannot be moved from a migration, because ALTER DATABASE ...
-	// COLLATE blocks until it times out with a second session attached, which is what a
-	// running application is. That is why every string column a future migration adds must
-	// spell its own COLLATE clause explicitly, naming the collation below, rather than
-	// relying on this line, and why a data test migrates the whole chain into a hostile
-	// database and asserts all 92 columns.
-	createDatabaseCommand := fmt.Sprintf(`
+		// Create database if it doesn't exist.
+		//
+		// The collation is case-, accent-, width- and kanatype-SENSITIVE, so a value that
+		// differs in case is a different value here exactly as it is on SQLite and PostgreSQL.
+		// RFC 6749 section 1.9 requires that of client_id, section 3.3 of scope and OpenID
+		// Connect Core section 2 of sub; the previous CI_AI collation folded all three, so
+		// client_id=myapp resolved a client registered as MyApp (#283). Migration 000040
+		// converts an existing database's 92 string columns to the same collation.
+		//
+		// IF NOT EXISTS, so a database an OPERATOR pre-created keeps their collation: the
+		// database default cannot be moved from a migration, because ALTER DATABASE ...
+		// COLLATE blocks until it times out with a second session attached, which is what a
+		// running application is. That is why every string column a future migration adds must
+		// spell its own COLLATE clause explicitly, naming the collation below, rather than
+		// relying on this line, and why a data test migrates the whole chain into a hostile
+		// database and asserts all 92 columns.
+		createDatabaseCommand := fmt.Sprintf(`
         IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'%s')
         BEGIN
             CREATE DATABASE [%s]
             COLLATE Latin1_General_100_CS_AS_KS_WS_SC_UTF8
         END`,
-		dbConfig.Name,
-		dbConfig.Name,
-	)
+			dbConfig.Name,
+			dbConfig.Name,
+		)
 
-	_, err = masterDB.Exec(createDatabaseCommand)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to create database")
+		_, err = masterDB.Exec(createDatabaseCommand)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create database")
+		}
+	} else {
+		// The operator says the database is already there, so nothing is created and master is
+		// never opened, let alone pinged. That matters more here than on the other two engines:
+		// an Azure SQL contained user cannot reach master at all, so the ping above would stop
+		// a start that has everything it needs inside the application database (#293).
+		slog.Info("db create: disabled, the database must already exist (GOIABADA_DB_CREATE=false)")
 	}
 
 	// Now connect to the actual database
@@ -119,11 +127,13 @@ func NewMsSQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MsSQLDatabase, er
 		return nil, errors.Wrap(err, "unable to open database")
 	}
 
-	// Test the connection to the new database
+	// Test the connection to the application database. This is also what makes an absent
+	// database the constructor's error rather than the migrator's on the skipping arm: SQL
+	// Server answers "Cannot open database ... requested by the login" here (#293).
 	err = db.Ping()
 	if err != nil {
 		_ = db.Close()
-		return nil, errors.Wrap(err, "unable to connect to created database")
+		return nil, errors.Wrap(err, "unable to connect to database")
 	}
 
 	commonDb := commondb.NewCommonDatabase(db, sqlbuilder.SQLServer, logSQL)

--- a/src/core/data/mssqldb/db_test.go
+++ b/src/core/data/mssqldb/db_test.go
@@ -1,0 +1,55 @@
+package mssqldb
+
+import (
+	"testing"
+)
+
+// TestQuoteIdentifier and TestQuoteLiteral pin SQL Server's half of the quoting the three server
+// engines now share.
+//
+// The create batch names the database twice, in two syntaxes: bracketed in CREATE DATABASE and
+// as an nvarchar literal compared against sys.databases.name. It was already bracketed, so this
+// engine was never broken the way PostgreSQL was; what these close is a name carrying `]`, which
+// escaped the brackets, and one carrying `'`, which ended the literal early (#293).
+func TestQuoteIdentifier(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lower case, what every existing deployment has", "goiabada", "[goiabada]"},
+		{"mixed case survives, as it always did here", "Goiabada", "[Goiabada]"},
+		{"a hyphen, a syntax error before quoting", "goiabada-prod", "[goiabada-prod]"},
+		{"a space", "goiabada prod", "[goiabada prod]"},
+		{"a closing bracket is doubled, not passed through", "go]iabada", "[go]]iabada]"},
+		{"a trailing closing bracket cannot end the identifier early", "goiabada]", "[goiabada]]]"},
+		{"an opening bracket needs nothing, and must not get it", "go[iabada", "[go[iabada]"},
+		{"empty, which the config default never produces but the function must not mangle", "", "[]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteIdentifier(tc.in); got != tc.want {
+				t.Errorf("quoteIdentifier(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQuoteLiteral(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lower case, what every existing deployment has", "goiabada", "'goiabada'"},
+		{"mixed case is carried verbatim; the folding is the collation's, not the literal's", "Goiabada", "'Goiabada'"},
+		{"a single quote is doubled, not passed through", "go'iabada", "'go''iabada'"},
+		{"a trailing single quote cannot end the literal early", "goiabada'", "'goiabada'''"},
+		{"empty, which the config default never produces but the function must not mangle", "", "''"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteLiteral(tc.in); got != tc.want {
+				t.Errorf("quoteLiteral(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/core/data/mysqldb/db.go
+++ b/src/core/data/mysqldb/db.go
@@ -67,6 +67,15 @@ func NewMySQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MySQLDatabase, er
 
 		// create the database if it does not exist.
 		//
+		// No lock around this, unlike PostgreSQL and SQL Server, and that asymmetry is measured
+		// rather than assumed. MySQL serialises on the schema metadata lock and demotes the
+		// duplicate: 23 of every 24 concurrent racers receive Note 1007, "Can't create database
+		// 'x'; database exists", which is a NOTE the driver never raises as an error. 288 full
+		// constructor sequences at 24-way concurrency against an absent database produced zero
+		// failures and the target collation every round. So there is nothing here for a lock to
+		// fix, and adding one for symmetry would buy a startup round-trip and a stuck-holder
+		// failure mode for nothing (#293 decision 6).
+		//
 		// The collation is case- and accent-SENSITIVE, so a value that differs in case is a
 		// different value here exactly as it is on SQLite and PostgreSQL. RFC 6749 section 1.9
 		// requires that of client_id, section 3.3 of scope and OpenID Connect Core section 2 of

--- a/src/core/data/mysqldb/db.go
+++ b/src/core/data/mysqldb/db.go
@@ -58,29 +58,49 @@ func NewMySQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MySQLDatabase, er
 		dbConfig.Port,
 		dbConfig.Name)
 
-	tempDB, err := sql.Open("mysql", dsnWithoutDBname)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to open database")
-	}
-	defer func() { _ = tempDB.Close() }()
+	if dbConfig.Create {
+		tempDB, err := sql.Open("mysql", dsnWithoutDBname)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to open database")
+		}
+		defer func() { _ = tempDB.Close() }()
 
-	// create the database if it does not exist.
-	//
-	// The collation is case- and accent-SENSITIVE, so a value that differs in case is a
-	// different value here exactly as it is on SQLite and PostgreSQL. RFC 6749 section 1.9
-	// requires that of client_id, section 3.3 of scope and OpenID Connect Core section 2 of
-	// sub; the previous _ai_ci collation folded all three, so client_id=myapp resolved a
-	// client registered as MyApp (#283). Migration 000040 converts an existing database,
-	// its default included, so a fresh install and a migrated one agree.
-	createDatabaseCommand := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %v CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;", dbConfig.Name)
-	_, err = tempDB.Exec(createDatabaseCommand)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to create database")
+		// create the database if it does not exist.
+		//
+		// The collation is case- and accent-SENSITIVE, so a value that differs in case is a
+		// different value here exactly as it is on SQLite and PostgreSQL. RFC 6749 section 1.9
+		// requires that of client_id, section 3.3 of scope and OpenID Connect Core section 2 of
+		// sub; the previous _ai_ci collation folded all three, so client_id=myapp resolved a
+		// client registered as MyApp (#283). Migration 000040 converts an existing database,
+		// its default included, so a fresh install and a migrated one agree.
+		createDatabaseCommand := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %v CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;", dbConfig.Name)
+		_, err = tempDB.Exec(createDatabaseCommand)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create database")
+		}
+	} else {
+		// The operator says the database is already there, so nothing is created and the
+		// maintenance connection above is never opened: a login with rights only inside the
+		// application schema is enough to start (#293). Logged because the operator who set
+		// this weeks ago needs the missing-database error below connected back to it.
+		slog.Info("db create: disabled, the database must already exist (GOIABADA_DB_CREATE=false)")
 	}
 
 	db, err := sql.Open("mysql", dsnWithDBname)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open database")
+	}
+
+	if !dbConfig.Create {
+		// sql.Open only parses the DSN, so without this an absent database would come back as
+		// a usable handle and a nil error, and the failure would surface inside the migrator
+		// as somebody else's problem. Ping forces first use here, so the caller gets MySQL's
+		// own "Error 1049 (42000): Unknown database" from the constructor. Not on the creating
+		// arm, where the CREATE DATABASE above already forces it (#293).
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			return nil, errors.Wrap(err, "unable to connect to database")
+		}
 	}
 
 	commonDb := commondb.NewCommonDatabase(db, sqlbuilder.MySQL, logSQL)

--- a/src/core/data/mysqldb/db.go
+++ b/src/core/data/mysqldb/db.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
 	gomigrate "github.com/golang-migrate/migrate/v4"
@@ -82,7 +83,7 @@ func NewMySQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MySQLDatabase, er
 		// sub; the previous _ai_ci collation folded all three, so client_id=myapp resolved a
 		// client registered as MyApp (#283). Migration 000040 converts an existing database,
 		// its default included, so a fresh install and a migrated one agree.
-		createDatabaseCommand := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %v CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;", dbConfig.Name)
+		createDatabaseCommand := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;", quoteIdentifier(dbConfig.Name))
 		_, err = tempDB.Exec(createDatabaseCommand)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to create database")
@@ -205,4 +206,18 @@ func (d *MySQLDatabase) Migrate() error {
 
 func (d *MySQLDatabase) IsEmpty() (bool, error) {
 	return d.CommonDB.IsEmpty()
+}
+
+// quoteIdentifier wraps name in the backticks MySQL spells an identifier with, doubling any
+// backtick inside it.
+//
+// MySQL was never broken the way PostgreSQL was: an unquoted identifier is not folded here, so
+// the name in this statement and the name in the DSN's path already agreed. What quoting buys is
+// the rest of the class. A name needing quotes for any other reason, a hyphen or a space, was a
+// syntax error, and the name reaches this statement by interpolation because an identifier
+// cannot be a bind parameter. GOIABADA_DB_NAME is operator-supplied configuration rather than
+// user input, so the doubling is hardening and not a live hole, but it is the only answer
+// available and it costs one line. Kept in the same shape on all three server engines (#293).
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }

--- a/src/core/data/mysqldb/db.go
+++ b/src/core/data/mysqldb/db.go
@@ -32,6 +32,9 @@ type DatabaseConfig struct {
 	Port     int
 	Name     string
 	DSN      string
+	// Create decides whether the constructor may create the database when it is absent. It is
+	// positive-sense, so the zero value does not create: every literal has to set it (#293).
+	Create bool
 }
 
 func NewMySQLDatabase(dbConfig *DatabaseConfig, logSQL bool) (*MySQLDatabase, error) {

--- a/src/core/data/mysqldb/db_test.go
+++ b/src/core/data/mysqldb/db_test.go
@@ -1,0 +1,32 @@
+package mysqldb
+
+import (
+	"testing"
+)
+
+// TestQuoteIdentifier pins MySQL's half of the quoting the three server engines now share.
+//
+// MySQL was never broken the way PostgreSQL was, since an unquoted identifier is not folded
+// here, so what these cases hold is the rest of the class: a name that needs quoting for some
+// other reason, and a name that could end the quoting early (#293).
+func TestQuoteIdentifier(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lower case, what every existing deployment has", "goiabada", "`goiabada`"},
+		{"mixed case survives, as it always did here", "Goiabada", "`Goiabada`"},
+		{"a hyphen, a syntax error before quoting", "goiabada-prod", "`goiabada-prod`"},
+		{"a space", "goiabada prod", "`goiabada prod`"},
+		{"an embedded backtick is doubled, not passed through", "go`iabada", "`go``iabada`"},
+		{"a trailing backtick cannot close the identifier early", "goiabada`", "`goiabada```"},
+		{"empty, which the config default never produces but the function must not mangle", "", "``"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteIdentifier(tc.in); got != tc.want {
+				t.Errorf("quoteIdentifier(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/core/data/postgresdb/db.go
+++ b/src/core/data/postgresdb/db.go
@@ -1,9 +1,11 @@
 package postgresdb
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"strings"
 
@@ -60,7 +62,14 @@ func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDataba
 	}
 
 	if dbConfig.Create {
-		// Create database if not exists
+		// Create database if not exists.
+		//
+		// Serialized, because PostgreSQL's CREATE DATABASE does NOT tolerate being raced. With
+		// the database absent, 7 of 8 concurrent creators fail with `duplicate key value
+		// violates unique constraint "pg_database_datname_index"` (SQLSTATE 23505), whose text
+		// does not contain "already exists" and so is not tolerated below: the loser returns
+		// "unable to create database" and the process exits. Two replicas starting together
+		// against a fresh server is an ordinary topology, not a hypothetical one (#293).
 		defaultDB, err := sql.Open("pgx", fmt.Sprintf("postgres://%v:%v@%v:%v/postgres",
 			dbConfig.Username,
 			dbConfig.Password,
@@ -71,9 +80,8 @@ func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDataba
 		}
 		defer func() { _ = defaultDB.Close() }()
 
-		_, err = defaultDB.Exec(fmt.Sprintf("CREATE DATABASE %v;", dbConfig.Name))
-		if err != nil && !strings.Contains(err.Error(), "already exists") {
-			return nil, errors.Wrap(err, "unable to create database")
+		if err := createDatabaseUnderAdvisoryLock(defaultDB, dbConfig.Name); err != nil {
+			return nil, err
 		}
 	} else {
 		// The operator says the database is already there, so nothing is created and no
@@ -103,6 +111,83 @@ func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDataba
 		dbConfig: dbConfig,
 	}
 	return &postgresDb, nil
+}
+
+// advisoryLockNamespace keeps this lock's keys away from any other advisory lock a session on
+// the maintenance database might take. Advisory locks share one 64-bit key space per database.
+const advisoryLockNamespace = "goiabada:create-database:"
+
+// advisoryLockKey derives the key createDatabaseUnderAdvisoryLock serializes on, from the name
+// of the database being created.
+//
+// FNV-1a computed in Go rather than through the server's own hashtextextended, so it needs no
+// minimum server version and is stable by construction: every Goiabada process racing for one
+// database name arrives at the same key without asking the server anything. The key is an opaque
+// identity, so the uint64 to int64 wrap that pg_advisory_lock's bigint argument forces is
+// deliberate and costs nothing.
+//
+// Keyed by NAME, unlike the SQL Server lock one file over, which is keyed by a constant. That
+// asymmetry is intentional and is not a thing to tidy: pg_database.datname is compared
+// byte-exact, so this key is exactly as precise as the catalog check it guards. SQL Server
+// compares sys.databases.name under master's collation, which folds case and more, and no
+// Go-side key can be made to agree with that (#293).
+func advisoryLockKey(name string) int64 {
+	h := fnv.New64a()
+	// hash.Hash documents that Write never returns an error.
+	_, _ = h.Write([]byte(advisoryLockNamespace + name))
+	return int64(h.Sum64())
+}
+
+// createDatabaseUnderAdvisoryLock creates the application database when it is not there, holding
+// an exclusive advisory lock across the check and the create so that at most one process ever
+// issues CREATE DATABASE.
+//
+// The lock, the check and the create all run on ONE connection pinned out of the maintenance
+// pool. A session-level advisory lock belongs to the session that took it, so a lock taken
+// through the pooled *sql.DB could be released on a different connection and stay held for the
+// life of the process, blocking every later start. Same hazard, same remedy, as the
+// sp_getapplock the SQL Server driver takes around its own version table (#284).
+//
+// Advisory locks live in a key space scoped to the database the session is connected to, and
+// every racer here is connected to `postgres`. That shared space is the whole reason this works.
+//
+// The lock is untimed, so a stuck holder blocks startup rather than failing it. Accepted in #293
+// decision 5, the same trade the migration lock one layer down already makes: what it spans is
+// one catalog read and one CREATE DATABASE.
+func createDatabaseUnderAdvisoryLock(maintenanceDB *sql.DB, name string) error {
+	ctx := context.Background()
+
+	conn, err := maintenanceDB.Conn(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unable to pin a connection for the database creation lock")
+	}
+	defer func() { _ = conn.Close() }()
+
+	key := advisoryLockKey(name)
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
+		return errors.Wrap(err, "unable to take the database creation lock")
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
+	}()
+
+	var found int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM pg_database WHERE datname = $1", name).Scan(&found); err != nil {
+		return errors.Wrap(err, "unable to check whether the database exists")
+	}
+	if found > 0 {
+		return nil
+	}
+
+	// The "already exists" tolerance stays. Under the lock it no longer covers another Goiabada
+	// process, which cannot be in here at the same time, but it still covers an operator running
+	// createdb by hand inside the window, and it costs one condition.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %v;", name)); err != nil &&
+		!strings.Contains(err.Error(), "already exists") {
+		return errors.Wrap(err, "unable to create database")
+	}
+	return nil
 }
 
 func (d *PostgresDatabase) BeginTransaction() (*sql.Tx, error) {

--- a/src/core/data/postgresdb/db.go
+++ b/src/core/data/postgresdb/db.go
@@ -59,20 +59,40 @@ func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDataba
 		return nil, errors.Wrap(err, "unable to open database")
 	}
 
-	// Create database if not exists
-	defaultDB, err := sql.Open("pgx", fmt.Sprintf("postgres://%v:%v@%v:%v/postgres",
-		dbConfig.Username,
-		dbConfig.Password,
-		dbConfig.Host,
-		dbConfig.Port))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to connect to default database")
-	}
-	defer func() { _ = defaultDB.Close() }()
+	if dbConfig.Create {
+		// Create database if not exists
+		defaultDB, err := sql.Open("pgx", fmt.Sprintf("postgres://%v:%v@%v:%v/postgres",
+			dbConfig.Username,
+			dbConfig.Password,
+			dbConfig.Host,
+			dbConfig.Port))
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to connect to default database")
+		}
+		defer func() { _ = defaultDB.Close() }()
 
-	_, err = defaultDB.Exec(fmt.Sprintf("CREATE DATABASE %v;", dbConfig.Name))
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
-		return nil, errors.Wrap(err, "unable to create database")
+		_, err = defaultDB.Exec(fmt.Sprintf("CREATE DATABASE %v;", dbConfig.Name))
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			return nil, errors.Wrap(err, "unable to create database")
+		}
+	} else {
+		// The operator says the database is already there, so nothing is created and no
+		// connection is opened to the postgres maintenance database: a role owning the
+		// application database and holding no CREATEDB is enough to start, which is what the
+		// production checklist's "don't use root/admin accounts" asks for and what this
+		// engine refused to allow before (#293).
+		slog.Info("db create: disabled, the database must already exist (GOIABADA_DB_CREATE=false)")
+
+		// sql.Open only parses the URL, so without this an absent database would come back as
+		// a usable handle and a nil error, and the failure would surface inside the migrator
+		// as somebody else's problem. Ping forces first use here, so the caller gets
+		// PostgreSQL's own `database "x" does not exist (SQLSTATE 3D000)` from the
+		// constructor. Not on the creating arm, where the CREATE DATABASE above already forces
+		// the question.
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			return nil, errors.Wrap(err, "unable to connect to database")
+		}
 	}
 
 	commonDb := commondb.NewCommonDatabase(db, sqlbuilder.PostgreSQL, logSQL)

--- a/src/core/data/postgresdb/db.go
+++ b/src/core/data/postgresdb/db.go
@@ -231,11 +231,38 @@ func createDatabaseUnderAdvisoryLock(maintenanceDB *sql.DB, name string) error {
 	// The "already exists" tolerance stays. Under the lock it no longer covers another Goiabada
 	// process, which cannot be in here at the same time, but it still covers an operator running
 	// createdb by hand inside the window, and it costs one condition.
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %v;", name)); err != nil &&
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s;", QuoteIdentifier(name))); err != nil &&
 		!strings.Contains(err.Error(), "already exists") {
 		return errors.Wrap(err, "unable to create database")
 	}
 	return nil
+}
+
+// QuoteIdentifier wraps name in the double quotes PostgreSQL spells an identifier with, doubling
+// any double quote inside it.
+//
+// It is here because the name is used two ways that have to agree, and unquoted they do not.
+// PostgreSQL down-cases an unquoted identifier, so CREATE DATABASE Goiabada creates `goiabada`,
+// while the same string sits in the connection URL's path as a literal connection parameter and
+// is not folded. GOIABADA_DB_NAME=Goiabada therefore used to create one database and then
+// connect to another, failing with `database "Goiabada" does not exist (SQLSTATE 3D000)` on
+// every start, for the life of the deployment, with the database it did create sitting next to
+// the one it asked for. Quoting makes both halves spell the same thing, and settles the
+// neighbouring case of a name that needs quotes for some other reason, a hyphen or a space,
+// which was a syntax error.
+//
+// Nothing here changes for a lower-case name, which is what every existing deployment has: a
+// name PostgreSQL would not have folded quotes to itself.
+//
+// pg_database.datname is compared byte-exact, so databaseExists and AdvisoryLockKey stay as they
+// are and stay exactly as precise as this statement. That is the asymmetry with SQL Server, one
+// file over, where the catalog folds and the lock resource has to be wider than the name.
+//
+// The doubling is the injection answer too. GOIABADA_DB_NAME is operator-supplied configuration
+// rather than user input, so this is hardening and not a live hole, but an identifier cannot be
+// passed as a bind parameter and this is the only thing that can be done about it.
+func QuoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func (d *PostgresDatabase) BeginTransaction() (*sql.Tx, error) {

--- a/src/core/data/postgresdb/db.go
+++ b/src/core/data/postgresdb/db.go
@@ -117,7 +117,7 @@ func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDataba
 // the maintenance database might take. Advisory locks share one 64-bit key space per database.
 const advisoryLockNamespace = "goiabada:create-database:"
 
-// advisoryLockKey derives the key createDatabaseUnderAdvisoryLock serializes on, from the name
+// AdvisoryLockKey derives the key createDatabaseUnderAdvisoryLock serializes on, from the name
 // of the database being created.
 //
 // FNV-1a computed in Go rather than through the server's own hashtextextended, so it needs no
@@ -131,11 +131,37 @@ const advisoryLockNamespace = "goiabada:create-database:"
 // byte-exact, so this key is exactly as precise as the catalog check it guards. SQL Server
 // compares sys.databases.name under master's collation, which folds case and more, and no
 // Go-side key can be made to agree with that (#293).
-func advisoryLockKey(name string) int64 {
+//
+// Exported because the key is an inter-process contract rather than an implementation detail:
+// anything that has to interoperate with a starting Goiabada, a test holding the lock from
+// outside included, needs the identity itself and cannot re-derive it without becoming a second
+// definition that is free to drift.
+func AdvisoryLockKey(name string) int64 {
 	h := fnv.New64a()
 	// hash.Hash documents that Write never returns an error.
 	_, _ = h.Write([]byte(advisoryLockNamespace + name))
 	return int64(h.Sum64())
+}
+
+// rowQuerier is the one method databaseExists needs, so that the same predicate can be asked of
+// the maintenance pool and of the single connection the lock is held on.
+type rowQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// databaseExists asks pg_database whether name is there.
+//
+// datname is compared byte-exact, which is what lets AdvisoryLockKey be derived from the name:
+// the key is exactly as precise as this check. Called twice per creating start, once outside
+// the lock to decide whether the lock is needed at all and once inside it to decide whether to
+// create. One function, so the two can never disagree (#293).
+func databaseExists(ctx context.Context, q rowQuerier, name string) (bool, error) {
+	var found int
+	if err := q.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM pg_database WHERE datname = $1", name).Scan(&found); err != nil {
+		return false, errors.Wrap(err, "unable to check whether the database exists")
+	}
+	return found > 0, nil
 }
 
 // createDatabaseUnderAdvisoryLock creates the application database when it is not there, holding
@@ -154,8 +180,31 @@ func advisoryLockKey(name string) int64 {
 // The lock is untimed, so a stuck holder blocks startup rather than failing it. Accepted in #293
 // decision 5, the same trade the migration lock one layer down already makes: what it spans is
 // one catalog read and one CREATE DATABASE.
+//
+// That trade is only affordable because the lock is reached ONLY when the database is absent.
+// An advisory lock taken in the `postgres` maintenance database shares one key space with every
+// session on the server, so ANY role that can connect there can hold this key indefinitely,
+// including a role with no rights whatsoever inside Goiabada's own database. Taking it
+// unconditionally would put that stranger on the path of every ordinary restart for the life of
+// the deployment, which is not the cost decision 5 weighed. The unlocked pre-check below keeps
+// the exposure inside the window where the database really is absent, which is the one start
+// that has to create it (#293).
+//
+// The pre-check cannot let a second creator through. It only returns early when the database is
+// already there, and what decides whether CREATE DATABASE runs is still the check taken under
+// the lock. Both ask pg_database the same question through databaseExists, deliberately: two
+// spellings of the same predicate could drift apart, and the outer one is only sound while it
+// is no weaker than the inner one.
 func createDatabaseUnderAdvisoryLock(maintenanceDB *sql.DB, name string) error {
 	ctx := context.Background()
+
+	exists, err := databaseExists(ctx, maintenanceDB, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
 
 	conn, err := maintenanceDB.Conn(ctx)
 	if err != nil {
@@ -163,7 +212,7 @@ func createDatabaseUnderAdvisoryLock(maintenanceDB *sql.DB, name string) error {
 	}
 	defer func() { _ = conn.Close() }()
 
-	key := advisoryLockKey(name)
+	key := AdvisoryLockKey(name)
 	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
 		return errors.Wrap(err, "unable to take the database creation lock")
 	}
@@ -171,12 +220,11 @@ func createDatabaseUnderAdvisoryLock(maintenanceDB *sql.DB, name string) error {
 		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
 	}()
 
-	var found int
-	if err := conn.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM pg_database WHERE datname = $1", name).Scan(&found); err != nil {
-		return errors.Wrap(err, "unable to check whether the database exists")
+	exists, err = databaseExists(ctx, conn, name)
+	if err != nil {
+		return err
 	}
-	if found > 0 {
+	if exists {
 		return nil
 	}
 

--- a/src/core/data/postgresdb/db.go
+++ b/src/core/data/postgresdb/db.go
@@ -33,6 +33,9 @@ type DatabaseConfig struct {
 	Port     int
 	Name     string
 	DSN      string
+	// Create decides whether the constructor may create the database when it is absent. It is
+	// positive-sense, so the zero value does not create: every literal has to set it (#293).
+	Create bool
 }
 
 func NewPostgresDatabase(dbConfig *DatabaseConfig, logSQL bool) (*PostgresDatabase, error) {

--- a/src/core/data/postgresdb/db_test.go
+++ b/src/core/data/postgresdb/db_test.go
@@ -45,3 +45,39 @@ func TestAdvisoryLockKey(t *testing.T) {
 			"compares byte-exact (#293)", "goiabada", "Goiabada", a)
 	}
 }
+
+// TestQuoteIdentifier holds the halves of the name together.
+//
+// The defect it closes had one symptom and two causes that only meet at runtime: CREATE DATABASE
+// folds an unquoted identifier, the connection URL's path does not. A unit test cannot connect,
+// so what it can pin is that the statement no longer folds anything, which is the half that was
+// wrong.
+func TestQuoteIdentifier(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lower case, what every existing deployment has", "goiabada", `"goiabada"`},
+		{"mixed case, the name that used to create one database and connect to another", "Goiabada", `"Goiabada"`},
+		{"a hyphen, a syntax error before quoting", "goiabada-prod", `"goiabada-prod"`},
+		{"a space", "goiabada prod", `"goiabada prod"`},
+		{"an embedded double quote is doubled, not passed through", `go"iabada`, `"go""iabada"`},
+		{"a trailing double quote cannot close the identifier early", `goiabada"`, `"goiabada"""`},
+		{"empty, which the config default never produces but the function must not mangle", "", `""`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := QuoteIdentifier(tc.in); got != tc.want {
+				t.Errorf("QuoteIdentifier(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// The claim the whole change rests on: a quoted identifier is the string PostgreSQL stores
+	// in pg_database.datname, which is the string the connection URL carries. Stripping the
+	// quoting has to give the name back unchanged, case included.
+	const mixed = "Goiabada"
+	if unquoted := QuoteIdentifier(mixed); unquoted != `"`+mixed+`"` {
+		t.Errorf("QuoteIdentifier(%q) does not preserve the name verbatim: %s", mixed, unquoted)
+	}
+}

--- a/src/core/data/postgresdb/db_test.go
+++ b/src/core/data/postgresdb/db_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-// TestAdvisoryLockKey pins what the comment on advisoryLockKey claims, because "stable by
+// TestAdvisoryLockKey pins what the comment on AdvisoryLockKey claims, because "stable by
 // construction" is only worth saying if something checks it.
 //
 // The lock is what makes concurrent starts against an absent database safe, and it only works
@@ -21,27 +21,27 @@ func TestAdvisoryLockKey(t *testing.T) {
 		want = int64(-3802063355692041455)
 	)
 
-	if got := advisoryLockKey(name); got != want {
-		t.Errorf("advisoryLockKey(%q) = %d, want %d: the key is the identity two Goiabada "+
+	if got := AdvisoryLockKey(name); got != want {
+		t.Errorf("AdvisoryLockKey(%q) = %d, want %d: the key is the identity two Goiabada "+
 			"processes serialise on, so changing it stops a new instance serialising against a "+
 			"running one (#293)", name, got, want)
 	}
 
-	if a, b := advisoryLockKey(name), advisoryLockKey(name); a != b {
-		t.Errorf("advisoryLockKey(%q) is not deterministic: %d then %d", name, a, b)
+	if a, b := AdvisoryLockKey(name), AdvisoryLockKey(name); a != b {
+		t.Errorf("AdvisoryLockKey(%q) is not deterministic: %d then %d", name, a, b)
 	}
 
 	// Different names take different locks, which is the point of keying by name at all:
 	// pg_database.datname is compared byte-exact, so two differently named databases have no
 	// reason to wait for each other.
-	if a, b := advisoryLockKey(name), advisoryLockKey(name+"_other"); a == b {
-		t.Errorf("advisoryLockKey collides for %q and %q, both %d", name, name+"_other", a)
+	if a, b := AdvisoryLockKey(name), AdvisoryLockKey(name+"_other"); a == b {
+		t.Errorf("AdvisoryLockKey collides for %q and %q, both %d", name, name+"_other", a)
 	}
 
 	// And case is a difference, not a fold. On PostgreSQL it genuinely is one, which is the
 	// whole reason this key carries the name while SQL Server's resource cannot.
-	if a, b := advisoryLockKey("goiabada"), advisoryLockKey("Goiabada"); a == b {
-		t.Errorf("advisoryLockKey folds case: %q and %q both give %d, but pg_database.datname "+
+	if a, b := AdvisoryLockKey("goiabada"), AdvisoryLockKey("Goiabada"); a == b {
+		t.Errorf("AdvisoryLockKey folds case: %q and %q both give %d, but pg_database.datname "+
 			"compares byte-exact (#293)", "goiabada", "Goiabada", a)
 	}
 }

--- a/src/core/data/postgresdb/db_test.go
+++ b/src/core/data/postgresdb/db_test.go
@@ -1,0 +1,47 @@
+package postgresdb
+
+import (
+	"testing"
+)
+
+// TestAdvisoryLockKey pins what the comment on advisoryLockKey claims, because "stable by
+// construction" is only worth saying if something checks it.
+//
+// The lock is what makes concurrent starts against an absent database safe, and it only works
+// while every process racing for one database name computes the SAME key. A change to the
+// namespace, the hash or the byte order would leave a redeployed instance taking a different
+// lock from one already running, which is the unserialised behaviour back again and silent: the
+// build stays green and the race only shows under concurrency against an absent database.
+//
+// Hence the literal. An assertion that merely recomputed the function would agree with any
+// change to it.
+func TestAdvisoryLockKey(t *testing.T) {
+	const (
+		name = "goiabada"
+		want = int64(-3802063355692041455)
+	)
+
+	if got := advisoryLockKey(name); got != want {
+		t.Errorf("advisoryLockKey(%q) = %d, want %d: the key is the identity two Goiabada "+
+			"processes serialise on, so changing it stops a new instance serialising against a "+
+			"running one (#293)", name, got, want)
+	}
+
+	if a, b := advisoryLockKey(name), advisoryLockKey(name); a != b {
+		t.Errorf("advisoryLockKey(%q) is not deterministic: %d then %d", name, a, b)
+	}
+
+	// Different names take different locks, which is the point of keying by name at all:
+	// pg_database.datname is compared byte-exact, so two differently named databases have no
+	// reason to wait for each other.
+	if a, b := advisoryLockKey(name), advisoryLockKey(name+"_other"); a == b {
+		t.Errorf("advisoryLockKey collides for %q and %q, both %d", name, name+"_other", a)
+	}
+
+	// And case is a difference, not a fold. On PostgreSQL it genuinely is one, which is the
+	// whole reason this key carries the name while SQL Server's resource cannot.
+	if a, b := advisoryLockKey("goiabada"), advisoryLockKey("Goiabada"); a == b {
+		t.Errorf("advisoryLockKey folds case: %q and %q both give %d, but pg_database.datname "+
+			"compares byte-exact (#293)", "goiabada", "Goiabada", a)
+	}
+}

--- a/src/core/data/sqlitedb/db.go
+++ b/src/core/data/sqlitedb/db.go
@@ -35,6 +35,10 @@ type DatabaseConfig struct {
 	DSN      string
 }
 
+// GOIABADA_DB_CREATE does not apply here, which is why DatabaseConfig has no Create field: there
+// is no create statement and no maintenance connection on SQLite, and what decides whether an
+// absent file is created is the operator's own DSN. The equivalent is mode=rw in it, which the
+// driver honours by refusing to create the file (#293).
 func NewSQLiteDatabase(dbConfig *DatabaseConfig, logSQL bool) (*SQLiteDatabase, error) {
 
 	dsn := dbConfig.DSN


### PR DESCRIPTION
Closes #293.

Starting Goiabada creates the application database when it is absent. That is done by a
maintenance connection to `master`, to `postgres`, or to the MySQL server with no database
selected, opened on every single start, followed by a create statement. Two deployments are broken
by it.

**Two instances starting at once against an absent database.** On SQL Server the create is a check
followed by a create, not one atomic statement, so racers can both pass the check and the losers
fail. Measured here: 5 of 8 processes failed, reproduced at 7/8 and 2/6. PostgreSQL is worse and
the issue did not know it, because its `CREATE DATABASE` is not `IF NOT EXISTS` at all: 7 of 8
racers died on `duplicate key value violates unique constraint "pg_database_datname_index"`
(`23505`), which the existing tolerance does not match, so the process exits. MySQL is immune
structurally, not by luck: it serialises on the schema metadata lock and demotes the duplicate to
`Note 1007`, which the driver never raises. SQLite has no create statement to race.

**A dedicated database user on PostgreSQL.** With the database already created and the application
role owning it but holding no `CREATEDB`, startup's `CREATE DATABASE` fails with
`permission denied to create database` (`42501`) and the process exits, although the role can do
everything Goiabada actually needs inside its own database. The production checklist tells readers
"Don't use root/admin accounts", which on PostgreSQL currently produces a server that will not
start.

## What this change does

`GOIABADA_DB_CREATE` / `--db-create`, default **true**, so nothing changes for anybody who sets
nothing. Set it to `false` and Goiabada issues no create statement **and opens no maintenance
connection at all**: not `master`, not `postgres`, not the no-database MySQL DSN. Each exists for
nothing but the create statement, and a managed deployment is exactly where the maintenance
database is out of reach. It applies to the three server engines; SQLite has no create step, and
its equivalent is `mode=rw` in the DSN.

On the default path, the create is serialised. PostgreSQL takes `pg_advisory_lock` on the
maintenance connection and SQL Server takes `sp_getapplock`, each held across the existence check
and the create on one connection pinned out of the pool, so at most one process ever issues
`CREATE DATABASE`. That is the same lock SQL Server already takes one layer down around
`schema_migrations` (#284). MySQL is unchanged.

## Two departures from the issue text

The issue names `Msg 2714` as the loser's error and proposes tolerating it. `Msg 2714` is the
duplicate-**object** error; creating a **database** gives `Msg 1801`, and most losers get no error
number and no message at all (`Number=0`, "Request failed but didn't provide reason"). Over 5
rounds of 8: 20 reason-less, 4 `Msg 1801`, 16 succeeded. With the driver's own message logging on,
the server sends nothing for those losers, so a tolerate-shaped remedy could not have been written
as an error-code test.

The issue also says the other three engines all tolerate a concurrent creation. PostgreSQL does
not, as above.

## What has landed

### Stage 1: The setting, wired end to end and inert

`072eb43d`. `config.DatabaseConfig` gains `Create bool`, read from `GOIABADA_DB_CREATE` (default
`true`) and `--db-create`, passed through `NewDatabase` to the mysql, postgres and mssql engine
configs. **Nothing reads it yet**: no constructor branches on it, so behaviour is identical on all
four engines. The wiring lands and is proved green before stage 2 gives it meaning.

The field is positive-sense, so its zero value does not create and every literal building an engine
config must set it. All 10 sites do: nine `true`, and the pre-created-database fixture in
`migration_testdb_helper.go` `false`, which is what that fixture has always meant. A missed site
fails loudly rather than quietly, since the database is then absent and the migration fails at once.

`getEnvAsBoolDefault` is new because `getEnvAsBool` takes no default and can only express
default-false; its 7 existing callers are untouched. SQLite gets no field and a comment saying so:
there is no create statement and no maintenance connection there, and `mode=rw` in the operator's
own DSN is the equivalent.

Tiers: unit 1290 pass, data 1528 pass across mysql, postgres, mssql and sqlite. Integration not
applicable, no handler, route or schema is touched. Two mutations against the new helper's default
and its parsing, both caught.

### Stage 2: The skipping path, and the documentation

`f144f788`. `GOIABADA_DB_CREATE=false` now means it. Each of `NewMySQLDatabase`,
`NewPostgresDatabase` and `NewMsSQLDatabase` wraps its maintenance connection and its create
statement in `if dbConfig.Create`, bodies unchanged, and logs the mode on the other arm. On SQL
Server that takes the `master` open, its `Ping` and the check-then-create batch, which is the point:
an Azure SQL contained user cannot reach `master` at all, so the ping alone would stop a start that
has everything it needs inside the application database. On PostgreSQL it fixes a plain bug: with
the database present and the role owning it but holding no `CREATEDB`, `CREATE DATABASE` gives
`SQLSTATE 42501`, which the `already exists` tolerance does not match, so the server would not
start. The production checklist's "don't use root/admin accounts" was advice a PostgreSQL reader
could not follow.

MySQL and PostgreSQL also validate the application handle on the skipping arm. `sql.Open` only
parses a DSN, so both used to return a usable-looking handle and a `nil` error against a database
that was not there, and the failure surfaced later inside the migrator as somebody else's. Both now
`Ping` there, so `Error 1049 (42000): Unknown database` and `database "x" does not exist (SQLSTATE
3D000)` reach the caller from the constructor. The creating arm is untouched: its create statement
already forces first use, which is what keeps existing deployments identical.

Data tests build a real restricted login per engine, because this tier connects as `root`, `sa` or
`postgres` and a superuser cannot observe the difference: MySQL a user granted only `ALL PRIVILEGES
ON <db>.*`, PostgreSQL a `LOGIN NOCREATEDB NOSUPERUSER` role owning the database, SQL Server a login
mapped `db_owner` into it and denied `VIEW ANY DATABASE`. Five cases: the least-privilege start on
three engines, the absent-database error on three engines with the catalog checked afterwards, an
operator's pre-created database left alone on the **creating** arm, and the two SQLite cases.

MySQL is the one engine where a restricted login proves nothing, and that is measured rather than
assumed: it has no per-schema `CONNECT` privilege, so no credential denies the maintenance DSN while
allowing the application one, and the `if dbConfig.Create` → `if true` mutation survives. The MySQL
case therefore reads `performance_schema.accounts.TOTAL_CONNECTIONS` for a fixture account created
for that test alone and requires exactly 1.

Docs: a new **[Database setup](https://github.com/leodip/goiabada/blob/issue-293-database-creation/site/src/content/docs/production-deployment/database.mdx)**
page, 252 words against a 350-word budget, with the `CREATE DATABASE` statement per engine and one
line on what the login must do inside it, an `Aside` for the one irreversible thing (SQL Server's
`COLLATE` clause), a sidebar entry after "Overview", a `GOIABADA_DB_CREATE` row in the reference
table linking to the page, and the checklist bullet doing the same.

Tiers: unit 4403 pass; data on mysql, postgres, mssql and sqlite, 518 / 519 / 521 / 508 pass, 0
fail. Integration not applicable, no handler, route or schema is touched. Seven mutations, all
caught.

One deviation worth knowing: the SQL Server fixture denies `VIEW ANY DATABASE` rather than `CONNECT`
in `master`, which the plan had asked for. `DENY CONNECT` on a `master` user locks the login out of
**every** database, the application's own included; denying sight of the catalog leaves it reachable
and makes the creating path fail the way a least-privilege deployment really fails, with `CREATE
DATABASE permission denied in database 'master'`.

### Stage 3: The lock on the creating path

Landed in `38e82928`. Goal 1: two instances starting at the same moment against a server where the
application database is absent both start.

`NewPostgresDatabase` and `NewMsSQLDatabase` no longer issue their create statement through the
pooled maintenance handle. Each now pins one connection out of that pool, takes an exclusive lock
on it, and holds it across the existence check and the create, so at most one process ever issues
`CREATE DATABASE`. PostgreSQL uses `pg_advisory_lock` keyed by a 64-bit FNV-1a of the database
name, computed in Go rather than through `hashtextextended` so it needs no minimum server version
and every racer reaches the same key without asking the server anything. SQL Server uses
`sp_getapplock` at `Exclusive` / `Session` / `LockTimeout = -1`, which is the shape the migration
lock one layer down already uses. Both locks are untimed, so a stuck holder blocks startup rather
than failing it; that is the trade the migration lock already made, and what each lock spans is a
catalog read and one `CREATE DATABASE`.

**The SQL Server lock resource carries no database name, deliberately.** `sp_getapplock` compares
its resource as binary, while `sys.databases.name` is compared under `master`'s collation, which
folds case, trailing space, Unicode normalization form and character width. A resource of
`"goiabada:create-database:" + name` would therefore give two instances configured `goiabada` and
`Goiabada` two *different* locks over what SQL Server treats as one database: both pass
`IF NOT EXISTS`, both create, which is the original defect with a lock bolted on. Normalizing in Go
cannot close that, because the equivalences are whatever the instance's collation says they are.
The constant resource is strictly wider than the thing it guards, which is the safe direction; its
cost, stated in the comment, is that creating two *different* Goiabada databases on one instance
now serializes against each other. PostgreSQL keeps its name-derived key, because
`pg_database.datname` is compared byte-exact and the key is then exactly as precise as the check.

MySQL is unchanged and gains only a comment saying why it needs no lock: it is immune structurally
rather than by luck, serialising on the schema metadata lock and demoting the duplicate to
`Note 1007`, which the driver never raises. 288 full constructor sequences at 24-way concurrency,
zero failures. SQLite has no create statement to race.

Tiers: unit 4404 pass; data on mysql, postgres, mssql and sqlite, 1546 pass, 0 fail. Integration not
applicable, no handler, route or schema is touched.

Four mutations, all caught, and each one reproduces the engine's own race error rather than merely
failing an assertion about a lock. Neutralising `pg_advisory_lock` brings back
`duplicate key value violates unique constraint "pg_database_datname_index" (SQLSTATE 23505)`;
neutralising `sp_getapplock` brings back `mssql: Request failed but didn't provide reason`, the
reason-less loser that is why this serializes instead of tolerating an error and re-checking;
restoring the database name into the SQL Server lock resource makes the case-variant pair create
twice; changing the advisory-lock namespace is caught by the unit case that pins the key literal.

One deviation worth knowing: `createDatabaseUnderAppLock` takes the database *name* and builds the
check-then-create batch itself, rather than being handed the finished statement. That is what makes
the lock-resource mutation writable at all, and it keeps the `IF NOT EXISTS` collation comment next
to the lock that now guards it.

### Folded in: the name it creates is the name it connects to

`7d931556`. This was drafted as a follow-up issue and folded in instead.

`GOIABADA_DB_NAME` reaches two places that have to agree: the create statement and the connection
string. On PostgreSQL they did not. `CREATE DATABASE` folds an unquoted identifier, so
`GOIABADA_DB_NAME=Goiabada` created `goiabada`, while the same string sits in the connection URL's
path as a literal connection parameter and is **not** folded, so the handle then asked for
`Goiabada`. The deployment could never start, it never self-corrected, and the database it did
create sat on the server next to the one the operator asked for. The constructor returned **no
error** for it: `sql.Open` only parses the URL and the creating arm has no `Ping`, the create
statement being what forces first use there, and on this path the create succeeded, against the
wrong name. The failure surfaced on the handle's first query, inside the migrator, as somebody
else's problem.

The three server engines now quote the identifier in the same shape: PostgreSQL `"name"`, MySQL
`` `name` ``, SQL Server `[name]`, each doubling its own quote character, and SQL Server's `N'...'`
catalog literal doubling the single quote. That closes the fold on PostgreSQL and, on all three,
the neighbouring case of a name needing quotes for some other reason, a hyphen or a space, which
was a syntax error. **Nothing changes for a lower-case name**, which is what every existing
deployment has.

MySQL and SQL Server were not broken: MySQL does not fold an unquoted identifier and SQL Server was
already bracketing. They are here so the three engines answer the question the same way, and
because the name reaches every one of these statements by interpolation, an identifier not being
something a bind parameter can carry. `GOIABADA_DB_NAME` is operator-supplied configuration rather
than user input, so the doubling is hardening and not a live hole.

`pg_database.datname` is compared byte-exact, so `databaseExists` and `AdvisoryLockKey` are
untouched and stay exactly as precise as the statement they guard. SQL Server's lock resource still
carries no name, for the reason it never did.

The data tier constructs at a mixed-case name and at a hyphenated one on all three engines, then
asks the returned handle which database it is in and the server how many databases answer to that
name ignoring case. Each engine package's unit tier holds the doubling itself, which no realistic
deployment would exercise. The two drop helpers in the fixtures now quote too: unquoted,
`dropPostgres` folded a mixed-case fixture's name and silently dropped nothing.

One line was added to the **Database setup** page's PostgreSQL section, saying to quote the name in
your own `CREATE DATABASE` when it is not all lower case.

Tiers: unit 4435 pass; data on mysql, postgres, mssql and sqlite, 2092 pass, 0 fail. Six mutations,
all caught, and three of them reproduce the engine's own error rather than merely failing an
assertion: unquoting PostgreSQL's create brings back
`FATAL: database "Goiabada_MixedCase_..." does not exist (SQLSTATE 3D000)` from a constructor that
returned `nil`, unquoting MySQL's brings back `Error 1064 (42000)` on the hyphenated name, and each
of the four escape helpers loses its doubling.

## Status

Complete. All three stages landed, the review found and closed one blocking defect, the drafted
follow-up was folded in rather than filed, and the check suite is green on the branch head.

| Stage | Commit | What it did |
|---|---|---|
| 1. The setting, wired end to end and inert | `072eb43d` | `GOIABADA_DB_CREATE` / `--db-create`, default true, carried to the three server engine configs. Nothing read it yet. |
| 2. The skipping path, and the documentation | `f144f788` | `false` skips both the create statement and the maintenance connection; new **Database setup** page. |
| 3. The lock on the creating path | `38e82928` | PostgreSQL and SQL Server serialise the check and the create on a pinned connection. |
| — review fix | `95dc8b3e` | The catalog check moved ahead of the lock, so the default path no longer reaches for a shared maintenance-database lock on every start. |
| — fold-in | `7d931556` | The three server engines quote the database identifier, so the name Goiabada creates is the name it connects to. |

All four goals are met: concurrent starts against an absent database all succeed on SQL Server and
PostgreSQL; an operator can tell Goiabada the database exists and it then opens no maintenance
connection on any engine; a least-privilege login starts the server on all four engines; and anybody
who sets nothing sees identical behaviour.

## Tiers

**Locally**, per stage, again after the review fix, and again after the fold-in: the unit tier
across all three modules (4435 pass), and the data tier on sqlite, mysql, postgres and mssql
(2092 pass, 33 skip, 0 fail on the last run). Twenty mutations across the run, every one caught.

**Integration was not run and is not applicable**, per decision 8: the diff reaches no handler,
route, template, schema or HTTP flow. Seventeen files, four of them documentation, the rest
`src/core/config`, `src/core/data`, `src/core/cmd/schemadump` and the data tier's fixtures.

**The four-engine result for the committed tree is the check suite's**, not a local run's. Green on
`95dc8b3e`, and re-running on `7d931556`, all eleven jobs: `Build validation`, `Vulnerabilities`, `Versions`, `Lint`,
`Unit / {core,authserver,adminconsole}` and `Tests / {sqlite,mysql,postgres,mssql}`, each of those
four being that engine's data tier.
[Run 33264170616](https://github.com/leodip/goiabada/actions/runs/33264170616).

### Review

Reviewed by `openai-codex/gpt-5.6-sol` at effort `xhigh`, 2 rounds over the whole branch, plus 1
round at the plan gate before any code existed. No stage was reviewed on its own.

| Gate | Round | Findings | Blocking | Outcome |
|---|---|---|---|---|
| plan | 1 | 3 | 0 | all fixed in the plan, before any code existed |
| final | 1 | 1 | 1 | fixed, `95dc8b3e` |
| final | 2 | 0 | 0 | clean |

- **blocking, security:** both creation locks were taken in the shared maintenance database
  (`postgres`, `master`) *before* the existence check, so every start on the default path reached for
  them, and any principal able to connect to that maintenance database, holding no rights at all
  inside Goiabada's own database, could stall every restart indefinitely. Reproduced live on both
  engines by the reviewer. Fixed in `95dc8b3e`: an unlocked catalog check runs first and the lock is
  reached only when there is something to create, with a regression test that holds the production
  lock identity from an unrelated session and requires an ordinary restart to return inside a bounded
  wait.
- **significant, conformance (plan gate):** on `Create: false` against an absent database, MySQL and
  PostgreSQL would have returned a handle and a `nil` error, because `sql.Open` is lazy. Stage 2
  validates the application handle on that arm, so the engine's own `1049` / `3D000` reaches the
  caller.
- **significant, quality (plan gate):** a restricted login cannot observe the skipped maintenance
  connection on MySQL, which has no per-schema `CONNECT`. Stage 2's MySQL case asserts
  `performance_schema.accounts.TOTAL_CONNECTIONS` is exactly 1 for a dedicated fixture account.
- **minor, conformance (plan gate):** the SQL Server lock resource would have been narrower than the
  identity it guards, since `sp_getapplock` compares binary while `sys.databases.name` follows
  `master`'s collation. Stage 3 uses a constant resource.

Full account, with the evidence, in [this comment](https://github.com/leodip/goiabada/pull/295#issuecomment-5463722470).

### Decisions and follow-ups

No decision was deferred; all ten were settled at the seal and none is open.

**One follow-up was drafted and has been folded in rather than filed**, in `7d931556`: PostgreSQL
folded a mixed-case `GOIABADA_DB_NAME` at creation but not at connection, so such a deployment
created one database and connected to another.
[The original draft](https://github.com/leodip/goiabada/pull/295#issuecomment-5463717633) stands as
the account of the defect; what shipped is the "quote the identifier" remedy it named, taken across
all three server engines rather than PostgreSQL alone. Nothing is left to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






