### PR TITLE
test: retire gofakeit for an in-tree core/testutil/fake package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,10 @@ Three test types:
 
 **Best way to run all tests**: `./run-tests.sh` inside the dev container (from `src/authserver/`).
 
+**Test fixtures**: tests draw random values from `core/testutil/fake`, a `_test.go`-only package
+over `crypto/rand` that replaced a third-party faker in #272. Reach for it rather than adding a
+dependency the next time a test needs a random string.
+
 **gofmt guard**: every module's unit tier runs `TestGoSourcesAreGofmted`, which holds every Go
 file under `src/` to gofmt's formatting through `core/testutil.AssertGofmted`. The walk is
 repository-wide from each tier because `cmd/goiabada-setup` has no tier of its own. CI's Lint job

--- a/src/adminconsole/go.sum
+++ b/src/adminconsole/go.sum
@@ -14,8 +14,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
-github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/src/authserver/go.mod
+++ b/src/authserver/go.mod
@@ -4,7 +4,6 @@ go 1.27.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/src/authserver/go.sum
+++ b/src/authserver/go.sum
@@ -21,8 +21,6 @@ github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmg
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.1.0 h1:ChaYjBR63fr4LFyGn8E8nt7dBSt3MiU3zMOZqFvVkHo=
 github.com/boombuler/barcode v1.1.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
-github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/src/authserver/tests/data/cascade_delete_test.go
+++ b/src/authserver/tests/data/cascade_delete_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,8 +34,8 @@ func createROPCRefreshToken(t *testing.T, userId, clientId int64) *models.Refres
 	refreshToken := &models.RefreshToken{
 		UserId:            sql.NullInt64{Int64: userId, Valid: true},
 		ClientId:          sql.NullInt64{Int64: clientId, Valid: true},
-		RefreshTokenJti:   gofakeit.UUID(),
-		SessionIdentifier: gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
+		SessionIdentifier: fake.UUID(),
 		RefreshTokenType:  "Offline",
 		Scope:             "openid profile offline_access",
 		IssuedAt:          sql.NullTime{Time: now, Valid: true},
@@ -55,8 +55,8 @@ func createCodeLinkedRefreshToken(t *testing.T, codeId int64) *models.RefreshTok
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	refreshToken := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: codeId, Valid: true},
-		RefreshTokenJti:   gofakeit.UUID(),
-		SessionIdentifier: gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
+		SessionIdentifier: fake.UUID(),
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile",
 		IssuedAt:          sql.NullTime{Time: now, Valid: true},

--- a/src/authserver/tests/data/client_permission_test.go
+++ b/src/authserver/tests/data/client_permission_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateClientPermission(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -21,7 +21,7 @@ func TestCreateClientPermission(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -31,7 +31,7 @@ func TestCreateClientPermission(t *testing.T) {
 
 	// Create a permission for testing
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -98,7 +98,7 @@ func TestCreateClientPermission(t *testing.T) {
 func TestUpdateClientPermission(t *testing.T) {
 	// Create a client for testing
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -108,7 +108,7 @@ func TestUpdateClientPermission(t *testing.T) {
 
 	// Create another client for updating
 	newClient := &models.Client{
-		ClientIdentifier: "new_test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "new_test_client_" + fake.LetterN(6),
 		Description:      "New Test Client",
 	}
 	err = database.CreateClient(nil, newClient)
@@ -118,7 +118,7 @@ func TestUpdateClientPermission(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -128,7 +128,7 @@ func TestUpdateClientPermission(t *testing.T) {
 
 	// Create a permission for testing
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -139,7 +139,7 @@ func TestUpdateClientPermission(t *testing.T) {
 
 	// Create another permission for updating
 	newPermission := &models.Permission{
-		PermissionIdentifier: "new_test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "new_test_permission_" + fake.LetterN(6),
 		Description:          "New Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -195,7 +195,7 @@ func TestUpdateClientPermission(t *testing.T) {
 func TestGetClientPermissionById(t *testing.T) {
 	// Create a client for testing
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -205,7 +205,7 @@ func TestGetClientPermissionById(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -215,7 +215,7 @@ func TestGetClientPermissionById(t *testing.T) {
 
 	// Create a permission for testing
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -274,7 +274,7 @@ func TestGetClientPermissionById(t *testing.T) {
 func TestGetClientPermissionByClientIdAndPermissionId(t *testing.T) {
 	// Create a client for testing
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -284,7 +284,7 @@ func TestGetClientPermissionByClientIdAndPermissionId(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -294,7 +294,7 @@ func TestGetClientPermissionByClientIdAndPermissionId(t *testing.T) {
 
 	// Create a permission for testing
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -344,7 +344,7 @@ func TestGetClientPermissionByClientIdAndPermissionId(t *testing.T) {
 func TestGetClientPermissionsByClientId(t *testing.T) {
 	// Create a client for testing
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -354,7 +354,7 @@ func TestGetClientPermissionsByClientId(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -366,7 +366,7 @@ func TestGetClientPermissionsByClientId(t *testing.T) {
 	permissions := make([]*models.Permission, 3)
 	for i := 0; i < 3; i++ {
 		permissions[i] = &models.Permission{
-			PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+			PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 			Description:          "Test Permission " + strconv.Itoa(i+1),
 			ResourceId:           resource.Id,
 		}
@@ -415,7 +415,7 @@ func TestGetClientPermissionsByClientId(t *testing.T) {
 func TestDeleteClientPermission(t *testing.T) {
 	// Create a client for testing
 	client := &models.Client{
-		ClientIdentifier: "test_client_" + gofakeit.LetterN(6),
+		ClientIdentifier: "test_client_" + fake.LetterN(6),
 		Description:      "Test Client",
 	}
 	err := database.CreateClient(nil, client)
@@ -425,7 +425,7 @@ func TestDeleteClientPermission(t *testing.T) {
 
 	// Create a resource for testing
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 	err = database.CreateResource(nil, resource)
@@ -435,7 +435,7 @@ func TestDeleteClientPermission(t *testing.T) {
 
 	// Create a permission for testing
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}

--- a/src/authserver/tests/data/client_test.go
+++ b/src/authserver/tests/data/client_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateClient(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -93,7 +93,7 @@ func TestCreateClient(t *testing.T) {
 }
 
 func TestUpdateClient(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	originalClient := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("original_secret"),
@@ -224,7 +224,7 @@ func TestUpdateClient(t *testing.T) {
 }
 
 func TestGetClientById(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -323,7 +323,7 @@ func TestGetClientById(t *testing.T) {
 }
 
 func TestGetClientByClientIdentifier(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	clientIdentifier := "test_client_" + random
 	client := &models.Client{
 		ClientIdentifier:                        clientIdentifier,
@@ -403,7 +403,7 @@ func TestGetClientByClientIdentifier(t *testing.T) {
 	}
 
 	// Test retrieving a non-existent client
-	nonExistentIdentifier := "non_existent_client_" + gofakeit.LetterN(6)
+	nonExistentIdentifier := "non_existent_client_" + fake.LetterN(6)
 	nonExistentClient, err := database.GetClientByClientIdentifier(nil, nonExistentIdentifier)
 	if err != nil {
 		t.Errorf("Expected no error for non-existent client, got: %v", err)
@@ -423,7 +423,7 @@ func TestGetClientByClientIdentifier(t *testing.T) {
 }
 
 func TestClientLoadRedirectURIs(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -484,7 +484,7 @@ func TestClientLoadRedirectURIs(t *testing.T) {
 
 	// Test loading redirect URIs for a client with no URIs
 	clientWithNoURIs := &models.Client{
-		ClientIdentifier: "client_with_no_uris_" + gofakeit.LetterN(6),
+		ClientIdentifier: "client_with_no_uris_" + fake.LetterN(6),
 	}
 	err = database.CreateClient(nil, clientWithNoURIs)
 	if err != nil {
@@ -508,7 +508,7 @@ func TestClientLoadRedirectURIs(t *testing.T) {
 }
 
 func TestClientLoadWebOrigins(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -569,7 +569,7 @@ func TestClientLoadWebOrigins(t *testing.T) {
 
 	// Test loading web origins for a client with no origins
 	clientWithNoOrigins := &models.Client{
-		ClientIdentifier: "client_with_no_origins_" + gofakeit.LetterN(6),
+		ClientIdentifier: "client_with_no_origins_" + fake.LetterN(6),
 	}
 	err = database.CreateClient(nil, clientWithNoOrigins)
 	if err != nil {
@@ -598,7 +598,7 @@ func TestGetClientsByIds(t *testing.T) {
 	clientIds := make([]int64, 3)
 
 	for i := 0; i < 3; i++ {
-		random := gofakeit.LetterN(6)
+		random := fake.LetterN(6)
 		client := models.Client{
 			ClientIdentifier:                        "test_client_" + random,
 			ClientSecretEncrypted:                   []byte("encrypted_secret_" + random),
@@ -705,7 +705,7 @@ func TestGetClientsByIds(t *testing.T) {
 }
 
 func TestClientLoadPermissions(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -791,7 +791,7 @@ func TestClientLoadPermissions(t *testing.T) {
 
 	// Test loading permissions for a client with no permissions
 	clientWithNoPermissions := &models.Client{
-		ClientIdentifier: "client_with_no_permissions_" + gofakeit.LetterN(6),
+		ClientIdentifier: "client_with_no_permissions_" + fake.LetterN(6),
 	}
 	err = database.CreateClient(nil, clientWithNoPermissions)
 	if err != nil {
@@ -832,7 +832,7 @@ func TestGetAllClients(t *testing.T) {
 	createdClients := make([]*models.Client, numClients)
 
 	for i := 0; i < numClients; i++ {
-		random := gofakeit.LetterN(6)
+		random := fake.LetterN(6)
 		client := &models.Client{
 			ClientIdentifier:                        "test_client_" + random,
 			ClientSecretEncrypted:                   []byte("encrypted_secret_" + random),
@@ -954,7 +954,7 @@ func TestGetAllClients(t *testing.T) {
 }
 
 func TestDeleteClient(t *testing.T) {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier:                        "test_client_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -1089,7 +1089,7 @@ func createTestClient(t *testing.T) *models.Client {
 }
 
 func createTestClientOn(t *testing.T, db data.Database) *models.Client {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	client := &models.Client{
 		ClientIdentifier: "test_client_" + random,
 		Description:      "Test Client",
@@ -1103,7 +1103,7 @@ func createTestClientOn(t *testing.T, db data.Database) *models.Client {
 
 func TestClientNullableOverrideFields(t *testing.T) {
 	// Test 1: Create client with nil override fields (use global settings)
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	clientWithNilOverrides := &models.Client{
 		ClientIdentifier:                        "test_client_nil_overrides_" + random,
 		ClientSecretEncrypted:                   []byte("encrypted_secret"),
@@ -1143,7 +1143,7 @@ func TestClientNullableOverrideFields(t *testing.T) {
 	}
 
 	// Test 2: Create client with explicit override values set to true
-	random2 := gofakeit.LetterN(6)
+	random2 := fake.LetterN(6)
 	pkceTrue := true
 	implicitTrue := true
 	ropcTrue := true
@@ -1188,7 +1188,7 @@ func TestClientNullableOverrideFields(t *testing.T) {
 	}
 
 	// Test 3: Create client with explicit override values set to false
-	random3 := gofakeit.LetterN(6)
+	random3 := fake.LetterN(6)
 	pkceFalse := false
 	implicitFalse := false
 	ropcFalse := false
@@ -1616,7 +1616,7 @@ func TestAcquireClientRow_MakesALaterReadSeeAConcurrentCommit(t *testing.T) {
 // row comes back. The data layer discards it (see commondb.engineFoldedTheMatch), which is
 // what makes this assertion mean the same thing on four engines.
 func TestGetClientByClientIdentifierIsCaseSensitive(t *testing.T) {
-	lower := "case_client_" + strings.ToLower(gofakeit.LetterN(6))
+	lower := "case_client_" + strings.ToLower(fake.LetterN(6))
 	upper := strings.ToUpper(lower)
 
 	lowerClient := newCaseTestClient(t, lower)

--- a/src/authserver/tests/data/code_test.go
+++ b/src/authserver/tests/data/code_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateCode(t *testing.T) {
@@ -15,7 +15,7 @@ func TestCreateCode(t *testing.T) {
 	client := createTestClient(t)
 	user := createTestUser(t)
 
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	code := &models.Code{
 		ClientId:            client.Id,
 		UserId:              user.Id,
@@ -515,7 +515,7 @@ func createTestCode(t *testing.T, clientId, userId int64) *models.Code {
 }
 
 func createTestCodeOn(t *testing.T, db data.Database, clientId, userId int64) *models.Code {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	code := &models.Code{
 		ClientId:            clientId,
 		UserId:              userId,
@@ -566,8 +566,8 @@ func TestDeleteUsedCodesWithoutRefreshTokens(t *testing.T) {
 	// Create refresh token for code2
 	refreshToken := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: code2.Id, Valid: true},
-		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
-		SessionIdentifier: "test_session_" + gofakeit.LetterN(6),
+		RefreshTokenJti:   "test_jti_" + fake.LetterN(6),
+		SessionIdentifier: "test_session_" + fake.LetterN(6),
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile",
 		IssuedAt:          sql.NullTime{Time: time.Now().UTC(), Valid: true},
@@ -632,8 +632,8 @@ func TestDeleteUsedCodesWithoutRefreshTokens(t *testing.T) {
 	// Create an expired refresh token for code4 (revoked too, which no longer matters)
 	revokedRefreshToken := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: code4.Id, Valid: true},
-		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
-		SessionIdentifier: "test_session_" + gofakeit.LetterN(6),
+		RefreshTokenJti:   "test_jti_" + fake.LetterN(6),
+		SessionIdentifier: "test_session_" + fake.LetterN(6),
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile",
 		IssuedAt:          sql.NullTime{Time: time.Now().UTC().Add(-2 * time.Hour), Valid: true},
@@ -795,7 +795,7 @@ func TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnused(t *testing.T) {
 	markCodeUsed(t, revokedUsedWithToken)
 	racingChild := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: revokedUsedWithToken.Id, Valid: true},
-		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
+		RefreshTokenJti:   "test_jti_" + fake.LetterN(6),
 		SessionIdentifier: revokedUsedWithToken.SessionIdentifier,
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile offline_access",
@@ -867,7 +867,7 @@ func TestDeleteUsedCodesWithoutRefreshTokens_RevokedUnusedWithRopcTokenPresent(t
 		CodeId:            sql.NullInt64{Valid: false},
 		UserId:            sql.NullInt64{Int64: user.Id, Valid: true},
 		ClientId:          sql.NullInt64{Int64: client.Id, Valid: true},
-		RefreshTokenJti:   "test_jti_" + gofakeit.LetterN(6),
+		RefreshTokenJti:   "test_jti_" + fake.LetterN(6),
 		SessionIdentifier: "",
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile",
@@ -906,7 +906,7 @@ func TestUpdateCode_DoesNotClobberAuthStateGeneration(t *testing.T) {
 
 	code.AuthStateGeneration = 7
 	code.Id = 0
-	code.CodeHash = "genhash_" + gofakeit.LetterN(8)
+	code.CodeHash = "genhash_" + fake.LetterN(8)
 	if err := database.CreateCode(nil, code); err != nil {
 		t.Fatalf("Failed to create code with a generation: %v", err)
 	}
@@ -989,8 +989,8 @@ func TestRevokeCodesBySessionIdentifier(t *testing.T) {
 	client := createTestClient(t)
 	user := createTestUser(t)
 
-	sessionA := "revoke_a_" + gofakeit.LetterN(8)
-	sessionB := "revoke_b_" + gofakeit.LetterN(8)
+	sessionA := "revoke_a_" + fake.LetterN(8)
+	sessionB := "revoke_b_" + fake.LetterN(8)
 
 	first := createTestCodeInSession(t, client.Id, user.Id, sessionA)
 	second := createTestCodeInSession(t, client.Id, user.Id, sessionA)
@@ -1027,7 +1027,7 @@ func TestRevokeCodesBySessionIdentifier(t *testing.T) {
 	assertCodeRevoked(t, first.Id, true, "a code after its session was revoked twice")
 
 	// An unknown session identifier is not an error, it simply matches nothing.
-	count, err = database.RevokeCodesBySessionIdentifier(nil, "revoke_missing_"+gofakeit.LetterN(8))
+	count, err = database.RevokeCodesBySessionIdentifier(nil, "revoke_missing_"+fake.LetterN(8))
 	if err != nil {
 		t.Fatalf("RevokeCodesBySessionIdentifier for an unknown session returned error: %v", err)
 	}
@@ -1055,7 +1055,7 @@ func TestRevokeCodesBySessionIdentifier(t *testing.T) {
 func TestRevokeCodesBySessionIdentifier_TransactionAndFailurePath(t *testing.T) {
 	client := createTestClient(t)
 	user := createTestUser(t)
-	session := "revoke_tx_" + gofakeit.LetterN(8)
+	session := "revoke_tx_" + fake.LetterN(8)
 	code := createTestCodeInSession(t, client.Id, user.Id, session)
 
 	tx := beginTx(t)

--- a/src/authserver/tests/data/dont_update_keys_test.go
+++ b/src/authserver/tests/data/dont_update_keys_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +59,7 @@ func TestUpdateRefreshToken_TheKeysAreNotRewritten(t *testing.T) {
 	original.CodeId = sql.NullInt64{Int64: otherCode.Id, Valid: true}
 	original.UserId = sql.NullInt64{Int64: otherUser.Id, Valid: true}
 	original.ClientId = sql.NullInt64{Int64: otherClient.Id, Valid: true}
-	original.Scope = "rewritten_" + gofakeit.LetterN(6)
+	original.Scope = "rewritten_" + fake.LetterN(6)
 	original.Revoked = true
 
 	require.NoError(t, database.UpdateRefreshToken(nil, original))

--- a/src/authserver/tests/data/group_attribute_test.go
+++ b/src/authserver/tests/data/group_attribute_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateGroupAttribute(t *testing.T) {
 	// Create a test group
 	group := createTestGroup(t)
 
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	groupAttribute := &models.GroupAttribute{
 		GroupId:              group.Id,
 		Key:                  "testkey_" + random,
@@ -275,7 +275,7 @@ func TestDeleteGroupAttribute(t *testing.T) {
 }
 
 func createTestGroupAttribute(t *testing.T, groupId int64) *models.GroupAttribute {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	groupAttribute := &models.GroupAttribute{
 		GroupId:              groupId,
 		Key:                  "TestKey_" + random,

--- a/src/authserver/tests/data/group_test.go
+++ b/src/authserver/tests/data/group_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateGroup(t *testing.T) {
 	group := &models.Group{
-		GroupIdentifier:      "test_group_" + gofakeit.LetterN(6),
+		GroupIdentifier:      "test_group_" + fake.LetterN(6),
 		Description:          "Test Group",
 		IncludeInIdToken:     true,
 		IncludeInAccessToken: false,
@@ -290,7 +290,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func createTestGroup(t *testing.T) *models.Group {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	group := &models.Group{
 		GroupIdentifier: "TestGroup_" + random,
 		Description:     "Test Group Description",
@@ -312,7 +312,7 @@ func createTestGroup(t *testing.T) *models.Group {
 // row comes back and the data layer discards it (commondb.engineFoldedTheMatch). See
 // TestGetClientByClientIdentifierIsCaseSensitive for the whole of the reasoning.
 func TestGetGroupByGroupIdentifierIsCaseSensitive(t *testing.T) {
-	lower := "case_group_" + strings.ToLower(gofakeit.LetterN(6))
+	lower := "case_group_" + strings.ToLower(fake.LetterN(6))
 	upper := strings.ToUpper(lower)
 
 	lowerGroup := &models.Group{GroupIdentifier: lower, Description: "lowercase"}

--- a/src/authserver/tests/data/key_pair_test.go
+++ b/src/authserver/tests/data/key_pair_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateKeyPair(t *testing.T) {
@@ -43,13 +43,13 @@ func TestUpdateKeyPair(t *testing.T) {
 
 	// Update all properties
 	keyPair.State = enums.KeyStatePrevious.String()
-	keyPair.KeyIdentifier = "updated_" + gofakeit.UUID()
+	keyPair.KeyIdentifier = "updated_" + fake.UUID()
 	keyPair.Type = "EC"
 	keyPair.Algorithm = "ES256"
-	keyPair.PrivateKeyPEM = []byte(gofakeit.LoremIpsumSentence(120))
-	keyPair.PublicKeyPEM = []byte(gofakeit.LoremIpsumSentence(60))
-	keyPair.PublicKeyASN1_DER = []byte(gofakeit.LoremIpsumSentence(40))
-	keyPair.PublicKeyJWK = []byte(gofakeit.LoremIpsumSentence(50))
+	keyPair.PrivateKeyPEM = []byte(fake.Sentence(120))
+	keyPair.PublicKeyPEM = []byte(fake.Sentence(60))
+	keyPair.PublicKeyASN1_DER = []byte(fake.Sentence(40))
+	keyPair.PublicKeyJWK = []byte(fake.Sentence(50))
 
 	time.Sleep(timestampTick)
 
@@ -291,13 +291,13 @@ func createKeyPairInState(t *testing.T, state string) *models.KeyPair {
 
 	keyPair := &models.KeyPair{
 		State:             state,
-		KeyIdentifier:     gofakeit.UUID(),
+		KeyIdentifier:     fake.UUID(),
 		Type:              "RSA",
 		Algorithm:         "RS256",
-		PrivateKeyPEM:     []byte(gofakeit.LoremIpsumSentence(100)),
-		PublicKeyPEM:      []byte(gofakeit.LoremIpsumSentence(50)),
-		PublicKeyASN1_DER: []byte(gofakeit.LoremIpsumSentence(30)),
-		PublicKeyJWK:      []byte(gofakeit.LoremIpsumSentence(40)),
+		PrivateKeyPEM:     []byte(fake.Sentence(100)),
+		PublicKeyPEM:      []byte(fake.Sentence(50)),
+		PublicKeyASN1_DER: []byte(fake.Sentence(30)),
+		PublicKeyJWK:      []byte(fake.Sentence(40)),
 	}
 	if err := database.CreateKeyPair(nil, keyPair); err != nil {
 		t.Fatalf("Failed to create test key pair in state %s: %v", state, err)

--- a/src/authserver/tests/data/load_helpers_test.go
+++ b/src/authserver/tests/data/load_helpers_test.go
@@ -3,9 +3,9 @@ package datatests
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // The association loaders in commondb had no direct data-layer tests: they are
@@ -21,9 +21,9 @@ func createUserWithGivenName(t *testing.T, givenName string) *models.User {
 	user := &models.User{
 		Enabled:   true,
 		Subject:   uuid.New(),
-		Username:  "u" + gofakeit.LetterN(12),
+		Username:  "u" + fake.LetterN(12),
 		GivenName: givenName,
-		Email:     gofakeit.LetterN(12) + "@example.com",
+		Email:     fake.LetterN(12) + "@example.com",
 	}
 	if err := database.CreateUser(nil, user); err != nil {
 		t.Fatalf("Failed to create user: %v", err)
@@ -519,7 +519,7 @@ func TestCountGroupMembers(t *testing.T) {
 // Members are ordered by given name, so the page boundaries are deterministic.
 func TestGetGroupMembersPaginated(t *testing.T) {
 	group := createTestGroup(t)
-	suffix := gofakeit.LetterN(6)
+	suffix := fake.LetterN(6)
 
 	userA := createUserWithGivenName(t, "Aaa"+suffix)
 	userB := createUserWithGivenName(t, "Bbb"+suffix)
@@ -622,7 +622,7 @@ func TestGetGroupMembersPaginated_InvalidGroupId(t *testing.T) {
 
 func TestGetLastUserWithOTPState(t *testing.T) {
 	t.Run("otp enabled", func(t *testing.T) {
-		user := createUserWithGivenName(t, "Otp"+gofakeit.LetterN(6))
+		user := createUserWithGivenName(t, "Otp"+fake.LetterN(6))
 		user.OTPEnabled = true
 		if err := database.UpdateUser(nil, user); err != nil {
 			t.Fatalf("Failed to update user: %v", err)
@@ -644,7 +644,7 @@ func TestGetLastUserWithOTPState(t *testing.T) {
 	})
 
 	t.Run("otp disabled", func(t *testing.T) {
-		user := createUserWithGivenName(t, "NoOtp"+gofakeit.LetterN(6))
+		user := createUserWithGivenName(t, "NoOtp"+fake.LetterN(6))
 		user.OTPEnabled = false
 		if err := database.UpdateUser(nil, user); err != nil {
 			t.Fatalf("Failed to update user: %v", err)
@@ -667,13 +667,13 @@ func TestGetLastUserWithOTPState(t *testing.T) {
 
 	// A disabled user is skipped even when its OTP state matches.
 	t.Run("disabled users are ignored", func(t *testing.T) {
-		enabledUser := createUserWithGivenName(t, "Enabled"+gofakeit.LetterN(6))
+		enabledUser := createUserWithGivenName(t, "Enabled"+fake.LetterN(6))
 		enabledUser.OTPEnabled = true
 		if err := database.UpdateUser(nil, enabledUser); err != nil {
 			t.Fatalf("Failed to update user: %v", err)
 		}
 
-		disabledUser := createUserWithGivenName(t, "Disabled"+gofakeit.LetterN(6))
+		disabledUser := createUserWithGivenName(t, "Disabled"+fake.LetterN(6))
 		disabledUser.OTPEnabled = true
 		disabledUser.Enabled = false
 		if err := database.UpdateUser(nil, disabledUser); err != nil {

--- a/src/authserver/tests/data/migration_000026_code_revoked_test.go
+++ b/src/authserver/tests/data/migration_000026_code_revoked_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +84,7 @@ func TestMigration000026_CodeRevoked(t *testing.T) {
 // migrated shared test database rather than this one.
 func seedCode000026(t *testing.T, h *isolatedDB) int64 {
 	t.Helper()
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 
 	client := &models.Client{
 		ClientIdentifier: "mig26_client_" + random,

--- a/src/authserver/tests/data/migration_000029_created_via_dcr_test.go
+++ b/src/authserver/tests/data/migration_000029_created_via_dcr_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/data/migrator"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,7 +80,7 @@ func TestMigration000029_CreatedViaDCR(t *testing.T) {
 		require.NoError(t, err, "migrate to head before seeding through the ORM")
 	}
 
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	cases := []struct {
 		identifier  string
 		wantDCR     bool

--- a/src/authserver/tests/data/migration_000033_public_clients_require_pkce_test.go
+++ b/src/authserver/tests/data/migration_000033_public_clients_require_pkce_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/data/migrator"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,7 +75,7 @@ func TestMigration000033_PublicClientsRequirePKCE(t *testing.T) {
 	}
 
 	no, yes := false, true
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	cases := []struct {
 		name     string
 		isPublic bool

--- a/src/authserver/tests/data/page_offset_overflow_test.go
+++ b/src/authserver/tests/data/page_offset_overflow_test.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,7 +82,7 @@ func TestPaginatedReads_AnOverflowingPageIsAnEmptyPage(t *testing.T) {
 	t.Run("SearchUsersPaginated", func(t *testing.T) {
 		// A given name shared by three users, so the search has rows of its own
 		// rather than depending on what the shared database happens to hold.
-		givenName := "offsettest" + gofakeit.LetterN(10)
+		givenName := "offsettest" + fake.LetterN(10)
 		for i := 0; i < 3; i++ {
 			user := createUserWithGivenName(t, givenName)
 			t.Cleanup(func() { _ = database.DeleteUser(nil, user.Id) })

--- a/src/authserver/tests/data/permission_test.go
+++ b/src/authserver/tests/data/permission_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreatePermission(t *testing.T) {
 	resource := createTestResource(t)
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission_" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission_" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}
@@ -211,7 +211,7 @@ func TestDeletePermission(t *testing.T) {
 
 func createTestPermission(t *testing.T, resource *models.Resource) *models.Permission {
 	permission := &models.Permission{
-		PermissionIdentifier: "test_permission" + gofakeit.LetterN(6),
+		PermissionIdentifier: "test_permission" + fake.LetterN(6),
 		Description:          "Test Permission",
 		ResourceId:           resource.Id,
 	}

--- a/src/authserver/tests/data/pre_registration_test.go
+++ b/src/authserver/tests/data/pre_registration_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreatePreRegistration(t *testing.T) {
@@ -33,9 +33,9 @@ func TestCreatePreRegistration(t *testing.T) {
 func TestUpdatePreRegistration(t *testing.T) {
 	preReg := createTestPreRegistration(t)
 
-	preReg.Email = "updated_" + gofakeit.Email()
-	preReg.PasswordHash = gofakeit.Password(true, true, true, true, false, 16)
-	preReg.VerificationCodeEncrypted = []byte(gofakeit.UUID())
+	preReg.Email = "updated_" + fake.Email()
+	preReg.PasswordHash = fake.Password(16)
+	preReg.VerificationCodeEncrypted = []byte(fake.UUID())
 	preReg.VerificationCodeIssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
 
 	time.Sleep(timestampTick)
@@ -122,11 +122,11 @@ func createTestPreRegistration(t *testing.T) *models.PreRegistration {
 	// caller does: verification_code_hash is UNIQUE, so two rows sharing the '' default
 	// would be refused by the index (#112).
 	preReg := &models.PreRegistration{
-		Email:                     gofakeit.Email(),
-		PasswordHash:              gofakeit.Password(true, true, true, true, false, 16),
-		VerificationCodeEncrypted: []byte(gofakeit.UUID()),
+		Email:                     fake.Email(),
+		PasswordHash:              fake.Password(16),
+		VerificationCodeEncrypted: []byte(fake.UUID()),
 		VerificationCodeIssuedAt:  sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
-		VerificationCodeHash:      codeHashOf(t, gofakeit.UUID()),
+		VerificationCodeHash:      codeHashOf(t, fake.UUID()),
 	}
 	err := database.CreatePreRegistration(nil, preReg)
 	if err != nil {
@@ -173,7 +173,7 @@ func TestGetPreRegistrationByVerificationCodeHash(t *testing.T) {
 	validatePreRegistration(t, preReg, found)
 
 	// 9. A hash no row carries is a miss, not an error.
-	missing, err := database.GetPreRegistrationByVerificationCodeHash(nil, codeHashOf(t, gofakeit.UUID()))
+	missing, err := database.GetPreRegistrationByVerificationCodeHash(nil, codeHashOf(t, fake.UUID()))
 	if err != nil {
 		t.Errorf("a hash no row carries must not be an error, got: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestGetPreRegistrationByVerificationCodeHash_EmptyNeverMatches(t *testing.T
 
 	dormant := &models.PreRegistration{
 		Email:        dormantEmail,
-		PasswordHash: gofakeit.Password(true, true, true, true, false, 16),
+		PasswordHash: fake.Password(16),
 	}
 	if err := database.CreatePreRegistration(nil, dormant); err != nil {
 		t.Fatalf("Failed to create the dormant pre-registration: %v", err)
@@ -243,14 +243,14 @@ func TestGetPreRegistrationByVerificationCodeHash_EmptyNeverMatches(t *testing.T
 // benign "no such code". It reads only through the transaction while that transaction is
 // open, for the reasons the users mirror documents.
 func TestGetPreRegistrationByVerificationCodeHash_Transaction(t *testing.T) {
-	hash := codeHashOf(t, gofakeit.UUID())
+	hash := codeHashOf(t, fake.UUID())
 
 	tx := beginTx(t)
 
 	preReg := &models.PreRegistration{
-		Email:                     gofakeit.Email(),
-		PasswordHash:              gofakeit.Password(true, true, true, true, false, 16),
-		VerificationCodeEncrypted: []byte(gofakeit.UUID()),
+		Email:                     fake.Email(),
+		PasswordHash:              fake.Password(16),
+		VerificationCodeEncrypted: []byte(fake.UUID()),
 		VerificationCodeIssuedAt:  sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
 		VerificationCodeHash:      hash,
 	}

--- a/src/authserver/tests/data/redirect_uri_test.go
+++ b/src/authserver/tests/data/redirect_uri_test.go
@@ -3,8 +3,8 @@ package datatests
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateRedirectURI(t *testing.T) {
@@ -119,7 +119,7 @@ func TestDeleteRedirectURI(t *testing.T) {
 
 func createTestRedirectURI(t *testing.T, clientId int64) *models.RedirectURI {
 	redirectURI := &models.RedirectURI{
-		URI:      "https://example.com/callback_" + gofakeit.LetterN(6),
+		URI:      "https://example.com/callback_" + fake.LetterN(6),
 		ClientId: clientId,
 	}
 	err := database.CreateRedirectURI(nil, redirectURI)

--- a/src/authserver/tests/data/refresh_token_test.go
+++ b/src/authserver/tests/data/refresh_token_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateRefreshToken(t *testing.T) {
@@ -238,8 +238,8 @@ func createTestRefreshToken(t *testing.T) *models.RefreshToken {
 		CodeId:            sql.NullInt64{Int64: code.Id, Valid: true},
 		UserId:            sql.NullInt64{Int64: user.Id, Valid: true},
 		ClientId:          sql.NullInt64{Int64: client.Id, Valid: true},
-		RefreshTokenJti:   gofakeit.UUID(),
-		SessionIdentifier: gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
+		SessionIdentifier: fake.UUID(),
 		RefreshTokenType:  "Bearer",
 		Scope:             "openid profile",
 		IssuedAt:          sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -306,7 +306,7 @@ func TestGetRefreshTokensByCodeId(t *testing.T) {
 
 	rt1 := &models.RefreshToken{
 		CodeId:           sql.NullInt64{Int64: code.Id, Valid: true},
-		RefreshTokenJti:  gofakeit.UUID(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Refresh",
 		Scope:            "openid",
 		IssuedAt:         sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -318,7 +318,7 @@ func TestGetRefreshTokensByCodeId(t *testing.T) {
 
 	rt2 := &models.RefreshToken{
 		CodeId:           sql.NullInt64{Int64: code.Id, Valid: true},
-		RefreshTokenJti:  gofakeit.UUID(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Offline",
 		Scope:            "openid offline_access",
 		IssuedAt:         sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -332,7 +332,7 @@ func TestGetRefreshTokensByCodeId(t *testing.T) {
 	otherCode := createTestCode(t, client.Id, user.Id)
 	rtOther := &models.RefreshToken{
 		CodeId:           sql.NullInt64{Int64: otherCode.Id, Valid: true},
-		RefreshTokenJti:  gofakeit.UUID(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Refresh",
 		Scope:            "openid",
 		IssuedAt:         sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -371,16 +371,16 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	client := createTestClient(t)
 	user := createTestUser(t)
 
-	sessionId := "sess_" + gofakeit.LetterN(12)
+	sessionId := "sess_" + fake.LetterN(12)
 
 	// Two codes share the same session identifier (e.g., user federated to two clients
 	// during the same SSO session, or one online + one offline exchange).
 	codeA := &models.Code{
 		ClientId:            client.Id,
 		UserId:              user.Id,
-		Code:                "code_a_" + gofakeit.LetterN(6),
-		CodeHash:            "hash_a_" + gofakeit.LetterN(6),
-		CodeChallenge:       sql.NullString{String: "challenge_a_" + gofakeit.LetterN(6), Valid: true},
+		Code:                "code_a_" + fake.LetterN(6),
+		CodeHash:            "hash_a_" + fake.LetterN(6),
+		CodeChallenge:       sql.NullString{String: "challenge_a_" + fake.LetterN(6), Valid: true},
 		CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
 		RedirectURI:         "https://example.com/callback",
 		Scope:               "openid",
@@ -400,9 +400,9 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	codeB := &models.Code{
 		ClientId:            client.Id,
 		UserId:              user.Id,
-		Code:                "code_b_" + gofakeit.LetterN(6),
-		CodeHash:            "hash_b_" + gofakeit.LetterN(6),
-		CodeChallenge:       sql.NullString{String: "challenge_b_" + gofakeit.LetterN(6), Valid: true},
+		Code:                "code_b_" + fake.LetterN(6),
+		CodeHash:            "hash_b_" + fake.LetterN(6),
+		CodeChallenge:       sql.NullString{String: "challenge_b_" + fake.LetterN(6), Valid: true},
 		CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
 		RedirectURI:         "https://example.com/callback",
 		Scope:               "openid offline_access",
@@ -422,7 +422,7 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	// Online refresh token (carries session_identifier on the row).
 	rtOnline := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: codeA.Id, Valid: true},
-		RefreshTokenJti:   gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
 		SessionIdentifier: sessionId,
 		RefreshTokenType:  "Refresh",
 		Scope:             "openid",
@@ -436,7 +436,7 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	// Offline refresh token (empty session_identifier on the row, but its code carries it).
 	rtOffline := &models.RefreshToken{
 		CodeId:           sql.NullInt64{Int64: codeB.Id, Valid: true},
-		RefreshTokenJti:  gofakeit.UUID(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Offline",
 		Scope:            "openid offline_access",
 		IssuedAt:         sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -450,9 +450,9 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	unrelatedCode := &models.Code{
 		ClientId:            client.Id,
 		UserId:              user.Id,
-		Code:                "code_c_" + gofakeit.LetterN(6),
-		CodeHash:            "hash_c_" + gofakeit.LetterN(6),
-		CodeChallenge:       sql.NullString{String: "challenge_c_" + gofakeit.LetterN(6), Valid: true},
+		Code:                "code_c_" + fake.LetterN(6),
+		CodeHash:            "hash_c_" + fake.LetterN(6),
+		CodeChallenge:       sql.NullString{String: "challenge_c_" + fake.LetterN(6), Valid: true},
 		CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
 		RedirectURI:         "https://example.com/callback",
 		Scope:               "openid",
@@ -460,7 +460,7 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 		UserAgent:           "test",
 		ResponseMode:        "query",
 		AuthenticatedAt:     time.Now().UTC().Truncate(time.Microsecond),
-		SessionIdentifier:   "different_" + gofakeit.LetterN(8),
+		SessionIdentifier:   "different_" + fake.LetterN(8),
 		AcrLevel:            "1",
 		AuthMethods:         "pwd",
 		Used:                true,
@@ -470,7 +470,7 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	}
 	rtUnrelated := &models.RefreshToken{
 		CodeId:           sql.NullInt64{Int64: unrelatedCode.Id, Valid: true},
-		RefreshTokenJti:  gofakeit.UUID(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Refresh",
 		Scope:            "openid",
 		IssuedAt:         sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -499,7 +499,7 @@ func TestGetRefreshTokensBySessionIdentifier(t *testing.T) {
 	}
 
 	// Unknown session identifier returns empty.
-	gotEmpty, err := database.GetRefreshTokensBySessionIdentifier(nil, "no-such-session-"+gofakeit.LetterN(8))
+	gotEmpty, err := database.GetRefreshTokensBySessionIdentifier(nil, "no-such-session-"+fake.LetterN(8))
 	if err != nil {
 		t.Fatalf("GetRefreshTokensBySessionIdentifier(unknown) failed: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestUpdateRefreshToken_DoesNotClobberAuthStateGeneration(t *testing.T) {
 
 	refreshToken.AuthStateGeneration = 7
 	refreshToken.Id = 0
-	refreshToken.RefreshTokenJti = gofakeit.UUID()
+	refreshToken.RefreshTokenJti = fake.UUID()
 	if err := database.CreateRefreshToken(nil, refreshToken); err != nil {
 		t.Fatalf("Failed to create refresh token with a generation: %v", err)
 	}
@@ -692,9 +692,9 @@ func TestGetRefreshTokensByUserId(t *testing.T) {
 		code := &models.Code{
 			ClientId:            client.Id,
 			UserId:              user.Id,
-			Code:                "code_" + gofakeit.LetterN(8),
-			CodeHash:            "hash_" + gofakeit.LetterN(8),
-			CodeChallenge:       sql.NullString{String: "chal_" + gofakeit.LetterN(8), Valid: true},
+			Code:                "code_" + fake.LetterN(8),
+			CodeHash:            "hash_" + fake.LetterN(8),
+			CodeChallenge:       sql.NullString{String: "chal_" + fake.LetterN(8), Valid: true},
 			CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
 			RedirectURI:         "https://example.com/callback",
 			Scope:               "openid",
@@ -714,7 +714,7 @@ func TestGetRefreshTokensByUserId(t *testing.T) {
 	}
 
 	newToken := func(rt *models.RefreshToken) *models.RefreshToken {
-		rt.RefreshTokenJti = gofakeit.UUID()
+		rt.RefreshTokenJti = fake.UUID()
 		rt.Scope = "openid"
 		rt.IssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
 		rt.ExpiresAt = sql.NullTime{Time: time.Now().UTC().Add(time.Hour).Truncate(time.Microsecond), Valid: true}
@@ -766,12 +766,12 @@ func TestGetRefreshTokensByUserId(t *testing.T) {
 	// only the user, so neither can pass with the predicate removed.
 	otherCode := &models.Code{
 		ClientId: client.Id, UserId: otherUser.Id,
-		Code: "code_o_" + gofakeit.LetterN(8), CodeHash: "hash_o_" + gofakeit.LetterN(8),
+		Code: "code_o_" + fake.LetterN(8), CodeHash: "hash_o_" + fake.LetterN(8),
 		CodeChallenge: sql.NullString{String: "chal_o", Valid: true}, CodeChallengeMethod: sql.NullString{String: "S256", Valid: true},
 		RedirectURI: "https://example.com/callback", Scope: "openid", IpAddress: "127.0.0.1",
 		UserAgent: "test", ResponseMode: "query",
 		AuthenticatedAt:   time.Now().UTC().Truncate(time.Microsecond),
-		SessionIdentifier: "sess_o_" + gofakeit.LetterN(8), AcrLevel: "1", AuthMethods: "pwd", Used: true,
+		SessionIdentifier: "sess_o_" + fake.LetterN(8), AcrLevel: "1", AuthMethods: "pwd", Used: true,
 	}
 	if err := database.CreateCode(nil, otherCode); err != nil {
 		t.Fatalf("Failed to create the other user's code: %v", err)
@@ -868,7 +868,7 @@ func TestGetRefreshTokensByClientId(t *testing.T) {
 	user := createTestUser(t)
 
 	newToken := func(rt *models.RefreshToken) *models.RefreshToken {
-		rt.RefreshTokenJti = gofakeit.UUID()
+		rt.RefreshTokenJti = fake.UUID()
 		rt.Scope = "openid"
 		rt.IssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
 		rt.ExpiresAt = sql.NullTime{Time: time.Now().UTC().Add(time.Hour).Truncate(time.Microsecond), Valid: true}
@@ -989,7 +989,7 @@ func TestGetRefreshTokensByClientId_TransactionAndFailurePath(t *testing.T) {
 
 	tx := beginTx(t)
 
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	code := &models.Code{
 		ClientId:            client.Id,
 		UserId:              user.Id,
@@ -1013,7 +1013,7 @@ func TestGetRefreshTokensByClientId_TransactionAndFailurePath(t *testing.T) {
 	refreshToken := &models.RefreshToken{
 		CodeId:            sql.NullInt64{Int64: code.Id, Valid: true},
 		SessionIdentifier: code.SessionIdentifier,
-		RefreshTokenJti:   gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
 		RefreshTokenType:  "Refresh",
 		Scope:             "openid",
 		IssuedAt:          sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
@@ -1221,7 +1221,7 @@ func seedFamilyToken(t *testing.T, spec familyTokenSpec) *models.RefreshToken {
 	t.Helper()
 
 	rt := &models.RefreshToken{
-		RefreshTokenJti:      gofakeit.UUID(),
+		RefreshTokenJti:      fake.UUID(),
 		FirstRefreshTokenJti: spec.FamilyJti,
 		SessionIdentifier:    spec.SessionIdentifier,
 		RefreshTokenType:     "Refresh",
@@ -1252,7 +1252,7 @@ func seedFamilyToken(t *testing.T, spec familyTokenSpec) *models.RefreshToken {
 func seedCodeOnSession(t *testing.T, clientId, userId int64, sessionIdentifier string) *models.Code {
 	t.Helper()
 
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	code := &models.Code{
 		ClientId:            clientId,
 		UserId:              userId,
@@ -1299,7 +1299,7 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		client := createTestClient(t)
 		user := createTestUser(t)
 		code := createTestCode(t, client.Id, user.Id)
-		family := gofakeit.UUID()
+		family := fake.UUID()
 
 		parent := seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id, Revoked: true})
 		child := seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id})
@@ -1325,7 +1325,7 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		client := createTestClient(t)
 		user := createTestUser(t)
 		code := createTestCode(t, client.Id, user.Id)
-		family := gofakeit.UUID()
+		family := fake.UUID()
 
 		seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id, Revoked: true})
 		childA := seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id})
@@ -1349,7 +1349,7 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		client := createTestClient(t)
 		user := createTestUser(t)
 		code := createTestCode(t, client.Id, user.Id)
-		family := gofakeit.UUID()
+		family := fake.UUID()
 
 		seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id, Revoked: true})
 		seedFamilyToken(t, familyTokenSpec{FamilyJti: family, CodeId: code.Id, Revoked: true})
@@ -1368,9 +1368,9 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		user := createTestUser(t)
 		code := createTestCode(t, client.Id, user.Id)
 
-		bystander := seedFamilyToken(t, familyTokenSpec{FamilyJti: gofakeit.UUID(), CodeId: code.Id})
+		bystander := seedFamilyToken(t, familyTokenSpec{FamilyJti: fake.UUID(), CodeId: code.Id})
 
-		count, err := database.RevokeRefreshTokenFamily(nil, "no-such-family-"+gofakeit.UUID())
+		count, err := database.RevokeRefreshTokenFamily(nil, "no-such-family-"+fake.UUID())
 		if err != nil {
 			t.Fatalf("RevokeRefreshTokenFamily failed: %v", err)
 		}
@@ -1389,12 +1389,12 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		// clients in one SSO session looks like.
 		client := createTestClient(t)
 		user := createTestUser(t)
-		sessionId := "sess_" + gofakeit.LetterN(12)
+		sessionId := "sess_" + fake.LetterN(12)
 		codeA := seedCodeOnSession(t, client.Id, user.Id, sessionId)
 		codeB := seedCodeOnSession(t, client.Id, user.Id, sessionId)
 
-		familyA := gofakeit.UUID()
-		familyB := gofakeit.UUID()
+		familyA := fake.UUID()
+		familyB := fake.UUID()
 
 		seedFamilyToken(t, familyTokenSpec{
 			FamilyJti: familyA, CodeId: codeA.Id, SessionIdentifier: sessionId, Revoked: true})
@@ -1428,7 +1428,7 @@ func TestRevokeRefreshTokenFamily(t *testing.T) {
 		// no join for it to work.
 		client := createTestClient(t)
 		user := createTestUser(t)
-		family := gofakeit.UUID()
+		family := fake.UUID()
 
 		parent := seedFamilyToken(t, familyTokenSpec{
 			FamilyJti: family, UserId: user.Id, ClientId: client.Id, Revoked: true})

--- a/src/authserver/tests/data/resource_test.go
+++ b/src/authserver/tests/data/resource_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateResource(t *testing.T) {
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource_" + gofakeit.LetterN(6),
+		ResourceIdentifier: "test_resource_" + fake.LetterN(6),
 		Description:        "Test Resource",
 	}
 
@@ -46,7 +46,7 @@ func TestCreateResource(t *testing.T) {
 func TestUpdateResource(t *testing.T) {
 	resource := createTestResource(t)
 
-	resource.ResourceIdentifier = "updated_resource_identifier_" + gofakeit.LetterN(6)
+	resource.ResourceIdentifier = "updated_resource_identifier_" + fake.LetterN(6)
 	resource.Description = "Updated Description"
 
 	time.Sleep(timestampTick)
@@ -229,7 +229,7 @@ func TestDeleteResource(t *testing.T) {
 
 func createTestResource(t *testing.T) *models.Resource {
 	resource := &models.Resource{
-		ResourceIdentifier: "test_resource" + gofakeit.LetterN(4),
+		ResourceIdentifier: "test_resource" + fake.LetterN(4),
 		Description:        "Test Resource",
 	}
 	err := database.CreateResource(nil, resource)
@@ -250,7 +250,7 @@ func createTestResource(t *testing.T) *models.Resource {
 // row comes back and the data layer discards it (commondb.engineFoldedTheMatch). See
 // TestGetClientByClientIdentifierIsCaseSensitive for the whole of the reasoning.
 func TestGetResourceByResourceIdentifierIsCaseSensitive(t *testing.T) {
-	lower := "case_resource_" + strings.ToLower(gofakeit.LetterN(6))
+	lower := "case_resource_" + strings.ToLower(fake.LetterN(6))
 	upper := strings.ToUpper(lower)
 
 	lowerResource := &models.Resource{ResourceIdentifier: lower, Description: "lowercase"}

--- a/src/authserver/tests/data/run_in_transaction_test.go
+++ b/src/authserver/tests/data/run_in_transaction_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ const deadlockCeiling = 60 * time.Second
 // newClientModel is a client that has not been inserted, for bodies that insert it themselves.
 func newClientModel() *models.Client {
 	return &models.Client{
-		ClientIdentifier: "rit_client_" + gofakeit.LetterN(8),
+		ClientIdentifier: "rit_client_" + fake.LetterN(8),
 		Description:      "RunInTransaction test client",
 	}
 }

--- a/src/authserver/tests/data/session_termination_test.go
+++ b/src/authserver/tests/data/session_termination_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/authserver/internal/handlers"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // TestTerminateUserSessionTx_SweepsAfterTheSessionRowIsDeleted is the data half of #139 decision 2.
@@ -106,7 +106,7 @@ func createTokenOfCodeOn(t *testing.T, db data.Database, clientId, userId, codeI
 		CodeId:            sql.NullInt64{Int64: codeId, Valid: true},
 		UserId:            sql.NullInt64{Int64: userId, Valid: true},
 		ClientId:          sql.NullInt64{Int64: clientId, Valid: true},
-		RefreshTokenJti:   gofakeit.UUID(),
+		RefreshTokenJti:   fake.UUID(),
 		SessionIdentifier: sessionIdentifier,
 		RefreshTokenType:  tokenType,
 		Scope:             "openid profile offline_access",

--- a/src/authserver/tests/data/transaction_test.go
+++ b/src/authserver/tests/data/transaction_test.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ import (
 // newTestGroup returns an unsaved group with a unique identifier.
 func newTestGroup() *models.Group {
 	return &models.Group{
-		GroupIdentifier: "TxGroup_" + gofakeit.LetterN(8),
+		GroupIdentifier: "TxGroup_" + fake.LetterN(8),
 		Description:     "Transaction test group",
 	}
 }

--- a/src/authserver/tests/data/unique_constraint_test.go
+++ b/src/authserver/tests/data/unique_constraint_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,8 +72,8 @@ func TestUnique_UserSubject(t *testing.T) {
 	duplicate := &models.User{
 		Enabled:  true,
 		Subject:  existing.Subject,
-		Username: gofakeit.Username(),
-		Email:    "dup_subject_" + gofakeit.LetterN(10) + "@example.com",
+		Username: fake.Username(),
+		Email:    "dup_subject_" + fake.LetterN(10) + "@example.com",
 	}
 	err := database.CreateUser(nil, duplicate)
 	assert.Error(t, err, "two users must not share a subject")
@@ -85,7 +85,7 @@ func TestUnique_UserEmail(t *testing.T) {
 	duplicate := &models.User{
 		Enabled:  true,
 		Subject:  uuid.New(),
-		Username: gofakeit.Username(),
+		Username: fake.Username(),
 		Email:    existing.Email,
 	}
 	err := database.CreateUser(nil, duplicate)
@@ -99,7 +99,7 @@ func TestUnique_CodeHash(t *testing.T) {
 
 	duplicate := *existing
 	duplicate.Id = 0
-	duplicate.Code = "other_" + gofakeit.LetterN(6)
+	duplicate.Code = "other_" + fake.LetterN(6)
 	err := database.CreateCode(nil, &duplicate)
 	assert.Error(t, err, "two codes must not share a code_hash")
 }
@@ -113,7 +113,7 @@ func TestUnique_KeyPairState(t *testing.T) {
 
 	duplicate := &models.KeyPair{
 		State:         existing.State,
-		KeyIdentifier: gofakeit.UUID(),
+		KeyIdentifier: fake.UUID(),
 		Type:          "RSA",
 		Algorithm:     "RS256",
 	}

--- a/src/authserver/tests/data/unknown_id_test.go
+++ b/src/authserver/tests/data/unknown_id_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -151,7 +151,7 @@ type byValueReader struct {
 
 func byValueReaders() []byValueReader {
 	randomUUID := func() string { return uuid.New().String() }
-	randomWord := func() string { return "missing_" + gofakeit.LetterN(16) }
+	randomWord := func() string { return "missing_" + fake.LetterN(16) }
 
 	return []byValueReader{
 		{"GetClientByClientIdentifier", randomWord, func(tx *sql.Tx, v string) (bool, error) {
@@ -166,7 +166,7 @@ func byValueReaders() []byValueReader {
 			u, err := database.GetUserBySubject(tx, v)
 			return u != nil, err
 		}},
-		{"GetUserByEmail", func() string { return "missing_" + gofakeit.LetterN(12) + "@example.com" },
+		{"GetUserByEmail", func() string { return "missing_" + fake.LetterN(12) + "@example.com" },
 			func(tx *sql.Tx, v string) (bool, error) {
 				u, err := database.GetUserByEmail(tx, v)
 				return u != nil, err
@@ -183,7 +183,7 @@ func byValueReaders() []byValueReader {
 			s, err := database.GetUserSessionBySessionIdentifier(tx, v)
 			return s != nil, err
 		}},
-		{"GetPreRegistrationByEmail", func() string { return "missing_" + gofakeit.LetterN(12) + "@example.com" },
+		{"GetPreRegistrationByEmail", func() string { return "missing_" + fake.LetterN(12) + "@example.com" },
 			func(tx *sql.Tx, v string) (bool, error) {
 				p, err := database.GetPreRegistrationByEmail(tx, v)
 				return p != nil, err

--- a/src/authserver/tests/data/user_attribute_test.go
+++ b/src/authserver/tests/data/user_attribute_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateUserAttribute(t *testing.T) {
@@ -162,10 +162,10 @@ func TestDeleteUserAttribute(t *testing.T) {
 
 func createTestUserAttribute(t *testing.T, userId int64) *models.UserAttribute {
 	attr := &models.UserAttribute{
-		Key:                  "TestKey_" + gofakeit.LetterN(6),
-		Value:                "TestValue_" + gofakeit.LetterN(6),
-		IncludeInIdToken:     gofakeit.Bool(),
-		IncludeInAccessToken: gofakeit.Bool(),
+		Key:                  "TestKey_" + fake.LetterN(6),
+		Value:                "TestValue_" + fake.LetterN(6),
+		IncludeInIdToken:     fake.Bool(),
+		IncludeInAccessToken: fake.Bool(),
 		UserId:               userId,
 	}
 	err := database.CreateUserAttribute(nil, attr)

--- a/src/authserver/tests/data/user_session_test.go
+++ b/src/authserver/tests/data/user_session_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateUserSession(t *testing.T) {
@@ -38,7 +38,7 @@ func TestUpdateUserSession(t *testing.T) {
 	userSession := createTestUserSession(t, user.Id)
 
 	// Update all properties
-	userSession.SessionIdentifier = "updated_" + gofakeit.UUID()
+	userSession.SessionIdentifier = "updated_" + fake.UUID()
 	userSession.Started = time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Microsecond)
 	userSession.LastAccessed = time.Now().UTC().Truncate(time.Microsecond)
 	userSession.AuthMethods = "pwd,otp"
@@ -324,14 +324,14 @@ func createTestUserSession(t *testing.T, userId int64) *models.UserSession {
 
 func createTestUserSessionOn(t *testing.T, db data.Database, userId int64) *models.UserSession {
 	userSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Truncate(time.Microsecond),
 		LastAccessed:      time.Now().UTC().Truncate(time.Microsecond),
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          time.Now().UTC().Truncate(time.Microsecond),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            userId,
@@ -428,14 +428,14 @@ func assertUserSessionEqual(t *testing.T, expected, actual *models.UserSession) 
 func TestDeleteIdleSessions(t *testing.T) {
 	// Create a test user
 	user := &models.User{
-		Username:      gofakeit.Username(),
-		Email:         gofakeit.Email(),
+		Username:      fake.Username(),
+		Email:         fake.Email(),
 		EmailVerified: true,
-		PasswordHash:  gofakeit.Password(true, true, true, true, false, 32),
+		PasswordHash:  fake.Password(32),
 		Subject:       uuid.New(),
 		Enabled:       true,
-		GivenName:     gofakeit.FirstName(),
-		FamilyName:    gofakeit.LastName(),
+		GivenName:     fake.FirstName(),
+		FamilyName:    fake.LastName(),
 		OTPEnabled:    false,
 	}
 	err := database.CreateUser(nil, user)
@@ -445,7 +445,7 @@ func TestDeleteIdleSessions(t *testing.T) {
 
 	// Create a test client
 	client := &models.Client{
-		ClientIdentifier:                        gofakeit.UUID(),
+		ClientIdentifier:                        fake.UUID(),
 		Description:                             "Test Client",
 		Enabled:                                 true,
 		ConsentRequired:                         true,
@@ -468,14 +468,14 @@ func TestDeleteIdleSessions(t *testing.T) {
 
 	// Create an active session (accessed 10 minutes ago)
 	activeSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-10 * time.Minute),
 		LastAccessed:      now.Add(-10 * time.Minute),
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-10 * time.Minute),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -499,14 +499,14 @@ func TestDeleteIdleSessions(t *testing.T) {
 
 	// Create an idle session (accessed 2 hours ago)
 	idleSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-3 * time.Hour),
 		LastAccessed:      now.Add(-2 * time.Hour),
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-3 * time.Hour),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -530,14 +530,14 @@ func TestDeleteIdleSessions(t *testing.T) {
 
 	// Create a very idle session (accessed 4 hours ago)
 	veryIdleSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-5 * time.Hour),
 		LastAccessed:      now.Add(-4 * time.Hour),
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-5 * time.Hour),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -626,14 +626,14 @@ func TestDeleteIdleSessions(t *testing.T) {
 func TestDeleteExpiredSessions(t *testing.T) {
 	// Create a test user
 	user := &models.User{
-		Username:      gofakeit.Username(),
-		Email:         gofakeit.Email(),
+		Username:      fake.Username(),
+		Email:         fake.Email(),
 		EmailVerified: true,
-		PasswordHash:  gofakeit.Password(true, true, true, true, false, 32),
+		PasswordHash:  fake.Password(32),
 		Subject:       uuid.New(),
 		Enabled:       true,
-		GivenName:     gofakeit.FirstName(),
-		FamilyName:    gofakeit.LastName(),
+		GivenName:     fake.FirstName(),
+		FamilyName:    fake.LastName(),
 		OTPEnabled:    false,
 	}
 	err := database.CreateUser(nil, user)
@@ -643,7 +643,7 @@ func TestDeleteExpiredSessions(t *testing.T) {
 
 	// Create a test client
 	client := &models.Client{
-		ClientIdentifier:                        gofakeit.UUID(),
+		ClientIdentifier:                        fake.UUID(),
 		Description:                             "Test Client",
 		Enabled:                                 true,
 		ConsentRequired:                         true,
@@ -666,14 +666,14 @@ func TestDeleteExpiredSessions(t *testing.T) {
 
 	// Create a recent session (started 1 hour ago)
 	recentSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-1 * time.Hour),
 		LastAccessed:      now,
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-1 * time.Hour),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -697,14 +697,14 @@ func TestDeleteExpiredSessions(t *testing.T) {
 
 	// Create an old session (started 2 days ago)
 	oldSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-48 * time.Hour),
 		LastAccessed:      now,
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-48 * time.Hour),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -728,14 +728,14 @@ func TestDeleteExpiredSessions(t *testing.T) {
 
 	// Create a very old session (started 5 days ago)
 	veryOldSession := &models.UserSession{
-		SessionIdentifier: gofakeit.UUID(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now.Add(-120 * time.Hour),
 		LastAccessed:      now,
 		AuthMethods:       "pwd",
 		AcrLevel:          enums.AcrLevel1.String(),
 		AuthTime:          now.Add(-120 * time.Hour),
-		IpAddress:         gofakeit.IPv4Address(),
-		DeviceName:        gofakeit.Name(),
+		IpAddress:         fake.IPv4Address(),
+		DeviceName:        fake.Name(),
 		DeviceType:        "desktop",
 		DeviceOS:          "Windows",
 		UserId:            user.Id,
@@ -838,7 +838,7 @@ func TestUpdateUserSession_DoesNotClobberAuthStateGeneration(t *testing.T) {
 	// than passing silently.
 	userSession.OtpConfigGeneration = 5
 	userSession.Id = 0
-	userSession.SessionIdentifier = gofakeit.UUID()
+	userSession.SessionIdentifier = fake.UUID()
 	if err := database.CreateUserSession(nil, userSession); err != nil {
 		t.Fatalf("Failed to create user session with a generation: %v", err)
 	}
@@ -1080,7 +1080,7 @@ func TestUpdateUserSession_TheOwnerIsNotRewritten(t *testing.T) {
 	userSession := createTestUserSession(t, owner.Id)
 
 	userSession.UserId = other.Id
-	userSession.DeviceName = "moved-" + gofakeit.LetterN(6)
+	userSession.DeviceName = "moved-" + fake.LetterN(6)
 	err := database.UpdateUserSession(nil, userSession)
 	if err != nil {
 		t.Fatalf("Failed to update user session: %v", err)

--- a/src/authserver/tests/data/user_test.go
+++ b/src/authserver/tests/data/user_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateUser(t *testing.T) {
@@ -45,37 +45,37 @@ func TestUpdateUser(t *testing.T) {
 	// Update all fields
 	user.Enabled = !user.Enabled
 	user.Subject = uuid.New()
-	user.Username = "updated_" + gofakeit.Username()
-	user.GivenName = "Updated" + gofakeit.FirstName()
-	user.MiddleName = "Updated" + gofakeit.MiddleName()
-	user.FamilyName = "Updated" + gofakeit.LastName()
-	user.Nickname = "Updated" + gofakeit.FirstName()
-	user.Website = "https://updated" + gofakeit.DomainName()
+	user.Username = "updated_" + fake.Username()
+	user.GivenName = "Updated" + fake.FirstName()
+	user.MiddleName = "Updated" + fake.MiddleName()
+	user.FamilyName = "Updated" + fake.LastName()
+	user.Nickname = "Updated" + fake.FirstName()
+	user.Website = "https://updated" + strings.ToLower(fake.LetterN(8)) + ".example.com"
 	user.Gender = enums.GenderFemale.String()
-	user.Email = "updated_" + gofakeit.Email()
+	user.Email = "updated_" + fake.Email()
 	user.EmailVerified = !user.EmailVerified
-	user.EmailVerificationCodeEncrypted = []byte(gofakeit.Password(true, true, true, true, false, 32))
+	user.EmailVerificationCodeEncrypted = []byte(fake.Password(32))
 	user.EmailVerificationCodeIssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
-	user.ZoneInfoCountryName = gofakeit.Country()
-	user.ZoneInfo = gofakeit.TimeZone()
-	user.Locale = gofakeit.Language()
-	user.BirthDate = sql.NullTime{Time: gofakeit.Date().Truncate(time.Microsecond), Valid: true}
-	user.PhoneNumberCountryUniqueId = gofakeit.CountryAbr()
-	user.PhoneNumberCountryCallingCode = fmt.Sprintf("+%s", gofakeit.Numerify("##"))
-	user.PhoneNumber = gofakeit.Phone()
+	user.ZoneInfoCountryName = "Country" + fake.LetterN(6)
+	user.ZoneInfo = "tz" + fake.LetterN(6)
+	user.Locale = "lang" + fake.LetterN(4)
+	user.BirthDate = sql.NullTime{Time: fake.Date().Truncate(time.Microsecond), Valid: true}
+	user.PhoneNumberCountryUniqueId = strings.ToUpper(fake.LetterN(2))
+	user.PhoneNumberCountryCallingCode = fmt.Sprintf("+%s", fake.DigitN(2))
+	user.PhoneNumber = fake.DigitN(10)
 	user.PhoneNumberVerified = !user.PhoneNumberVerified
-	user.PhoneNumberVerificationCodeEncrypted = []byte(gofakeit.Password(true, true, true, true, false, 32))
+	user.PhoneNumberVerificationCodeEncrypted = []byte(fake.Password(32))
 	user.PhoneNumberVerificationCodeIssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
-	user.AddressLine1 = gofakeit.StreetName()
-	user.AddressLine2 = gofakeit.StreetNumber()
-	user.AddressLocality = gofakeit.City()
-	user.AddressRegion = gofakeit.State()
-	user.AddressPostalCode = gofakeit.Zip()
-	user.AddressCountry = gofakeit.CountryAbr()
-	user.PasswordHash = gofakeit.Password(true, true, true, true, false, 64)
-	user.OTPSecret = gofakeit.UUID()
+	user.AddressLine1 = "Street " + fake.LetterN(8)
+	user.AddressLine2 = fake.DigitN(3)
+	user.AddressLocality = "City" + fake.LetterN(6)
+	user.AddressRegion = "State" + fake.LetterN(6)
+	user.AddressPostalCode = fake.DigitN(5)
+	user.AddressCountry = strings.ToUpper(fake.LetterN(2))
+	user.PasswordHash = fake.Password(64)
+	user.OTPSecret = fake.UUID()
 	user.OTPEnabled = !user.OTPEnabled
-	user.ForgotPasswordCodeEncrypted = []byte(gofakeit.Password(true, true, true, true, false, 32))
+	user.ForgotPasswordCodeEncrypted = []byte(fake.Password(32))
 	user.ForgotPasswordCodeIssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
 
 	time.Sleep(timestampTick)
@@ -217,8 +217,8 @@ func TestSearchUsersPaginated(t *testing.T) {
 	t.Run("the search folds case on every engine", func(t *testing.T) {
 		// The tag begins "Tag", so it differs from both its own lowercase and its own uppercase
 		// form whatever LetterN returns, which is what makes the two folding queries real.
-		tag := "Tag" + gofakeit.LetterN(10)
-		want := createSearchUser(t, tag, "u"+gofakeit.LetterN(12))
+		tag := "Tag" + fake.LetterN(10)
+		want := createSearchUser(t, tag, "u"+fake.LetterN(12))
 
 		for _, c := range []struct {
 			name  string
@@ -241,11 +241,11 @@ func TestSearchUsersPaginated(t *testing.T) {
 	})
 
 	t.Run("a % in the term is matched literally", func(t *testing.T) {
-		tag := "Tag" + gofakeit.LetterN(10)
-		withPercent := createSearchUser(t, tag+"%x", "u"+gofakeit.LetterN(12))
+		tag := "Tag" + fake.LetterN(10)
+		withPercent := createSearchUser(t, tag+"%x", "u"+fake.LetterN(12))
 		// Differs from the row above in exactly one character, the one under test, so it can
 		// only be matched by reading "%" as a wildcard.
-		createSearchUser(t, tag+"zx", "u"+gofakeit.LetterN(12))
+		createSearchUser(t, tag+"zx", "u"+fake.LetterN(12))
 
 		assertSearchFindsExactly(t, tag+"%x", withPercent.Id)
 	})
@@ -253,9 +253,9 @@ func TestSearchUsersPaginated(t *testing.T) {
 	t.Run("a term of % stops matching every user", func(t *testing.T) {
 		// #95 as reported: the term is the wildcard itself, so the search returns the whole
 		// user table a page at a time.
-		tag := "Tag" + gofakeit.LetterN(10)
-		withPercent := createSearchUser(t, tag+"%x", "u"+gofakeit.LetterN(12))
-		plain := createSearchUser(t, tag+"plain", "u"+gofakeit.LetterN(12))
+		tag := "Tag" + fake.LetterN(10)
+		withPercent := createSearchUser(t, tag+"%x", "u"+fake.LetterN(12))
+		plain := createSearchUser(t, tag+"plain", "u"+fake.LetterN(12))
 
 		// Large enough that the whole result set fits on one page in a test database of any
 		// plausible size, and the guard below turns an overflow into this test's own failure
@@ -278,10 +278,10 @@ func TestSearchUsersPaginated(t *testing.T) {
 	})
 
 	t.Run("an _ in the term is matched literally", func(t *testing.T) {
-		tag := "Tag" + gofakeit.LetterN(10)
-		withUnderscore := createSearchUser(t, "g"+gofakeit.LetterN(12), tag+"a_b")
+		tag := "Tag" + fake.LetterN(10)
+		withUnderscore := createSearchUser(t, "g"+fake.LetterN(12), tag+"a_b")
 		// Again one character apart: "_" matches any single character until it is escaped.
-		createSearchUser(t, "g"+gofakeit.LetterN(12), tag+"axb")
+		createSearchUser(t, "g"+fake.LetterN(12), tag+"axb")
 
 		assertSearchFindsExactly(t, tag+"a_b", withUnderscore.Id)
 	})
@@ -290,8 +290,8 @@ func TestSearchUsersPaginated(t *testing.T) {
 		// "!" is the escape character the predicate declares, so the escaper has to double it.
 		// Undoubled, the pattern reads "!e" as an escaped "e" and finds a row spelled without
 		// the "!" instead of this one. An email local part may legally contain "!".
-		tag := "Tag" + gofakeit.LetterN(10)
-		withBang := createSearchUser(t, tag+"!e", "u"+gofakeit.LetterN(12))
+		tag := "Tag" + fake.LetterN(10)
+		withBang := createSearchUser(t, tag+"!e", "u"+fake.LetterN(12))
 
 		assertSearchFindsExactly(t, tag+"!e", withBang.Id)
 	})
@@ -301,9 +301,9 @@ func TestSearchUsersPaginated(t *testing.T) {
 		// class, so this case is only rejected there: unescaped, "[x]" matches a single "x" and
 		// finds the second row instead of the first. On the other three "[" is already a
 		// literal and both spellings pass, which is why the data tier has to run on all four.
-		tag := "Tag" + gofakeit.LetterN(10)
-		withClass := createSearchUser(t, tag+"[x]y", "u"+gofakeit.LetterN(12))
-		createSearchUser(t, tag+"xy", "u"+gofakeit.LetterN(12))
+		tag := "Tag" + fake.LetterN(10)
+		withClass := createSearchUser(t, tag+"[x]y", "u"+fake.LetterN(12))
+		createSearchUser(t, tag+"xy", "u"+fake.LetterN(12))
 
 		assertSearchFindsExactly(t, tag+"[x]y", withClass.Id)
 	})
@@ -318,7 +318,7 @@ func createSearchUser(t *testing.T, givenName string, username string) *models.U
 		Subject:   uuid.New(),
 		Username:  username,
 		GivenName: givenName,
-		Email:     gofakeit.LetterN(12) + "@example.com",
+		Email:     fake.LetterN(12) + "@example.com",
 	}
 	if err := database.CreateUser(nil, user); err != nil {
 		t.Fatalf("Failed to create user: %v", err)
@@ -364,7 +364,7 @@ func userIds(users []models.User) map[int64]bool {
 func TestSearchUsersPaginated_TiedGivenNamesStillPageAsAPartition(t *testing.T) {
 	// One given name shared by every user, which is the worst case: the entire result set is a
 	// single tie group. The random suffix is what keeps the search matching only these rows.
-	givenName := "TiedPage" + gofakeit.LetterN(10)
+	givenName := "TiedPage" + fake.LetterN(10)
 
 	const userCount = 7
 	wantIds := make([]int64, 0, userCount)
@@ -439,39 +439,39 @@ func createTestUser(t *testing.T) *models.User {
 
 func createTestUserOn(t *testing.T, db data.Database) *models.User {
 	user := &models.User{
-		Enabled:                              gofakeit.Bool(),
+		Enabled:                              fake.Bool(),
 		Subject:                              uuid.New(),
-		Username:                             gofakeit.Username(),
-		GivenName:                            gofakeit.FirstName(),
-		MiddleName:                           gofakeit.MiddleName(),
-		FamilyName:                           gofakeit.LastName(),
-		Nickname:                             gofakeit.FirstName(),
-		Website:                              gofakeit.URL(),
+		Username:                             fake.Username(),
+		GivenName:                            fake.FirstName(),
+		MiddleName:                           fake.MiddleName(),
+		FamilyName:                           fake.LastName(),
+		Nickname:                             fake.FirstName(),
+		Website:                              fake.URL(),
 		Gender:                               enums.GenderOther.String(),
-		Email:                                gofakeit.Email(),
-		EmailVerified:                        gofakeit.Bool(),
-		EmailVerificationCodeEncrypted:       []byte(gofakeit.Password(true, true, true, true, false, 32)),
+		Email:                                fake.Email(),
+		EmailVerified:                        fake.Bool(),
+		EmailVerificationCodeEncrypted:       []byte(fake.Password(32)),
 		EmailVerificationCodeIssuedAt:        sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
-		ZoneInfoCountryName:                  gofakeit.Country(),
-		ZoneInfo:                             gofakeit.TimeZone(),
-		Locale:                               gofakeit.Language(),
-		BirthDate:                            sql.NullTime{Time: gofakeit.Date().Truncate(time.Microsecond), Valid: true},
-		PhoneNumberCountryUniqueId:           gofakeit.CountryAbr(),
-		PhoneNumberCountryCallingCode:        fmt.Sprintf("+%s", gofakeit.Numerify("##")),
-		PhoneNumber:                          gofakeit.Phone(),
-		PhoneNumberVerified:                  gofakeit.Bool(),
-		PhoneNumberVerificationCodeEncrypted: []byte(gofakeit.Password(true, true, true, true, false, 32)),
+		ZoneInfoCountryName:                  "Country" + fake.LetterN(6),
+		ZoneInfo:                             "tz" + fake.LetterN(6),
+		Locale:                               "lang" + fake.LetterN(4),
+		BirthDate:                            sql.NullTime{Time: fake.Date().Truncate(time.Microsecond), Valid: true},
+		PhoneNumberCountryUniqueId:           strings.ToUpper(fake.LetterN(2)),
+		PhoneNumberCountryCallingCode:        fmt.Sprintf("+%s", fake.DigitN(2)),
+		PhoneNumber:                          fake.DigitN(10),
+		PhoneNumberVerified:                  fake.Bool(),
+		PhoneNumberVerificationCodeEncrypted: []byte(fake.Password(32)),
 		PhoneNumberVerificationCodeIssuedAt:  sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
-		AddressLine1:                         gofakeit.StreetName(),
-		AddressLine2:                         gofakeit.StreetNumber(),
-		AddressLocality:                      gofakeit.City(),
-		AddressRegion:                        gofakeit.State(),
-		AddressPostalCode:                    gofakeit.Zip(),
-		AddressCountry:                       gofakeit.CountryAbr(),
-		PasswordHash:                         gofakeit.Password(true, true, true, true, false, 64),
-		OTPSecret:                            gofakeit.UUID(),
-		OTPEnabled:                           gofakeit.Bool(),
-		ForgotPasswordCodeEncrypted:          []byte(gofakeit.Password(true, true, true, true, false, 32)),
+		AddressLine1:                         "Street " + fake.LetterN(8),
+		AddressLine2:                         fake.DigitN(3),
+		AddressLocality:                      "City" + fake.LetterN(6),
+		AddressRegion:                        "State" + fake.LetterN(6),
+		AddressPostalCode:                    fake.DigitN(5),
+		AddressCountry:                       strings.ToUpper(fake.LetterN(2)),
+		PasswordHash:                         fake.Password(64),
+		OTPSecret:                            fake.UUID(),
+		OTPEnabled:                           fake.Bool(),
+		ForgotPasswordCodeEncrypted:          []byte(fake.Password(32)),
 		ForgotPasswordCodeIssuedAt:           sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
 	}
 
@@ -609,8 +609,8 @@ func TestUpdateUser_DoesNotClobberAuthStateGeneration(t *testing.T) {
 	// not do, so the nonzero value has to arrive through an insert.
 	user.Id = 0
 	user.Subject = uuid.New()
-	user.Username = "gen_" + gofakeit.LetterN(8)
-	user.Email = gofakeit.LetterN(8) + "@example.com"
+	user.Username = "gen_" + fake.LetterN(8)
+	user.Email = fake.LetterN(8) + "@example.com"
 	if err := database.CreateUser(nil, user); err != nil {
 		t.Fatalf("Failed to create user with a generation: %v", err)
 	}
@@ -1736,7 +1736,7 @@ func TestTryConsumeForgotPasswordCode_ConcurrentCallersProduceOneWinner(t *testi
 // editor or a tool that normalises the file would silently turn the NFD case into a
 // comparison of a string with itself, and the test would pass having stopped testing.
 func TestGetUserByEmailIsCaseSensitive(t *testing.T) {
-	random := strings.ToLower(gofakeit.LetterN(6))
+	random := strings.ToLower(fake.LetterN(6))
 	lower := "case_email_" + random + "@case.local"
 	upper := strings.ToUpper(lower)
 
@@ -1829,9 +1829,9 @@ func createUserWithEmail(t *testing.T, email string) *models.User {
 	user := &models.User{
 		Enabled:      true,
 		Subject:      uuid.New(),
-		Username:     "case_" + gofakeit.LetterN(10),
+		Username:     "case_" + fake.LetterN(10),
 		Email:        email,
-		PasswordHash: gofakeit.Password(true, true, true, true, false, 60),
+		PasswordHash: fake.Password(60),
 	}
 	if err := database.CreateUser(nil, user); err != nil {
 		t.Fatalf("Failed to create a user at %q, which every engine must now accept: %v", email, err)

--- a/src/authserver/tests/data/web_origin_test.go
+++ b/src/authserver/tests/data/web_origin_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestCreateWebOrigin(t *testing.T) {
@@ -213,7 +213,7 @@ func TestWebOriginExists(t *testing.T) {
 // mock-backed test can see that.
 func TestWebOriginExists_Transaction(t *testing.T) {
 	client := createTestClient(t)
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	origin := "https://" + random + ".tx.example.com"
 
 	tx := beginTx(t)
@@ -285,7 +285,7 @@ func webOriginExistsWithin(t *testing.T, tx *sql.Tx, origin string, within time.
 }
 
 func createTestWebOrigin(t *testing.T, clientId int64) *models.WebOrigin {
-	random := gofakeit.LetterN(6)
+	random := fake.LetterN(6)
 	webOrigin := &models.WebOrigin{
 		Origin:   "https://" + random + ".example.com",
 		ClientId: clientId,

--- a/src/authserver/tests/integration/account_register_test.go
+++ b/src/authserver/tests/integration/account_register_test.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,7 +130,7 @@ func TestSelfRegister_Post_SMTPDisabled_RendersSuccessPage(t *testing.T) {
 	httpClient := createHttpClient(t)
 	loadRegisterPage(t, httpClient)
 
-	email := gofakeit.Email()
+	email := fake.Email()
 	resp := postRegister(t, httpClient, email, "Password123!", "Password123!")
 	defer func() { _ = resp.Body.Close() }()
 
@@ -164,7 +164,7 @@ func TestSelfRegister_Post_SMTPEnabled_NoVerification_RendersSuccess(t *testing.
 	httpClient := createHttpClient(t)
 	loadRegisterPage(t, httpClient)
 
-	email := gofakeit.Email()
+	email := fake.Email()
 	resp := postRegister(t, httpClient, email, "Password123!", "Password123!")
 	defer func() { _ = resp.Body.Close() }()
 
@@ -189,7 +189,7 @@ func TestSelfRegister_Post_SMTPEnabled_NoVerification_RendersSuccess(t *testing.
 // form-urlencoded rules where '+' decodes to a space, so the pre-registration was never found
 // and these users could not register at all.
 func registerPlusAddress() string {
-	return "register+tag." + strings.ToLower(gofakeit.LetterN(10)) + "@example.com"
+	return "register+tag." + strings.ToLower(fake.LetterN(10)) + "@example.com"
 }
 
 var activationLinkPattern = regexp.MustCompile(`https?://[^"'<>\s]+/account/activate[^"'<>\s]*`)
@@ -414,7 +414,7 @@ func TestSelfRegister_Post_Disabled_ReturnsError(t *testing.T) {
 
 	setRegSettings(t, false, false, false)
 
-	resp := postRegister(t, httpClient, gofakeit.Email(), "Password123!", "Password123!")
+	resp := postRegister(t, httpClient, fake.Email(), "Password123!", "Password123!")
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
@@ -428,7 +428,7 @@ func TestSelfRegister_Post_DuplicateEmail(t *testing.T) {
 	existing := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: "irrelevant",
 	}
 	err := database.CreateUser(nil, existing)
@@ -453,7 +453,7 @@ func TestSelfRegister_Post_DuplicatePreRegistration(t *testing.T) {
 	httpClient := createHttpClient(t)
 	loadRegisterPage(t, httpClient)
 
-	email := gofakeit.Email()
+	email := fake.Email()
 	resp1 := postRegister(t, httpClient, email, "Password123!", "Password123!")
 	_ = resp1.Body.Close()
 	assert.Equal(t, http.StatusOK, resp1.StatusCode)
@@ -480,7 +480,7 @@ func TestSelfRegister_Post_PasswordMismatch(t *testing.T) {
 	httpClient := createHttpClient(t)
 	loadRegisterPage(t, httpClient)
 
-	email := gofakeit.Email()
+	email := fake.Email()
 	resp := postRegister(t, httpClient, email, "Password123!", "Different456!")
 	defer func() { _ = resp.Body.Close() }()
 

--- a/src/authserver/tests/integration/api_account_email_test.go
+++ b/src/authserver/tests/integration/api_account_email_test.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +25,7 @@ func TestAPIAccountEmailPut_Success(t *testing.T) {
 	accessToken, u := getUserAccessTokenWithAccountScope_Email(t)
 
 	// New random email (<= 60 chars total)
-	local := strings.ToLower(gofakeit.LetterN(8))
+	local := strings.ToLower(fake.LetterN(8))
 	newEmail := local + "@example.com"
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/account/email"
@@ -90,7 +90,7 @@ func TestAPIAccountEmailPut_EmailAlreadyExists(t *testing.T) {
 	accessToken, _ := getUserAccessTokenWithAccountScope_Email(t)
 
 	// Create another user with a known email
-	otherEmail := "existing_" + strings.ToLower(gofakeit.LetterN(6)) + "@example.com"
+	otherEmail := "existing_" + strings.ToLower(fake.LetterN(6)) + "@example.com"
 	otherUser := &models.User{Email: otherEmail, Enabled: true, Subject: uuid.New()}
 	err := database.CreateUser(nil, otherUser)
 	assert.NoError(t, err)

--- a/src/authserver/tests/integration/api_account_logout_request_test.go
+++ b/src/authserver/tests/integration/api_account_logout_request_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +24,7 @@ import (
 // Returns (httpClientWithCookies, accessToken, code)
 func getUserAccessTokenAndCodeForAccountScope(t *testing.T) (*http.Client, string, *models.Code) {
 	scope := "openid profile email " + constants.AuthServerResourceIdentifier + ":" + constants.ManageAccountPermissionIdentifier
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeEnsuringUserScope(t, clientSecret, scope)
 
 	// Exchange code for tokens using the same client to preserve cookies for session
@@ -51,7 +51,7 @@ func TestAPIAccountLogoutRequest_Success_And_LogoutFlow_WithAndWithoutCookie(t *
 	// Request logout URL
 	reqBody := api.AccountLogoutRequest{
 		PostLogoutRedirectUri: code.RedirectURI,
-		State:                 gofakeit.LetterN(12),
+		State:                 fake.LetterN(12),
 		ResponseMode:          "redirect",
 	}
 	urlLogoutReq := config.GetAuthServer().BaseURL + "/api/v1/account/logout-request"
@@ -159,7 +159,7 @@ func TestLogout_RejectedHint_AsksTheEndUserAndRefusesTheRedirect(t *testing.T) {
 		"id_token_hint":            {"not.a.token"},
 		"post_logout_redirect_uri": {grant.redirectURI},
 		"client_id":                {grant.client.ClientIdentifier},
-		"state":                    {gofakeit.LetterN(8)},
+		"state":                    {fake.LetterN(8)},
 	})
 	defer func() { _ = resp.Body.Close() }()
 
@@ -193,7 +193,7 @@ func TestLogout_RejectedHint_AsksTheEndUserAndRefusesTheRedirect(t *testing.T) {
 func logoutWithHint(t *testing.T, grant *offlineGrant, idToken string) {
 	t.Helper()
 
-	state := gofakeit.LetterN(10)
+	state := fake.LetterN(10)
 	logoutURL := config.GetAuthServer().BaseURL + "/auth/logout?id_token_hint=" + url.QueryEscape(idToken) +
 		"&post_logout_redirect_uri=" + url.QueryEscape(grant.redirectURI) +
 		"&state=" + state
@@ -268,7 +268,7 @@ func TestLogout_WithIdTokenHint_OtherClientOnSession_KeepsSessionBoundTokensWork
 	// session listings. What handleExistingSessionOnLogout reads is the NUMBER of clients on the
 	// session, not how each got there.
 	otherClient := &models.Client{
-		ClientIdentifier:         "logout-other-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "logout-other-" + fake.LetterN(8),
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Second client sharing the session",
 		Enabled:                  true,
@@ -955,7 +955,7 @@ func TestLogout_Hintless_UnregisteredTargetIsDeclinedButTheLogoutHappens(t *test
 	resp := logoutThroughConsentPage(t, grant.httpClient, url.Values{
 		"post_logout_redirect_uri": {"https://example.com/not-registered"},
 		"client_id":                {grant.client.ClientIdentifier},
-		"state":                    {gofakeit.LetterN(8)},
+		"state":                    {fake.LetterN(8)},
 	})
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1071,7 +1071,7 @@ func followSeeOther(t *testing.T, httpClient *http.Client, resp *http.Response) 
 func TestLogout_CrossOriginPost_WithHintInTheBody_LogsTheUserOut(t *testing.T) {
 	grant := createOfflineGrant(t)
 	idToken, _ := sessionBoundGrantOnSameSession(t, grant)
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 
 	before, err := database.GetUserSessionBySessionIdentifier(nil, grant.sessionIdentifier)
 	require.NoError(t, err)
@@ -1163,7 +1163,7 @@ func TestLogout_CrossOriginPost_WithoutHint_IsRefused(t *testing.T) {
 	resp := crossOriginLogoutPost(t, grant.httpClient, url.Values{
 		"post_logout_redirect_uri": {grant.redirectURI},
 		"client_id":                {grant.client.ClientIdentifier},
-		"state":                    {gofakeit.LetterN(8)},
+		"state":                    {fake.LetterN(8)},
 	})
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1204,7 +1204,7 @@ func TestLogout_CrossOriginPost_WithoutHint_IsRefused(t *testing.T) {
 // exists to avoid, and because it feeds input already judged unusable back into the next request.
 func TestLogout_CrossOriginPost_RejectedHint_ReachesASubmittableConsentPage(t *testing.T) {
 	grant := createOfflineGrant(t)
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 
 	// A registered URI and a real client_id, so the redirect below is refused because the hint was
 	// rejected and not because the target failed validation. Without the hint these same parameters

--- a/src/authserver/tests/integration/api_account_profile_test.go
+++ b/src/authserver/tests/integration/api_account_profile_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,7 +72,7 @@ func TestAPIAccountProfilePut_Success(t *testing.T) {
 	accessToken, _ := getUserAccessTokenWithAccountScope(t)
 
 	// Use a random username to avoid uniqueness collisions across runs
-	randUsername := "u" + strings.ToLower(gofakeit.LetterN(7))
+	randUsername := "u" + strings.ToLower(fake.LetterN(7))
 	reqBody := api.UpdateUserProfileRequest{
 		Username:            randUsername,
 		GivenName:           "First",

--- a/src/authserver/tests/integration/api_audit_logs_test.go
+++ b/src/authserver/tests/integration/api_audit_logs_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +31,7 @@ const auditLogsURL = "/api/v1/admin/audit-logs"
 // deterministic.
 func seedAuditLogs(t *testing.T, count int) string {
 	t.Helper()
-	auditEvent := "test_audit_event_" + gofakeit.LetterN(10)
+	auditEvent := "test_audit_event_" + fake.LetterN(10)
 	base := time.Now().UTC().Add(-time.Duration(count) * time.Second)
 
 	for i := 0; i < count; i++ {
@@ -224,7 +224,7 @@ func TestAPIAuditLogsGet_EventFilter(t *testing.T) {
 	})
 
 	t.Run("an unmatched event yields nothing", func(t *testing.T) {
-		body, resp := getAuditLogs(t, accessToken, "auditEvent=no_such_event_"+gofakeit.LetterN(8))
+		body, resp := getAuditLogs(t, accessToken, "auditEvent=no_such_event_"+fake.LetterN(8))
 		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/src/authserver/tests/integration/api_client_logo_test.go
+++ b/src/authserver/tests/integration/api_client_logo_test.go
@@ -11,17 +11,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 // createTestClientForLogo creates a client for logo tests
 func createTestClientForLogo(t *testing.T) *models.Client {
 	t.Helper()
-	ident := "test-logo-" + strings.ToLower(gofakeit.LetterN(10))
+	ident := "test-logo-" + strings.ToLower(fake.LetterN(10))
 	client := &models.Client{
 		ClientIdentifier: ident,
 		Description:      "Test client for logo tests",

--- a/src/authserver/tests/integration/api_client_permissions_test.go
+++ b/src/authserver/tests/integration/api_client_permissions_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +23,7 @@ func TestAPIClientPermissions_Get_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create client
-	client := &models.Client{ClientIdentifier: "api-perm-get-" + gofakeit.LetterN(6), Enabled: true, IsPublic: true}
+	client := &models.Client{ClientIdentifier: "api-perm-get-" + fake.LetterN(6), Enabled: true, IsPublic: true}
 	err := database.CreateClient(nil, client)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
@@ -84,12 +84,12 @@ func TestAPIClientPermissions_Put_AddRemove(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create confidential client with client-credentials enabled
-	secret := gofakeit.Password(true, true, true, true, false, 32)
+	secret := fake.Password(32)
 	enc, err := encryption.EncryptData(secret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "api-perm-put-" + strings.ToLower(gofakeit.LetterN(6)),
+		ClientIdentifier:         "api-perm-put-" + strings.ToLower(fake.LetterN(6)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -138,11 +138,11 @@ func TestAPIClientPermissions_Put_Idempotent(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create confidential client with client-credentials enabled
-	secret := gofakeit.Password(true, true, true, true, false, 32)
+	secret := fake.Password(32)
 	enc, err := encryption.EncryptData(secret)
 	assert.NoError(t, err)
 
-	client := &models.Client{ClientIdentifier: "api-perm-put-same-" + strings.ToLower(gofakeit.LetterN(6)), Enabled: true, ClientCredentialsEnabled: true, IsPublic: false, ClientSecretEncrypted: enc}
+	client := &models.Client{ClientIdentifier: "api-perm-put-same-" + strings.ToLower(fake.LetterN(6)), Enabled: true, ClientCredentialsEnabled: true, IsPublic: false, ClientSecretEncrypted: enc}
 	err = database.CreateClient(nil, client)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
@@ -178,7 +178,7 @@ func TestAPIClientPermissions_Put_Idempotent(t *testing.T) {
 // Test GET and PUT unauthorized (no access token)
 func TestAPIClientPermissions_Unauthorized(t *testing.T) {
 	// Create a target client
-	client := &models.Client{ClientIdentifier: "api-perm-unauth-" + gofakeit.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
+	client := &models.Client{ClientIdentifier: "api-perm-unauth-" + fake.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
 	err := database.CreateClient(nil, client)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
@@ -214,7 +214,7 @@ func TestAPIClientPermissions_Put_ClientCredentialsDisabled(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "api-perm-put-nocc-" + gofakeit.LetterN(6),
+		ClientIdentifier:         "api-perm-put-nocc-" + fake.LetterN(6),
 		Enabled:                  true,
 		ClientCredentialsEnabled: false,
 		IsPublic:                 true,
@@ -326,7 +326,7 @@ func TestAPIClientPermissions_Put_PermissionNotFound(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create client with client-credentials enabled
-	client := &models.Client{ClientIdentifier: "api-perm-put-noperm-" + gofakeit.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
+	client := &models.Client{ClientIdentifier: "api-perm-put-noperm-" + fake.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
 	err := database.CreateClient(nil, client)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
@@ -348,11 +348,11 @@ func TestAPIClientPermissions_Put_InsufficientScope(t *testing.T) {
 	httpClient := createHttpClient(t)
 
 	// Create confidential client and grant userinfo
-	secret := gofakeit.Password(true, true, true, true, false, 32)
+	secret := fake.Password(32)
 	enc, err := encryption.EncryptData(secret)
 	assert.NoError(t, err)
 
-	client := &models.Client{ClientIdentifier: "api-perm-put-scope-" + strings.ToLower(gofakeit.LetterN(6)), Enabled: true, ClientCredentialsEnabled: true, IsPublic: false, ClientSecretEncrypted: enc}
+	client := &models.Client{ClientIdentifier: "api-perm-put-scope-" + strings.ToLower(fake.LetterN(6)), Enabled: true, ClientCredentialsEnabled: true, IsPublic: false, ClientSecretEncrypted: enc}
 	err = database.CreateClient(nil, client)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
@@ -386,7 +386,7 @@ func TestAPIClientPermissions_Put_InsufficientScope(t *testing.T) {
 	assert.NotEmpty(t, tok)
 
 	// Create target client to update
-	target := &models.Client{ClientIdentifier: "api-perm-put-target-" + gofakeit.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
+	target := &models.Client{ClientIdentifier: "api-perm-put-target-" + fake.LetterN(6), Enabled: true, ClientCredentialsEnabled: true, IsPublic: true}
 	err = database.CreateClient(nil, target)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, target.Id) }()

--- a/src/authserver/tests/integration/api_clients_authentication_update_test.go
+++ b/src/authserver/tests/integration/api_clients_authentication_update_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestAPIClientAuthenticationPut_ConfidentialToPublic_Success(t *testing.T) {
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 	client := &models.Client{
-		ClientIdentifier:      "auth-client-" + strings.ToLower(gofakeit.LetterN(10)),
+		ClientIdentifier:      "auth-client-" + strings.ToLower(fake.LetterN(10)),
 		Enabled:               true,
 		ConsentRequired:       false,
 		IsPublic:              false,
@@ -195,7 +195,7 @@ func TestAPIClientAuthenticationPut_InsufficientScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "inscope-auth-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "inscope-auth-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -250,7 +250,7 @@ func TestAPIClientAuthenticationPut_InsufficientScope(t *testing.T) {
 func createPublicClient(t *testing.T) *models.Client {
 	t.Helper()
 	client := &models.Client{
-		ClientIdentifier:         "pub-client-" + strings.ToLower(gofakeit.LetterN(10)),
+		ClientIdentifier:         "pub-client-" + strings.ToLower(fake.LetterN(10)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,

--- a/src/authserver/tests/integration/api_clients_create_test.go
+++ b/src/authserver/tests/integration/api_clients_create_test.go
@@ -8,19 +8,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIClientCreate_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		Description:              "  Test client  ",
@@ -130,7 +130,7 @@ func TestAPIClientCreate_Validation(t *testing.T) {
 func TestAPIClientCreate_Duplicate(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/clients"
 
 	first := api.CreateClientRequest{ClientIdentifier: ident, Description: "first"}
@@ -168,12 +168,12 @@ func TestAPIClientCreate_InsufficientScope(t *testing.T) {
 	// Create a client with a different permission (auth-server:userinfo) and request a token for that scope
 	// Then call the admin endpoint and expect 403
 	// Setup client
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "inscope-client-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "inscope-client-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -214,7 +214,7 @@ func TestAPIClientCreate_InsufficientScope(t *testing.T) {
 
 	// Attempt to create client with token lacking required scope
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/clients"
-	reqBody := api.CreateClientRequest{ClientIdentifier: "noadmin-" + strings.ToLower(gofakeit.LetterN(8)), Description: "x"}
+	reqBody := api.CreateClientRequest{ClientIdentifier: "noadmin-" + strings.ToLower(fake.LetterN(8)), Description: "x"}
 	resp := makeAPIRequest(t, "POST", url, accessToken, reqBody)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -223,7 +223,7 @@ func TestAPIClientCreate_InsufficientScope(t *testing.T) {
 func TestAPIClientCreate_WithDisplayName(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		DisplayName:              "My App",
@@ -247,7 +247,7 @@ func TestAPIClientCreate_WithDisplayName(t *testing.T) {
 func TestAPIClientCreate_EmptyDisplayName(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		DisplayName:              "",
@@ -271,7 +271,7 @@ func TestAPIClientCreate_EmptyDisplayName(t *testing.T) {
 func TestAPIClientCreate_DisplayNameTooLong(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		DisplayName:              strings.Repeat("a", 101),
@@ -293,7 +293,7 @@ func TestAPIClientCreate_DisplayNameTooLong(t *testing.T) {
 func TestAPIClientCreate_DisplayNameTrimmed(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		DisplayName:              "  My App  ",
@@ -317,7 +317,7 @@ func TestAPIClientCreate_DisplayNameTrimmed(t *testing.T) {
 func TestAPIClientCreate_DisplayNameSanitizedToEmpty(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		DisplayName:              "<script>alert(1)</script>",
@@ -341,7 +341,7 @@ func TestAPIClientCreate_DisplayNameSanitizedToEmpty(t *testing.T) {
 func TestAPIClientCreate_DescriptionOnlyBackwardCompat(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		Description:              "some desc",
@@ -365,7 +365,7 @@ func TestAPIClientCreate_DescriptionOnlyBackwardCompat(t *testing.T) {
 func TestAPIClientCreate_BothDescriptionAndDisplayName(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	ident := "client-" + strings.ToLower(gofakeit.LetterN(8))
+	ident := "client-" + strings.ToLower(fake.LetterN(8))
 	reqBody := api.CreateClientRequest{
 		ClientIdentifier:         ident,
 		Description:              "some desc",

--- a/src/authserver/tests/integration/api_clients_delete_test.go
+++ b/src/authserver/tests/integration/api_clients_delete_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +24,7 @@ func TestAPIClientDelete_Success(t *testing.T) {
 
 	// Create a client directly in DB to delete
 	client := &models.Client{
-		ClientIdentifier: "del-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "del-client-" + fake.LetterN(8),
 		Description:      "to delete",
 		Enabled:          true,
 		IsPublic:         true,
@@ -118,7 +118,7 @@ func TestAPIClientGetPermissions_IncludesPermissions(t *testing.T) {
 
 	// Create a client and assign a permission
 	client := &models.Client{
-		ClientIdentifier: "perm-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "perm-client-" + fake.LetterN(8),
 		Enabled:          true,
 		IsPublic:         true,
 	}
@@ -160,12 +160,12 @@ func TestAPIClientDelete_InsufficientScope(t *testing.T) {
 	var accessToken string
 	var clientWithScope *models.Client
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "inscope-client-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "inscope-client-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -209,7 +209,7 @@ func TestAPIClientDelete_InsufficientScope(t *testing.T) {
 
 	// Create a target client to attempt deleting
 	target := &models.Client{
-		ClientIdentifier: "target-del-" + gofakeit.LetterN(6),
+		ClientIdentifier: "target-del-" + fake.LetterN(6),
 		Enabled:          true,
 		IsPublic:         true,
 	}
@@ -229,7 +229,7 @@ func TestAPIClientDelete_CascadesLinkedData(t *testing.T) {
 
 	// Create client
 	client := &models.Client{
-		ClientIdentifier: "cascade-client-" + gofakeit.LetterN(6),
+		ClientIdentifier: "cascade-client-" + fake.LetterN(6),
 		Enabled:          true,
 		IsPublic:         true,
 	}
@@ -243,7 +243,7 @@ func TestAPIClientDelete_CascadesLinkedData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create user and consent to the client
-	user := &models.User{Subject: uuid.New(), Enabled: true, Email: gofakeit.Email()}
+	user := &models.User{Subject: uuid.New(), Enabled: true, Email: fake.Email()}
 	err = database.CreateUser(nil, user)
 	assert.NoError(t, err)
 	consent := &models.UserConsent{ClientId: client.Id, UserId: user.Id, Scope: "openid"}

--- a/src/authserver/tests/integration/api_clients_detail_secret_test.go
+++ b/src/authserver/tests/integration/api_clients_detail_secret_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,12 +33,12 @@ func TestAPIClientGet_ConfidentialIncludesSecretInDetailButNotList(t *testing.T)
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create confidential client with encrypted secret
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "secret-client-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "secret-client-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,

--- a/src/authserver/tests/integration/api_clients_flip_revocation_test.go
+++ b/src/authserver/tests/integration/api_clients_flip_revocation_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
@@ -16,6 +15,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +131,7 @@ func TestAPIClientAuthenticationPut_FlipToPublic_RevokesTheClientsGrants(t *test
 	requireDatabaseAuditLogs(t)
 	adminToken, _ := createAdminClientWithToken(t)
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 	defer func() { _ = database.DeleteClient(nil, code.ClientId) }()
 
@@ -188,18 +188,18 @@ func TestAPIClientAuthenticationPut_FlipToPublic_RevokesTheClientsGrants(t *test
 func TestAPIClientAuthenticationPut_FlipToPublic_LeavesTheUsersOtherClientAlone(t *testing.T) {
 	adminToken, _ := createAdminClientWithToken(t)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	require.NoError(t, database.CreateUser(nil, user))
 
-	flippedSecret := gofakeit.LetterN(32)
+	flippedSecret := fake.LetterN(32)
 	flippedClient, flippedCode := createAuthCode(t, flippedSecret, "openid profile email",
 		authCodeOptions{user: user, userPassword: password})
 	defer func() { _ = database.DeleteClient(nil, flippedCode.ClientId) }()
@@ -208,7 +208,7 @@ func TestAPIClientAuthenticationPut_FlipToPublic_LeavesTheUsersOtherClientAlone(
 	// decoration: two ceremonies for one user from the same device replace each other's session,
 	// so without this the first grant would be dead before the flip ever ran and the refusal
 	// below would prove nothing.
-	otherSecret := gofakeit.LetterN(32)
+	otherSecret := fake.LetterN(32)
 	otherClient, otherCode := createAuthCode(t, otherSecret, "openid profile email",
 		authCodeOptions{user: user, userPassword: password, userAgent: "goiabada-d2-second-device"})
 	defer func() { _ = database.DeleteClient(nil, otherCode.ClientId) }()
@@ -257,8 +257,8 @@ func TestAPIClientAuthenticationPut_FlipToPublic_RevokesROPCGrantsToo(t *testing
 		}
 	}()
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
 	user := createROPCUser(t, password)
@@ -292,7 +292,7 @@ func TestAPIClientAuthenticationPut_FlipToPublic_RevokesROPCGrantsToo(t *testing
 func TestAPIClientAuthenticationPut_FlipToConfidential_DoesNotRevoke(t *testing.T) {
 	adminToken, _ := createAdminClientWithToken(t)
 
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email",
 		authCodeOptions{isPublic: true})
 	defer func() { _ = database.DeleteClient(nil, code.ClientId) }()
 
@@ -314,7 +314,7 @@ func TestAPIClientAuthenticationPut_FlipToConfidential_DoesNotRevoke(t *testing.
 func TestAPIClientAuthenticationPut_RotatingAConfidentialSecret_DoesNotRevoke(t *testing.T) {
 	adminToken, _ := createAdminClientWithToken(t)
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 	defer func() { _ = database.DeleteClient(nil, code.ClientId) }()
 
@@ -337,7 +337,7 @@ func TestAPIClientAuthenticationPut_RotatingAConfidentialSecret_DoesNotRevoke(t 
 func TestAPIClientAuthenticationPut_SavingAnAlreadyPublicClient_DoesNotRevoke(t *testing.T) {
 	adminToken, _ := createAdminClientWithToken(t)
 
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email",
 		authCodeOptions{isPublic: true})
 	defer func() { _ = database.DeleteClient(nil, code.ClientId) }()
 
@@ -363,7 +363,7 @@ func TestAPIClientAuthenticationPut_FlipToPublic_SetsPKCERequired(t *testing.T) 
 	// been left alone.
 	pkceOptional := false
 	client := &models.Client{
-		ClientIdentifier:         "flip-pkce-" + strings.ToLower(gofakeit.LetterN(10)),
+		ClientIdentifier:         "flip-pkce-" + strings.ToLower(fake.LetterN(10)),
 		Enabled:                  true,
 		IsPublic:                 false,
 		AuthorizationCodeEnabled: true,

--- a/src/authserver/tests/integration/api_clients_oauth2_flows_update_test.go
+++ b/src/authserver/tests/integration/api_clients_oauth2_flows_update_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +25,7 @@ func TestAPIClientOAuth2FlowsPut_Success_PublicClient_ForcesNoClientCredentials(
 
 	// Create a public client
 	client := &models.Client{
-		ClientIdentifier:         "flows-public-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-public-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -68,7 +68,7 @@ func TestAPIClientOAuth2FlowsPut_Success_ConfidentialClient_ToggleBoth(t *testin
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 	client := &models.Client{
-		ClientIdentifier:         "flows-conf-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-conf-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 false,
@@ -167,7 +167,7 @@ func TestAPIClientOAuth2FlowsPut_InvalidRequestBodyAndUnauthorized(t *testing.T)
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "flows-invalid-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-invalid-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -213,7 +213,7 @@ func TestAPIClientOAuth2FlowsPut_InsufficientScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "flows-inscope-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-inscope-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -255,7 +255,7 @@ func TestAPIClientOAuth2FlowsPut_InsufficientScope(t *testing.T) {
 
 	// Create a target client to attempt updating
 	target := &models.Client{
-		ClientIdentifier:         "flows-target-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-target-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: false,
@@ -280,7 +280,7 @@ func TestAPIClientOAuth2FlowsPut_BothDisabledAllowed(t *testing.T) {
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 	client := &models.Client{
-		ClientIdentifier:         "flows-bothoff-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-bothoff-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 false,
@@ -319,7 +319,7 @@ func TestAPIClientOAuth2FlowsPut_ImplicitGrantEnabled_UseGlobalSetting(t *testin
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "flows-implicit-global-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-implicit-global-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,
@@ -354,7 +354,7 @@ func TestAPIClientOAuth2FlowsPut_ImplicitGrantEnabled_ExplicitEnable(t *testing.
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "flows-implicit-on-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-implicit-on-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,
@@ -393,7 +393,7 @@ func TestAPIClientOAuth2FlowsPut_ImplicitGrantEnabled_ExplicitDisable(t *testing
 	// Start with implicit explicitly enabled
 	implicitEnabled := true
 	client := &models.Client{
-		ClientIdentifier:         "flows-implicit-off-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-implicit-off-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,
@@ -435,7 +435,7 @@ func TestAPIClientOAuth2FlowsPut_PKCERequired_TriState(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "flows-pkce-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-pkce-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 false,
 		AuthorizationCodeEnabled: true,
@@ -507,7 +507,7 @@ func TestAPIClientOAuth2FlowsPut_PKCERequired_PublicClientIsAlwaysRequired(t *te
 
 	pkceOptional := false
 	client := &models.Client{
-		ClientIdentifier:         "flows-pub-pkce-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-pub-pkce-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,
@@ -558,7 +558,7 @@ func TestAPIClientOAuth2FlowsPut_ImplicitOnly_NoAuthCode(t *testing.T) {
 	// Create client with only implicit flow (no auth code)
 	implicitEnabled := true
 	client := &models.Client{
-		ClientIdentifier:         "flows-implicit-only-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "flows-implicit-only-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: false,
@@ -598,7 +598,7 @@ func TestAPIClientOAuth2FlowsPut_ROPCEnabled_UseGlobalSetting(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:                        "flows-ropc-global-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:                        "flows-ropc-global-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -633,7 +633,7 @@ func TestAPIClientOAuth2FlowsPut_ROPCEnabled_ExplicitEnable(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:                        "flows-ropc-on-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:                        "flows-ropc-on-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -672,7 +672,7 @@ func TestAPIClientOAuth2FlowsPut_ROPCEnabled_ExplicitDisable(t *testing.T) {
 	// Start with ROPC explicitly enabled
 	ropcEnabled := true
 	client := &models.Client{
-		ClientIdentifier:                        "flows-ropc-off-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:                        "flows-ropc-off-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -709,7 +709,7 @@ func TestAPIClientOAuth2FlowsPut_ROPCEnabled_TriState(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:                        "flows-ropc-tristate-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:                        "flows-ropc-tristate-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -771,7 +771,7 @@ func TestAPIClientOAuth2FlowsPut_ROPCOnly_NoOtherFlows(t *testing.T) {
 	// Create client with only ROPC flow (no auth code or client credentials)
 	ropcEnabled := true
 	client := &models.Client{
-		ClientIdentifier:                        "flows-ropc-only-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:                        "flows-ropc-only-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                false,

--- a/src/authserver/tests/integration/api_clients_redirect_uris_update_test.go
+++ b/src/authserver/tests/integration/api_clients_redirect_uris_update_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ func TestAPIClientRedirectURIsPut_Success_AddRemoveAndTrim(t *testing.T) {
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 	client := &models.Client{
-		ClientIdentifier:         "redir-succ-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-succ-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 false,
@@ -98,7 +98,7 @@ func TestAPIClientRedirectURIsPut_NoRedirectFlowRejected(t *testing.T) {
 
 	implicitDisabled := false
 	client := &models.Client{
-		ClientIdentifier:         "redir-disabled-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-disabled-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -133,7 +133,7 @@ func TestAPIClientRedirectURIsPut_ImplicitOnlyClientAllowed(t *testing.T) {
 
 	implicitEnabled := true
 	client := &models.Client{
-		ClientIdentifier:         "redir-implicit-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-implicit-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -199,7 +199,7 @@ func TestAPIClientRedirectURIsPut_DuplicateAndInvalidURLs(t *testing.T) {
 
 	// Auth code enabled client
 	client := &models.Client{
-		ClientIdentifier:         "redir-vali-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-vali-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -323,7 +323,7 @@ func TestAPIClientRedirectURIsPut_NotFound_InvalidId_InvalidBody_Unauthorized(t 
 
 	// Invalid body
 	client2 := &models.Client{
-		ClientIdentifier:         "redir-bad-body-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-bad-body-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -367,7 +367,7 @@ func TestAPIClientRedirectURIsPut_InsufficientScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "redir-inscope-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-inscope-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -409,7 +409,7 @@ func TestAPIClientRedirectURIsPut_InsufficientScope(t *testing.T) {
 
 	// Create a target client with auth code enabled
 	target := &models.Client{
-		ClientIdentifier:         "redir-target-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "redir-target-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,

--- a/src/authserver/tests/integration/api_clients_tokens_update_test.go
+++ b/src/authserver/tests/integration/api_clients_tokens_update_test.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -194,12 +194,12 @@ func TestAPIClientTokensPut_InvalidRequestBodyAndUnauthorized(t *testing.T) {
 
 func TestAPIClientTokensPut_InsufficientScope(t *testing.T) {
 	// Create a client with only auth-server:userinfo scope
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "inscope-client-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "inscope-client-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,

--- a/src/authserver/tests/integration/api_clients_update_test.go
+++ b/src/authserver/tests/integration/api_clients_update_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -513,12 +513,12 @@ func TestAPIClientUpdatePut_InvalidDefaultAcrLevelValue(t *testing.T) {
 
 func TestAPIClientUpdatePut_InsufficientScope(t *testing.T) {
 	// Create a token with only auth-server:userinfo scope
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "inscope-client-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "inscope-client-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -572,7 +572,7 @@ func TestAPIClientUpdatePut_InsufficientScope(t *testing.T) {
 // helper to create a client directly in DB
 func createTestClientUnique(t *testing.T, authCodeEnabled bool) *models.Client {
 	t.Helper()
-	ident := "test-client-" + strings.ToLower(gofakeit.LetterN(10))
+	ident := "test-client-" + strings.ToLower(fake.LetterN(10))
 	client := &models.Client{
 		ClientIdentifier:         ident,
 		Description:              "Test client",

--- a/src/authserver/tests/integration/api_clients_web_origins_update_test.go
+++ b/src/authserver/tests/integration/api_clients_web_origins_update_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ func TestAPIClientWebOriginsPut_Success_AddRemoveAndNormalize(t *testing.T) {
 	enc, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 	client := &models.Client{
-		ClientIdentifier:         "weborig-succ-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-succ-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 false,
@@ -100,7 +100,7 @@ func TestAPIClientWebOriginsPut_AuthCodeDisabledAccepted(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "weborig-noauthcode-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-noauthcode-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -111,7 +111,7 @@ func TestAPIClientWebOriginsPut_AuthCodeDisabledAccepted(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
 
-	origin := "https://spa-" + strings.ToLower(gofakeit.LetterN(8)) + ".example.com"
+	origin := "https://spa-" + strings.ToLower(fake.LetterN(8)) + ".example.com"
 	reqBody := api.UpdateClientWebOriginsRequest{WebOrigins: []string{origin}}
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/clients/" + strconv.FormatInt(client.Id, 10) + "/web-origins"
 	resp := makeAPIRequest(t, "PUT", url, accessToken, reqBody)
@@ -142,7 +142,7 @@ func TestAPIClientWebOriginsPut_StoresTheCanonicalOrigin(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	client := &models.Client{
-		ClientIdentifier:         "weborig-canon-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-canon-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -153,7 +153,7 @@ func TestAPIClientWebOriginsPut_StoresTheCanonicalOrigin(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, client.Id) }()
 
-	host := "canon-" + strings.ToLower(gofakeit.LetterN(8)) + ".example.com"
+	host := "canon-" + strings.ToLower(fake.LetterN(8)) + ".example.com"
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/clients/" + strconv.FormatInt(client.Id, 10) + "/web-origins"
 
 	testCases := []struct {
@@ -224,7 +224,7 @@ func TestAPIClientWebOriginsPut_ValidationErrors(t *testing.T) {
 
 	// Create a client with auth code enabled
 	client := &models.Client{
-		ClientIdentifier:         "weborig-valid-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-valid-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -314,7 +314,7 @@ func TestAPIClientWebOriginsPut_NotFound_InvalidId_InvalidBody_Unauthorized(t *t
 
 	// Invalid body
 	client2 := &models.Client{
-		ClientIdentifier:         "weborig-bad-body-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-bad-body-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ConsentRequired:          false,
 		IsPublic:                 true,
@@ -358,7 +358,7 @@ func TestAPIClientWebOriginsPut_InsufficientScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "weborig-inscope-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-inscope-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -400,7 +400,7 @@ func TestAPIClientWebOriginsPut_InsufficientScope(t *testing.T) {
 
 	// Create a target client with auth code enabled
 	target := &models.Client{
-		ClientIdentifier:         "weborig-target-" + strings.ToLower(gofakeit.LetterN(8)),
+		ClientIdentifier:         "weborig-target-" + strings.ToLower(fake.LetterN(8)),
 		Enabled:                  true,
 		IsPublic:                 true,
 		AuthorizationCodeEnabled: true,

--- a/src/authserver/tests/integration/api_granular_scopes_test.go
+++ b/src/authserver/tests/integration/api_granular_scopes_test.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 // createClientWithGranularScope creates a client with a specific granular permission scope
 // and returns an access token for that client
 func createClientWithGranularScope(t *testing.T, permissionIdentifier string) (string, *models.Client) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "granular-test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "granular-test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -89,7 +89,7 @@ func TestGranularScopes_AdminReadCanOnlyReadUserEndpoints(t *testing.T) {
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -119,7 +119,7 @@ func TestGranularScopes_AdminReadCanOnlyReadUserEndpoints(t *testing.T) {
 
 	// Test: Should NOT be able to create user (POST)
 	resp = makeAPIRequest(t, "POST", baseURL+"/api/v1/admin/users/create", accessToken, map[string]string{
-		"email": gofakeit.Email(),
+		"email": fake.Email(),
 	})
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "admin-read should NOT create user")
 	_ = resp.Body.Close()
@@ -141,7 +141,7 @@ func TestGranularScopes_AdminReadCanOnlyReadClientEndpoints(t *testing.T) {
 
 	// Create a test client for the tests
 	testClient := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          true,
 	}
 	err := database.CreateClient(nil, testClient)
@@ -171,7 +171,7 @@ func TestGranularScopes_AdminReadCanOnlyReadClientEndpoints(t *testing.T) {
 
 	// Test: Should NOT be able to create client (POST)
 	resp = makeAPIRequest(t, "POST", baseURL+"/api/v1/admin/clients", accessToken, map[string]string{
-		"clientIdentifier": "new-client-" + gofakeit.LetterN(8),
+		"clientIdentifier": "new-client-" + fake.LetterN(8),
 	})
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "admin-read should NOT create client")
 	_ = resp.Body.Close()
@@ -217,7 +217,7 @@ func TestGranularScopes_AdminReadCanOnlyReadSettingsEndpoints(t *testing.T) {
 
 	// Test: Should NOT be able to create resource (POST)
 	resp = makeAPIRequest(t, "POST", baseURL+"/api/v1/admin/resources", accessToken, map[string]string{
-		"resourceIdentifier": "new-resource-" + gofakeit.LetterN(8),
+		"resourceIdentifier": "new-resource-" + fake.LetterN(8),
 	})
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "admin-read should NOT create resource")
 	_ = resp.Body.Close()
@@ -236,7 +236,7 @@ func TestGranularScopes_ManageUsersCanAccessUserEndpointsOnly(t *testing.T) {
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -247,7 +247,7 @@ func TestGranularScopes_ManageUsersCanAccessUserEndpointsOnly(t *testing.T) {
 
 	// Create a test client
 	testClient := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          true,
 	}
 	err = database.CreateClient(nil, testClient)
@@ -295,7 +295,7 @@ func TestGranularScopes_ManageClientsCanAccessClientEndpointsOnly(t *testing.T) 
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -306,7 +306,7 @@ func TestGranularScopes_ManageClientsCanAccessClientEndpointsOnly(t *testing.T) 
 
 	// Create a test client
 	testClient := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          true,
 	}
 	err = database.CreateClient(nil, testClient)
@@ -354,7 +354,7 @@ func TestGranularScopes_ManageSettingsCanAccessSettingsEndpointsOnly(t *testing.
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -399,7 +399,7 @@ func TestGranularScopes_ManageCanAccessAllEndpoints(t *testing.T) {
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -410,7 +410,7 @@ func TestGranularScopes_ManageCanAccessAllEndpoints(t *testing.T) {
 
 	// Create a test client
 	testClient := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          true,
 	}
 	err = database.CreateClient(nil, testClient)
@@ -608,7 +608,7 @@ func TestGranularScopes_UserPermissionsRequireUsersScope(t *testing.T) {
 	testUser := &models.User{
 		Subject:   uuid.New(),
 		Enabled:   true,
-		Email:     gofakeit.Email(),
+		Email:     fake.Email(),
 		GivenName: "TestUser",
 	}
 	err := database.CreateUser(nil, testUser)
@@ -651,7 +651,7 @@ func TestGranularScopes_UserPermissionsRequireUsersScope(t *testing.T) {
 func TestGranularScopes_ClientPermissionsRequireClientsScope(t *testing.T) {
 	// Create a test client
 	testClient := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          true,
 	}
 	err := database.CreateClient(nil, testClient)
@@ -709,8 +709,8 @@ func TestGranularScopes_WriteOperationsRequireSpecificScopes(t *testing.T) {
 	// Test user creation
 	t.Run("user creation requires manage-users scope", func(t *testing.T) {
 		newUserPayload := map[string]interface{}{
-			"email":    gofakeit.Email(),
-			"password": gofakeit.Password(true, true, true, true, false, 12),
+			"email":    fake.Email(),
+			"password": fake.Password(12),
 		}
 
 		// admin-read should fail
@@ -737,7 +737,7 @@ func TestGranularScopes_WriteOperationsRequireSpecificScopes(t *testing.T) {
 	// Test group creation
 	t.Run("group creation requires manage-users scope", func(t *testing.T) {
 		newGroupPayload := map[string]interface{}{
-			"groupIdentifier": "test-group-" + gofakeit.LetterN(8),
+			"groupIdentifier": "test-group-" + fake.LetterN(8),
 			"description":     "Test group",
 		}
 

--- a/src/authserver/tests/integration/api_groups_create_test.go
+++ b/src/authserver/tests/integration/api_groups_create_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +18,7 @@ func TestHandleAPIGroupCreatePost_Success(t *testing.T) {
 
 	// Create request data
 	reqData := map[string]interface{}{
-		"groupIdentifier":      "test-group-" + gofakeit.LetterN(6),
+		"groupIdentifier":      "test-group-" + fake.LetterN(6),
 		"description":          "Test Group Description",
 		"includeInIdToken":     true,
 		"includeInAccessToken": false,
@@ -142,7 +142,7 @@ func TestHandleAPIGroupCreatePost_DuplicateGroupIdentifier(t *testing.T) {
 
 	// Create a group first
 	existingGroup := &models.Group{
-		GroupIdentifier:      "existing-group-" + gofakeit.LetterN(6),
+		GroupIdentifier:      "existing-group-" + fake.LetterN(6),
 		Description:          "Existing Group",
 		IncludeInIdToken:     true,
 		IncludeInAccessToken: false,
@@ -180,7 +180,7 @@ func TestHandleAPIGroupCreatePost_InputSanitization(t *testing.T) {
 
 	// Create request data with potentially malicious input in description
 	reqData := map[string]interface{}{
-		"groupIdentifier":      "test-group-" + gofakeit.LetterN(6), // Valid identifier (no spaces) to pass validation
+		"groupIdentifier":      "test-group-" + fake.LetterN(6), // Valid identifier (no spaces) to pass validation
 		"description":          "  <script>alert('xss')</script>Test Description  ",
 		"includeInIdToken":     true,
 		"includeInAccessToken": false,

--- a/src/authserver/tests/integration/api_groups_search_annotated_test.go
+++ b/src/authserver/tests/integration/api_groups_search_annotated_test.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -105,7 +105,7 @@ func TestAPIGroupsSearch_PermissionNotFound(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Use a random large ID that should not exist
-	missingId := int64(gofakeit.Number(9_000_000, 9_999_999))
+	missingId := int64(fake.Number(9_000_000, 9_999_999))
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/groups/search?annotatePermissionId=" + strconv.FormatInt(missingId, 10)
 	resp := makeAPIRequest(t, "GET", url, accessToken, nil)
 	defer func() { _ = resp.Body.Close() }()

--- a/src/authserver/tests/integration/api_groups_update_test.go
+++ b/src/authserver/tests/integration/api_groups_update_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ func TestAPIGroupUpdatePut_Success(t *testing.T) {
 
 	// Test: Update group
 	updateReq := api.UpdateGroupRequest{
-		GroupIdentifier:      "updated-group-" + gofakeit.LetterN(6),
+		GroupIdentifier:      "updated-group-" + fake.LetterN(6),
 		Description:          "Updated group description",
 		IncludeInIdToken:     false,
 		IncludeInAccessToken: true,
@@ -288,7 +288,7 @@ func TestAPIGroupUpdatePut_WhitespaceHandling(t *testing.T) {
 
 	// Test: Update with whitespace that should fail validation
 	updateReq := api.UpdateGroupRequest{
-		GroupIdentifier:      "  whitespace-identifier-" + gofakeit.LetterN(4) + "  ",
+		GroupIdentifier:      "  whitespace-identifier-" + fake.LetterN(4) + "  ",
 		Description:          "  Whitespace description  ",
 		IncludeInIdToken:     true,
 		IncludeInAccessToken: false,
@@ -325,7 +325,7 @@ func TestAPIGroupUpdatePut_BooleanFlags(t *testing.T) {
 
 	// Setup: Create test group with specific initial values
 	testGroup := &models.Group{
-		GroupIdentifier:      "test-bool-group-" + gofakeit.LetterN(8),
+		GroupIdentifier:      "test-bool-group-" + fake.LetterN(8),
 		Description:          "Test boolean flags",
 		IncludeInIdToken:     false,
 		IncludeInAccessToken: false,

--- a/src/authserver/tests/integration/api_permission_users_test.go
+++ b/src/authserver/tests/integration/api_permission_users_test.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +23,7 @@ func TestAPIPermissionUsersGet_Success(t *testing.T) {
 	perm := createPermission(t, res.Id)
 
 	// Create three users; assign permission to two
-	randSuffix := gofakeit.LetterN(6)
+	randSuffix := fake.LetterN(6)
 	u1 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser1-" + randSuffix, Email: "permuser1-" + randSuffix + "@test.com", GivenName: "U1", FamilyName: "T"}
 	u2 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser2-" + randSuffix, Email: "permuser2-" + randSuffix + "@test.com", GivenName: "U2", FamilyName: "T"}
 	u3 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser3-" + randSuffix, Email: "permuser3-" + randSuffix + "@test.com", GivenName: "U3", FamilyName: "T"}
@@ -82,7 +82,7 @@ func TestAPIPermissionUsersGet_InvalidPermissionId(t *testing.T) {
 
 func TestAPIPermissionUsersGet_PermissionNotFound(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
-	missingId := int64(gofakeit.Number(7_000_000, 7_999_999))
+	missingId := int64(fake.Number(7_000_000, 7_999_999))
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/permissions/" + strconv.FormatInt(missingId, 10) + "/users"
 	resp := makeAPIRequest(t, "GET", url, accessToken, nil)
 	defer func() { _ = resp.Body.Close() }()

--- a/src/authserver/tests/integration/api_profile_picture_test.go
+++ b/src/authserver/tests/integration/api_profile_picture_test.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,14 +63,14 @@ func makeMultipartRequest(t *testing.T, method, url, accessToken, fieldName stri
 
 // createTestUserForProfilePicture creates a user for profile picture tests
 func createTestUserForProfilePicture(t *testing.T) *models.User {
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 

--- a/src/authserver/tests/integration/api_resource_permissions_update_test.go
+++ b/src/authserver/tests/integration/api_resource_permissions_update_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +19,7 @@ func TestAPIResourcePermissionsPut_Success_CreateUpdateDelete(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create resource
-	resource := createTestResource(t, "perm-put-res-"+gofakeit.LetterN(6), "Perms Test")
+	resource := createTestResource(t, "perm-put-res-"+fake.LetterN(6), "Perms Test")
 	defer func() { _ = database.DeleteResource(nil, resource.Id) }()
 
 	// Seed existing permissions
@@ -74,7 +74,7 @@ func TestAPIResourcePermissionsPut_Success_CreateUpdateDelete(t *testing.T) {
 func TestAPIResourcePermissionsPut_ValidationErrors(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	resource := createTestResource(t, "perm-put-val-"+gofakeit.LetterN(6), "Val Test")
+	resource := createTestResource(t, "perm-put-val-"+fake.LetterN(6), "Val Test")
 	defer func() { _ = database.DeleteResource(nil, resource.Id) }()
 
 	baseURL := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(resource.Id, 10) + "/permissions"
@@ -108,7 +108,7 @@ func TestAPIResourcePermissionsPut_ValidationErrors(t *testing.T) {
 func TestAPIResourcePermissionsPut_UpdateConflict(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	resource := createTestResource(t, "perm-put-conf-"+gofakeit.LetterN(6), "Conf Test")
+	resource := createTestResource(t, "perm-put-conf-"+fake.LetterN(6), "Conf Test")
 	defer func() { _ = database.DeleteResource(nil, resource.Id) }()
 
 	p1 := createTestPermission(t, resource.Id, "aaa", "A")
@@ -155,7 +155,7 @@ func TestAPIResourcePermissionsPut_SystemResourceAddPermissionAllowed(t *testing
 		})
 	}
 	// Add a new permission
-	newPermIdentifier := "test-new-perm-" + gofakeit.LetterN(6)
+	newPermIdentifier := "test-new-perm-" + fake.LetterN(6)
 	permUpserts = append(permUpserts, api.ResourcePermissionUpsert{
 		Id:                   0, // New permission
 		PermissionIdentifier: newPermIdentifier,
@@ -458,7 +458,7 @@ func TestAPIResourcePermissionsPut_DuplicateIdRejected(t *testing.T) {
 func TestAPIResourcePermissionsPut_DuplicateIdNonSystemRejected(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	resource := createTestResource(t, "perm-put-dupid-"+gofakeit.LetterN(6), "DupId Test")
+	resource := createTestResource(t, "perm-put-dupid-"+fake.LetterN(6), "DupId Test")
 	defer func() { _ = database.DeleteResource(nil, resource.Id) }()
 
 	p1 := createTestPermission(t, resource.Id, "read", "Read")
@@ -482,7 +482,7 @@ func TestAPIResourcePermissionsPut_DuplicateIdNonSystemRejected(t *testing.T) {
 // Test unauthorized and invalid token
 func TestAPIResourcePermissionsPut_Unauthorized(t *testing.T) {
 	// Create a resource
-	res := createTestResource(t, "perm-put-unauth-"+gofakeit.LetterN(6), "Unauth Test")
+	res := createTestResource(t, "perm-put-unauth-"+fake.LetterN(6), "Unauth Test")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10) + "/permissions"

--- a/src/authserver/tests/integration/api_resources_create_test.go
+++ b/src/authserver/tests/integration/api_resources_create_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +18,7 @@ import (
 func TestAPIResourcesCreate_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	identifier := "api-test-create-resource-" + gofakeit.LetterN(8)
+	identifier := "api-test-create-resource-" + fake.LetterN(8)
 	reqBody := api.CreateResourceRequest{
 		ResourceIdentifier: identifier,
 		Description:        "  Created via API  ",
@@ -101,7 +101,7 @@ func TestAPIResourcesCreate_DuplicateIdentifier(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Pre-create a resource
-	identifier := "api-test-dup-resource-" + gofakeit.LetterN(8)
+	identifier := "api-test-dup-resource-" + fake.LetterN(8)
 	existing := createTestResource(t, identifier, "Existing")
 	defer func() { _ = database.DeleteResource(nil, existing.Id) }()
 
@@ -155,7 +155,7 @@ func TestAPIResourcesCreate_UnauthorizedAndScope(t *testing.T) {
 
 	// Insufficient scope (e.g., userinfo only)
 	token := createClientCredentialsTokenWithScope(t, constants.AuthServerResourceIdentifier, constants.UserinfoPermissionIdentifier)
-	resp3 := makeAPIRequest(t, "POST", url, token, api.CreateResourceRequest{ResourceIdentifier: "valid-" + gofakeit.LetterN(6), Description: "x"})
+	resp3 := makeAPIRequest(t, "POST", url, token, api.CreateResourceRequest{ResourceIdentifier: "valid-" + fake.LetterN(6), Description: "x"})
 	defer func() { _ = resp3.Body.Close() }()
 	assert.Equal(t, http.StatusForbidden, resp3.StatusCode)
 	body3, _ := io.ReadAll(resp3.Body)

--- a/src/authserver/tests/integration/api_resources_delete_test.go
+++ b/src/authserver/tests/integration/api_resources_delete_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +18,7 @@ func TestAPIResourceDelete_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Create a test resource to delete
-	res := createTestResource(t, "api-test-del-resource-"+gofakeit.LetterN(6), "To be deleted")
+	res := createTestResource(t, "api-test-del-resource-"+fake.LetterN(6), "To be deleted")
 
 	// Delete the resource via API
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10)
@@ -87,7 +87,7 @@ func TestAPIResourceDelete_SystemLevelResource(t *testing.T) {
 
 func TestAPIResourceDelete_UnauthorizedAndScope(t *testing.T) {
 	// Prepare a test resource to reference
-	res := createTestResource(t, "api-test-del-unauth-"+gofakeit.LetterN(6), "desc")
+	res := createTestResource(t, "api-test-del-unauth-"+fake.LetterN(6), "desc")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10)

--- a/src/authserver/tests/integration/api_resources_get_update_test.go
+++ b/src/authserver/tests/integration/api_resources_get_update_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +18,7 @@ import (
 func TestAPIResourceGet_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	res := createTestResource(t, "api-test-get-resource-"+gofakeit.LetterN(6), "Get Resource")
+	res := createTestResource(t, "api-test-get-resource-"+fake.LetterN(6), "Get Resource")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10)
@@ -92,11 +92,11 @@ func TestAPIResourceGet_UnauthorizedAndScope(t *testing.T) {
 func TestAPIResourceUpdatePut_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
-	res := createTestResource(t, "api-test-update-resource-"+gofakeit.LetterN(6), "Original")
+	res := createTestResource(t, "api-test-update-resource-"+fake.LetterN(6), "Original")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	updateReq := api.UpdateResourceRequest{
-		ResourceIdentifier: "updated-resource-" + gofakeit.LetterN(6),
+		ResourceIdentifier: "updated-resource-" + fake.LetterN(6),
 		Description:        "  Updated desc  ",
 	}
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10)
@@ -124,7 +124,7 @@ func TestAPIResourceUpdatePut_Success(t *testing.T) {
 
 func TestAPIResourceUpdatePut_ValidationErrors(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
-	res := createTestResource(t, "api-test-update-val-"+gofakeit.LetterN(6), "desc")
+	res := createTestResource(t, "api-test-update-val-"+fake.LetterN(6), "desc")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	// Empty identifier
@@ -156,8 +156,8 @@ func TestAPIResourceUpdatePut_ValidationErrors(t *testing.T) {
 
 func TestAPIResourceUpdatePut_DuplicateIdentifier(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
-	res1 := createTestResource(t, "api-test-dup1-"+gofakeit.LetterN(6), "desc")
-	res2 := createTestResource(t, "api-test-dup2-"+gofakeit.LetterN(6), "desc")
+	res1 := createTestResource(t, "api-test-dup1-"+fake.LetterN(6), "desc")
+	res2 := createTestResource(t, "api-test-dup2-"+fake.LetterN(6), "desc")
 	defer func() { _ = database.DeleteResource(nil, res1.Id); _ = database.DeleteResource(nil, res2.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res2.Id, 10)
@@ -231,7 +231,7 @@ func TestAPIResourceUpdatePut_InvalidIdAndBody(t *testing.T) {
 
 	// Not found
 	urlNF := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/9999999"
-	respNF := makeAPIRequest(t, "PUT", urlNF, accessToken, api.UpdateResourceRequest{ResourceIdentifier: "valid-" + gofakeit.LetterN(6), Description: "y"})
+	respNF := makeAPIRequest(t, "PUT", urlNF, accessToken, api.UpdateResourceRequest{ResourceIdentifier: "valid-" + fake.LetterN(6), Description: "y"})
 	defer func() { _ = respNF.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, respNF.StatusCode)
 
@@ -251,7 +251,7 @@ func TestAPIResourceUpdatePut_InvalidIdAndBody(t *testing.T) {
 
 func TestAPIResourceUpdatePut_UnauthorizedAndScope(t *testing.T) {
 	// Prepare a test resource to reference
-	res := createTestResource(t, "api-test-update-unauth-"+gofakeit.LetterN(6), "desc")
+	res := createTestResource(t, "api-test-update-unauth-"+fake.LetterN(6), "desc")
 	defer func() { _ = database.DeleteResource(nil, res.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/resources/" + strconv.FormatInt(res.Id, 10)

--- a/src/authserver/tests/integration/api_settings_general_test.go
+++ b/src/authserver/tests/integration/api_settings_general_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,7 +88,7 @@ func TestAPISettingsGeneralPut_DisableSelfRegForcesVerificationFalse(t *testing.
 	// First enable both
 	preReq := api.UpdateSettingsGeneralRequest{
 		AppName:                 "App X",
-		Issuer:                  "issuer-" + gofakeit.LetterN(6),
+		Issuer:                  "issuer-" + fake.LetterN(6),
 		SelfRegistrationEnabled: true,
 		SelfRegistrationRequiresEmailVerification: true,
 		PasswordPolicy: "low",

--- a/src/authserver/tests/integration/api_users_search_annotate_permission_test.go
+++ b/src/authserver/tests/integration/api_users_search_annotate_permission_test.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +23,7 @@ func TestAPIUsersSearch_AnnotatePermission_Success(t *testing.T) {
 	perm := createPermission(t, res.Id)
 
 	// Create three users; grant permission to two
-	randSuffix := gofakeit.LetterN(6)
+	randSuffix := fake.LetterN(6)
 	u1 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm1-" + randSuffix, Email: "annperm1-" + randSuffix + "@test.com", GivenName: "A1", FamilyName: "T"}
 	u2 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm2-" + randSuffix, Email: "annperm2-" + randSuffix + "@test.com", GivenName: "A2", FamilyName: "T"}
 	u3 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm3-" + randSuffix, Email: "annperm3-" + randSuffix + "@test.com", GivenName: "A3", FamilyName: "T"}
@@ -84,7 +84,7 @@ func TestAPIUsersSearch_AnnotatePermission_InvalidParam(t *testing.T) {
 
 func TestAPIUsersSearch_AnnotatePermission_PermissionNotFound(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
-	missingId := int64(gofakeit.Number(8_000_000, 8_999_999))
+	missingId := int64(fake.Number(8_000_000, 8_999_999))
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/users/search?annotatePermissionId=" + strconv.FormatInt(missingId, 10)
 	resp := makeAPIRequest(t, "GET", url, accessToken, nil)
 	defer func() { _ = resp.Body.Close() }()

--- a/src/authserver/tests/integration/api_users_search_test.go
+++ b/src/authserver/tests/integration/api_users_search_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUsersSearch_Success(t *testing.T) {
 
 	// Setup: Create test users with unique identifiers to avoid conflicts
 	// and allow searching by query instead of paginating through all users
-	uniqueSuffix := gofakeit.LetterN(10)
+	uniqueSuffix := fake.LetterN(10)
 	testUsers := createTestUsersWithSuffix(t, uniqueSuffix)
 	defer func() {
 		// Cleanup: Delete test users
@@ -82,7 +82,7 @@ func TestAPIUsersSearch_WithQuery(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Setup: Create test users with more unique identifiers to avoid conflicts
-	uniqueSuffix := gofakeit.LetterN(8)
+	uniqueSuffix := fake.LetterN(8)
 	user1 := &models.User{
 		Subject:       uuid.New(),
 		Enabled:       true,

--- a/src/authserver/tests/integration/auth_otp_client_display_test.go
+++ b/src/authserver/tests/integration/auth_otp_client_display_test.go
@@ -3,11 +3,11 @@ package integrationtests
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +15,7 @@ import (
 func TestAuthOtp_ClientDisplay_ShowDisplayName_Enabled(t *testing.T) {
 	// Create client with display name enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		ShowDisplayName:  true,
 		ShowLogo:         false,
@@ -27,17 +27,17 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user with OTP enabled
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -74,7 +74,7 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enabled(t *testing.T) {
 func TestAuthOtp_ClientDisplay_AllEnabled_Enabled(t *testing.T) {
 	// Create client with all display settings enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		Description:      "The best app for testing OAuth flows",
 		WebsiteURL:       "https://example.com",
@@ -89,17 +89,17 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user with OTP enabled
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -135,7 +135,7 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enabled(t *testing.T) {
 
 func TestAuthOtp_ClientDisplay_AllDisabled_Enabled(t *testing.T) {
 	// Create client with all display settings disabled
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "My Awesome Application",
@@ -152,17 +152,17 @@ func TestAuthOtp_ClientDisplay_AllDisabled_Enabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user with OTP enabled
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -199,7 +199,7 @@ func TestAuthOtp_ClientDisplay_AllDisabled_Enabled(t *testing.T) {
 func TestAuthOtp_ClientDisplay_ShowDisplayName_Enrollment(t *testing.T) {
 	// Create client with display name enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		ShowDisplayName:  true,
 		ShowLogo:         false,
@@ -211,20 +211,20 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enrollment(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user WITHOUT OTP (enrollment scenario)
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false, // No OTP yet
 	}
@@ -249,7 +249,7 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enrollment(t *testing.T) {
 func TestAuthOtp_ClientDisplay_AllEnabled_Enrollment(t *testing.T) {
 	// Create client with all display settings enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		Description:      "The best app for testing OAuth flows",
 		WebsiteURL:       "https://example.com",
@@ -264,20 +264,20 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enrollment(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user WITHOUT OTP (enrollment scenario)
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}
@@ -301,7 +301,7 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enrollment(t *testing.T) {
 
 func TestAuthOtp_ClientDisplay_AllDisabled_Enrollment(t *testing.T) {
 	// Create client with all display settings disabled
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "My Awesome Application",
@@ -318,20 +318,20 @@ func TestAuthOtp_ClientDisplay_AllDisabled_Enrollment(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user WITHOUT OTP (enrollment scenario)
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}

--- a/src/authserver/tests/integration/auth_otp_replay_test.go
+++ b/src/authserver/tests/integration/auth_otp_replay_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
@@ -17,6 +16,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/otp"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +30,7 @@ import (
 // user the account API created needs the same fixture to be driven through the browser flow.
 func createLevel2MandatoryClient(t *testing.T) (*models.Client, *models.RedirectURI) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -43,7 +43,7 @@ func createLevel2MandatoryClient(t *testing.T) (*models.Client, *models.Redirect
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	if err != nil {
@@ -66,7 +66,7 @@ func createLevel2MandatoryUser(t *testing.T, otpEnabled bool) (*models.Client, *
 
 	client, redirectUri := createLevel2MandatoryClient(t)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -75,7 +75,7 @@ func createLevel2MandatoryUser(t *testing.T, otpEnabled bool) (*models.Client, *
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -138,10 +138,10 @@ func startOtpCeremonyOn(t *testing.T, httpClient *http.Client, client *models.Cl
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		extra
 
 	resp, err := httpClient.Get(destUrl)

--- a/src/authserver/tests/integration/auth_otp_reprompt_test.go
+++ b/src/authserver/tests/integration/auth_otp_reprompt_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,10 +36,10 @@ func authorizeOnExistingSession(t *testing.T, httpClient *http.Client, client *m
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {

--- a/src/authserver/tests/integration/auth_pwd_client_display_test.go
+++ b/src/authserver/tests/integration/auth_pwd_client_display_test.go
@@ -3,16 +3,16 @@ package integrationtests
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthPwd_ClientDisplay_ShowDisplayName_WithValue(t *testing.T) {
 	// Create client with display name enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		ShowDisplayName:  true,
 		ShowLogo:         false,
@@ -25,7 +25,7 @@ func TestAuthPwd_ClientDisplay_ShowDisplayName_WithValue(t *testing.T) {
 	// Create redirect URI
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestAuthPwd_ClientDisplay_ShowDisplayName_WithValue(t *testing.T) {
 
 func TestAuthPwd_ClientDisplay_ShowDisplayName_Empty(t *testing.T) {
 	// Create client with display name enabled but empty
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "", // Empty display name
@@ -63,7 +63,7 @@ func TestAuthPwd_ClientDisplay_ShowDisplayName_Empty(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestAuthPwd_ClientDisplay_ShowDisplayName_Empty(t *testing.T) {
 
 func TestAuthPwd_ClientDisplay_HideDisplayName(t *testing.T) {
 	// Create client with display name set but ShowDisplayName=false
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "My Awesome Application",
@@ -97,7 +97,7 @@ func TestAuthPwd_ClientDisplay_HideDisplayName(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -118,7 +118,7 @@ func TestAuthPwd_ClientDisplay_HideDisplayName(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 	// Create client with logo enabled and uploaded
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		ShowLogo:         true,
 		UploadLogo:       true, // Upload logo
 		ShowDisplayName:  false,
@@ -130,7 +130,7 @@ func TestAuthPwd_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestAuthPwd_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowLogo_NoLogo(t *testing.T) {
 	// Create client with logo enabled but not uploaded
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		ShowLogo:         true,
 		UploadLogo:       false, // No logo uploaded
 		ShowDisplayName:  false,
@@ -163,7 +163,7 @@ func TestAuthPwd_ClientDisplay_ShowLogo_NoLogo(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestAuthPwd_ClientDisplay_ShowLogo_NoLogo(t *testing.T) {
 func TestAuthPwd_ClientDisplay_HideLogo_WithLogo(t *testing.T) {
 	// Create client with logo uploaded but ShowLogo=false
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		ShowLogo:         false, // Hidden
 		UploadLogo:       true,  // Logo exists
 		ShowDisplayName:  false,
@@ -196,7 +196,7 @@ func TestAuthPwd_ClientDisplay_HideLogo_WithLogo(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -217,7 +217,7 @@ func TestAuthPwd_ClientDisplay_HideLogo_WithLogo(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowDescription_WithValue(t *testing.T) {
 	// Create client with description enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		Description:      "The best app for testing OAuth flows",
 		ShowDescription:  true,
 		ShowLogo:         false,
@@ -229,7 +229,7 @@ func TestAuthPwd_ClientDisplay_ShowDescription_WithValue(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -250,7 +250,7 @@ func TestAuthPwd_ClientDisplay_ShowDescription_WithValue(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowDescription_Empty(t *testing.T) {
 	// Create client with description enabled but empty
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		Description:      "", // Empty
 		ShowDescription:  true,
 		ShowLogo:         false,
@@ -262,7 +262,7 @@ func TestAuthPwd_ClientDisplay_ShowDescription_Empty(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -283,7 +283,7 @@ func TestAuthPwd_ClientDisplay_ShowDescription_Empty(t *testing.T) {
 func TestAuthPwd_ClientDisplay_HideDescription(t *testing.T) {
 	// Create client with description set but ShowDescription=false
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		Description:      "The best app for testing OAuth flows",
 		ShowDescription:  false, // Hidden
 		ShowLogo:         false,
@@ -295,7 +295,7 @@ func TestAuthPwd_ClientDisplay_HideDescription(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -316,7 +316,7 @@ func TestAuthPwd_ClientDisplay_HideDescription(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_WithValue(t *testing.T) {
 	// Create client with website URL enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		WebsiteURL:       "https://example.com",
 		ShowWebsiteURL:   true,
 		ShowLogo:         false,
@@ -328,7 +328,7 @@ func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_WithValue(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -349,7 +349,7 @@ func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_WithValue(t *testing.T) {
 func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_Empty(t *testing.T) {
 	// Create client with website URL enabled but empty
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		WebsiteURL:       "", // Empty
 		ShowWebsiteURL:   true,
 		ShowLogo:         false,
@@ -361,7 +361,7 @@ func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_Empty(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -382,7 +382,7 @@ func TestAuthPwd_ClientDisplay_ShowWebsiteUrl_Empty(t *testing.T) {
 func TestAuthPwd_ClientDisplay_HideWebsiteUrl(t *testing.T) {
 	// Create client with website URL set but ShowWebsiteURL=false
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		WebsiteURL:       "https://example.com",
 		ShowWebsiteURL:   false, // Hidden
 		ShowLogo:         false,
@@ -394,7 +394,7 @@ func TestAuthPwd_ClientDisplay_HideWebsiteUrl(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -415,7 +415,7 @@ func TestAuthPwd_ClientDisplay_HideWebsiteUrl(t *testing.T) {
 func TestAuthPwd_ClientDisplay_AllEnabled(t *testing.T) {
 	// Create client with all display settings enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		Description:      "The best app for testing OAuth flows",
 		WebsiteURL:       "https://example.com",
@@ -430,7 +430,7 @@ func TestAuthPwd_ClientDisplay_AllEnabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
@@ -450,7 +450,7 @@ func TestAuthPwd_ClientDisplay_AllEnabled(t *testing.T) {
 
 func TestAuthPwd_ClientDisplay_AllDisabled(t *testing.T) {
 	// Create client with all display settings disabled
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "My Awesome Application",
@@ -467,7 +467,7 @@ func TestAuthPwd_ClientDisplay_AllDisabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)

--- a/src/authserver/tests/integration/auth_pwd_ui_locales_test.go
+++ b/src/authserver/tests/integration/auth_pwd_ui_locales_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ import (
 // or the form-body capture not being persisted on POST authorize).
 func TestAuthPwd_UILocales_PreservedAcrossFlow(t *testing.T) {
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-uiloc-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-uiloc-" + fake.LetterN(8),
 		DisplayName:      "Test app",
 		ShowDisplayName:  true,
 		ConsentRequired:  false,
@@ -31,7 +31,7 @@ func TestAuthPwd_UILocales_PreservedAcrossFlow(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)

--- a/src/authserver/tests/integration/authorize_acr_snapshot_test.go
+++ b/src/authserver/tests/integration/authorize_acr_snapshot_test.go
@@ -4,12 +4,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +42,7 @@ import (
 // the case is what happens in the gap between them.
 func TestAcrSnapshot_ClientRaisedMidCeremonyDoesNotElevateTheAcr(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -56,7 +56,7 @@ func TestAcrSnapshot_ClientRaisedMidCeremonyDoesNotElevateTheAcr(t *testing.T) {
 	}
 	require.NoError(t, database.CreateRedirectURI(nil, redirectUri))
 
-	password := gofakeit.Password(true, true, true, true, false, 10)
+	password := fake.Password(10)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestAcrSnapshot_ClientRaisedMidCeremonyDoesNotElevateTheAcr(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	require.NoError(t, database.CreateUser(nil, user))
@@ -76,10 +76,10 @@ func TestAcrSnapshot_ClientRaisedMidCeremonyDoesNotElevateTheAcr(t *testing.T) {
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	require.NoError(t, err)

--- a/src/authserver/tests/integration/authorize_ceremony_binding_test.go
+++ b/src/authserver/tests/integration/authorize_ceremony_binding_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,7 +26,7 @@ func createConsentClient(t *testing.T) (*models.Client, *models.RedirectURI) {
 // a stale login form finished it and the code was issued with nothing shown to the user at all.
 func createLevel1Client(t *testing.T, consentRequired bool) (*models.Client, *models.RedirectURI) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          consentRequired,
@@ -38,7 +38,7 @@ func createLevel1Client(t *testing.T, consentRequired bool) (*models.Client, *mo
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	if err := database.CreateRedirectURI(nil, redirectUri); err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ func createLevel1Client(t *testing.T, consentRequired bool) (*models.Client, *mo
 
 // createCeremonyUser makes an enabled user with a password, and returns that password.
 func createCeremonyUser(t *testing.T) (*models.User, string) {
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func createCeremonyUser(t *testing.T) (*models.User, string) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	if err := database.CreateUser(nil, user); err != nil {
@@ -99,10 +99,10 @@ func authorizeUrlFor(client *models.Client, redirectUri *models.RedirectURI, sco
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(scope) +
 		"&state=" + state +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 }
 
 // TestAuthorize_ConsentFormFromAReplacedCeremonyIsRefused walks the defect end to end.
@@ -125,7 +125,7 @@ func TestAuthorize_ConsentFormFromAReplacedCeremonyIsRefused(t *testing.T) {
 	httpClient := createHttpClient(t)
 
 	// Client A's authorization, all the way to its consent screen.
-	stateA := gofakeit.LetterN(8)
+	stateA := fake.LetterN(8)
 	resp, err := httpClient.Get(authorizeUrlFor(clientA, redirectUriA, "openid profile email", stateA))
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +159,7 @@ func TestAuthorize_ConsentFormFromAReplacedCeremonyIsRefused(t *testing.T) {
 
 	// The second tab. Client B's authorization runs on the same browser, reusing the session A's
 	// ceremony created, and its auth context replaces A's. A's consent screen is still on screen.
-	stateB := gofakeit.LetterN(8)
+	stateB := fake.LetterN(8)
 	resp, err = httpClient.Get(authorizeUrlFor(clientB, redirectUriB, "openid profile", stateB))
 	if err != nil {
 		t.Fatal(err)
@@ -254,7 +254,7 @@ func TestAuthorize_PasswordFormFromAReplacedCeremonyIsRefused(t *testing.T) {
 	httpClient := createHttpClient(t)
 
 	// Client A's authorization, as far as its login screen.
-	stateA := gofakeit.LetterN(8)
+	stateA := fake.LetterN(8)
 	resp, err := httpClient.Get(authorizeUrlFor(clientA, redirectUriA, "openid profile email", stateA))
 	if err != nil {
 		t.Fatal(err)
@@ -273,7 +273,7 @@ func TestAuthorize_PasswordFormFromAReplacedCeremonyIsRefused(t *testing.T) {
 
 	// The second tab. Client B's authorization replaces A's context, and A's login screen is still
 	// on the user's screen.
-	stateB := gofakeit.LetterN(8)
+	stateB := fake.LetterN(8)
 	resp, err = httpClient.Get(authorizeUrlFor(clientB, redirectUriB, "openid profile", stateB))
 	if err != nil {
 		t.Fatal(err)
@@ -378,14 +378,14 @@ func TestAuthorize_OtpFormFromAReplacedCeremonyIsRefused(t *testing.T) {
 
 	httpClient := createHttpClient(t)
 
-	stateA := gofakeit.LetterN(8)
+	stateA := fake.LetterN(8)
 	otpUrlA, otpPageA := walkToOtpPrompt(t, httpClient, clientA, redirectUriA, stateA, user, password)
 	defer func() { _ = otpPageA.Body.Close() }()
 
 	ceremonyA := getCeremonyIdFromPage(t, otpPageA)
 
 	// The second tab, on the same browser. A's OTP prompt is still on the user's screen.
-	stateB := gofakeit.LetterN(8)
+	stateB := fake.LetterN(8)
 	otpUrlB, otpPageB := walkToOtpPrompt(t, httpClient, clientB, redirectUriB, stateB, user, password)
 	defer func() { _ = otpPageB.Body.Close() }()
 

--- a/src/authserver/tests/integration/authorize_client_redirect_validation_test.go
+++ b/src/authserver/tests/integration/authorize_client_redirect_validation_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +59,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_ClientDoesNotExist(t *testing.T)
 
 func TestAuthorize_ValidateClientAndRedirectURI_ClientIsDisabled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier: "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-client-" + fake.LetterN(8),
 		Enabled:          false,
 	}
 
@@ -91,7 +91,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_ClientIsDisabled(t *testing.T) {
 
 func TestAuthorize_ValidateClientAndRedirectURI_ClientDoesNotSupportTheAuthorizationCodeFlow(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: false,
 	}
@@ -124,7 +124,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_ClientDoesNotSupportTheAuthoriza
 
 func TestAuthorize_ValidateClientAndRedirectURI_RedirectURIIsMissing(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -157,7 +157,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_RedirectURIIsMissing(t *testing.
 
 func TestAuthorize_ValidateClientAndRedirectURI_ClientDoesNotHaveRedirectURI(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -167,7 +167,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_ClientDoesNotHaveRedirectURI(t *
 		t.Fatal(err)
 	}
 
-	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier + "&redirect_uri=" + gofakeit.URL()
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier + "&redirect_uri=" + fake.URL()
 
 	httpClient := createHttpClient(t)
 
@@ -207,7 +207,7 @@ func TestAuthorize_ValidateClientAndRedirectURI_RedirectURIIsNotAbsolute(t *test
 	const nonAbsoluteURI = "//evil.example/cb"
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}

--- a/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
+++ b/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
@@ -6,12 +6,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +33,7 @@ import (
 // login makes /auth/pwd reject the credentials and /auth/completed is never reached.
 func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -47,7 +47,7 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -55,7 +55,7 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +64,7 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -73,15 +73,15 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	httpClient := createHttpClient(t)
 
@@ -146,7 +146,7 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 // filtering to nothing happens at /auth/completed.
 func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -160,7 +160,7 @@ func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) 
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -168,7 +168,7 @@ func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -177,7 +177,7 @@ func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -191,12 +191,12 @@ func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) 
 	permission := createPermission(t, resource.Id)
 	requestScope := resource.ResourceIdentifier + ":" + permission.PermissionIdentifier
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(requestScope) +
 		"&state=" + requestState
 

--- a/src/authserver/tests/integration/authorize_cross_user_session_test.go
+++ b/src/authserver/tests/integration/authorize_cross_user_session_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -16,6 +15,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,14 +70,14 @@ type crossUserBrowser struct {
 // plaintext on the model so a case can generate a passcode from it, and encrypted at rest the way
 // production stores it.
 func createCrossUserUser(t *testing.T, withOtp bool) (*models.User, string) {
-	password := gofakeit.Password(true, true, true, true, false, 10)
+	password := fake.Password(10)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -121,12 +121,12 @@ func createCrossUserBrowser(t *testing.T, defaultAcrLevel enums.AcrLevel,
 	require.False(t, defaultAcrLevel.IsHigherThan(aSessionAcrLevel),
 		"the client's level is a floor under A's ceremony too, so A's session cannot end up below it")
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	require.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -199,8 +199,8 @@ func crossUserAuthorizeUrl(b *crossUserBrowser, extra string) string {
 		"&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(crossUserCodeVerifier) +
 		"&scope=" + url.QueryEscape(crossUserScope) +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		extra
 }
 

--- a/src/authserver/tests/integration/authorize_deferred_error_test.go
+++ b/src/authserver/tests/integration/authorize_deferred_error_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -182,7 +182,7 @@ func TestAuthorize_Deferred_NonConformingDescriptionMatchesTheImmediatePath(t *t
 		"&redirect_uri=" + url.QueryEscape(deferralRedirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&state=" + url.QueryEscape(deferralState) +
 		"&scope=" + url.QueryEscape(emojiScope)
 
@@ -228,7 +228,7 @@ func TestAuthorizePost_Deferred_CookielessRequestIsSentToLogin(t *testing.T) {
 	form.Set("redirect_uri", deferralRedirectURI)
 	form.Set("response_type", "code")
 	form.Set("code_challenge_method", "S256")
-	form.Set("code_challenge", gofakeit.LetterN(43))
+	form.Set("code_challenge", fake.LetterN(43))
 	form.Set("scope", "not_a_valid_scope")
 	form.Set("state", deferralState)
 
@@ -270,7 +270,7 @@ func TestAuthorize_Deferred_LeavesNoUserSession(t *testing.T) {
 		"&redirect_uri=" + url.QueryEscape(deferralRedirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email")
 
 	second, err := httpClient.Get(valid)
@@ -289,7 +289,7 @@ func deferralAuthorizeURL(clientIdentifier string, responseMode string) string {
 		"&redirect_uri=" + url.QueryEscape(deferralRedirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&state=" + url.QueryEscape(deferralState) +
 		"&scope=not_a_valid_scope"
 
@@ -357,7 +357,7 @@ func newDeferralClient(t *testing.T) (*models.Client, *models.User, string) {
 	t.Helper()
 
 	client := &models.Client{
-		ClientIdentifier:         "deferral-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "deferral-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -372,14 +372,14 @@ func newDeferralClient(t *testing.T) (*models.Client, *models.User, string) {
 	})
 	require.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)

--- a/src/authserver/tests/integration/authorize_existing_session_test.go
+++ b/src/authserver/tests/integration/authorize_existing_session_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,9 +24,9 @@ func TestAuthorize_ExistingAcrLevel1Session_AcrLevel1Request(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -105,9 +105,9 @@ func TestAuthorize_ExistingAcrLevel1Session_AcrLevel2OptionalRequest_OtpDisabled
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -200,9 +200,9 @@ func TestAuthorize_ExistingAcrLevel1Session_AcrLevel2OptionalRequest_OtpEnabled(
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -296,9 +296,9 @@ func TestAuthorize_ExistingAcrLevel1Session_AcrLevel2MandatoryRequest_OtpDisable
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -404,9 +404,9 @@ func TestAuthorize_ExistingAcrLevel1Session_AcrLevel2MandatoryRequest_OtpEnabled
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -494,9 +494,9 @@ func TestAuthorize_ExistingAcrLevel2OptionalSession_AcrLevel1Request(t *testing.
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -576,9 +576,9 @@ func TestAuthorize_ExistingAcrLevel2OptionalSession_AcrLevel2OptionalRequest_Otp
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -677,9 +677,9 @@ func TestAuthorize_ExistingAcrLevel2OptionalSession_AcrLevel2OptionalRequest_Otp
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -785,9 +785,9 @@ func TestAuthorize_ExistingAcrLevel2OptionalSession_AcrLevel2MandatoryRequest_Ot
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -901,9 +901,9 @@ func TestAuthorize_ExistingAcrLevel2OptionalSession_AcrLevel2MandatoryRequest_Ot
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -999,9 +999,9 @@ func TestAuthorize_ExistingAcrLevel2MandatorySession_AcrLevel1Request(t *testing
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1082,9 +1082,9 @@ func TestAuthorize_ExistingAcrLevel2MandatorySession_AcrLevel2OptionalRequest_Ot
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1170,9 +1170,9 @@ func TestAuthorize_ExistingAcrLevel2MandatorySession_AcrLevel2OptionalRequest_Ot
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1277,9 +1277,9 @@ func TestAuthorize_ExistingAcrLevel2MandatorySession_AcrLevel2MandatoryRequest_O
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1381,9 +1381,9 @@ func TestAuthorize_ExistingAcrLevel2MandatorySession_AcrLevel2MandatoryRequest_O
 
 	time.Sleep(200 * time.Millisecond)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/authserver/tests/integration/authorize_id_token_hint_test.go
+++ b/src/authserver/tests/integration/authorize_id_token_hint_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -13,6 +12,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,27 +29,27 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	// =========================================================================
 	// Step 1: Create User A and User B
 	// =========================================================================
-	passwordA := gofakeit.Password(true, true, true, true, false, 10)
+	passwordA := fake.Password(10)
 	passwordHashedA, err := hashutil.HashPassword(passwordA)
 	assert.NoError(t, err)
 
 	userA := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashedA,
 	}
 	err = database.CreateUser(nil, userA)
 	assert.NoError(t, err)
 
-	passwordB := gofakeit.Password(true, true, true, true, false, 10)
+	passwordB := fake.Password(10)
 	passwordHashedB, err := hashutil.HashPassword(passwordB)
 	assert.NoError(t, err)
 
 	userB := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashedB,
 	}
 	err = database.CreateUser(nil, userB)
@@ -58,12 +58,12 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	// =========================================================================
 	// Step 2: Create client with confidential credentials
 	// =========================================================================
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -87,8 +87,8 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	httpClientA := createHttpClient(t)
 	codeVerifierA := "code-verifier-a"
 	requestCodeChallengeA := oauth.GeneratePKCECodeChallenge(codeVerifierA)
-	requestStateA := gofakeit.LetterN(8)
-	requestNonceA := gofakeit.LetterN(8)
+	requestStateA := fake.LetterN(8)
+	requestNonceA := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrlA := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -164,8 +164,8 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	httpClientB := createHttpClient(t) // Fresh client, no session
 	codeVerifierB := "code-verifier-b"
 	requestCodeChallengeB := oauth.GeneratePKCECodeChallenge(codeVerifierB)
-	requestStateB := gofakeit.LetterN(8)
-	requestNonceB := gofakeit.LetterN(8)
+	requestStateB := fake.LetterN(8)
+	requestNonceB := fake.LetterN(8)
 
 	destUrlB := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -251,14 +251,14 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	// =========================================================================
 	// Step 1: Create User A
 	// =========================================================================
-	password := gofakeit.Password(true, true, true, true, false, 10)
+	password := fake.Password(10)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -267,12 +267,12 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	// =========================================================================
 	// Step 2: Create client
 	// =========================================================================
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -296,8 +296,8 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	httpClient1 := createHttpClient(t)
 	codeVerifier1 := "code-verifier-1"
 	requestCodeChallenge1 := oauth.GeneratePKCECodeChallenge(codeVerifier1)
-	requestState1 := gofakeit.LetterN(8)
-	requestNonce1 := gofakeit.LetterN(8)
+	requestState1 := fake.LetterN(8)
+	requestNonce1 := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl1 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -365,8 +365,8 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	httpClient2 := createHttpClient(t) // Fresh client
 	codeVerifier2 := "code-verifier-2"
 	requestCodeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -441,39 +441,39 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 // id_token_hint works even without prompt=login parameter.
 func TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	// Create two users
-	passwordA := gofakeit.Password(true, true, true, true, false, 10)
+	passwordA := fake.Password(10)
 	passwordHashedA, err := hashutil.HashPassword(passwordA)
 	assert.NoError(t, err)
 
 	userA := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashedA,
 	}
 	err = database.CreateUser(nil, userA)
 	assert.NoError(t, err)
 
-	passwordB := gofakeit.Password(true, true, true, true, false, 10)
+	passwordB := fake.Password(10)
 	passwordHashedB, err := hashutil.HashPassword(passwordB)
 	assert.NoError(t, err)
 
 	userB := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashedB,
 	}
 	err = database.CreateUser(nil, userB)
 	assert.NoError(t, err)
 
 	// Create client
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -495,8 +495,8 @@ func TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	httpClientA := createHttpClient(t)
 	codeVerifierA := "code-verifier-a"
 	requestCodeChallengeA := oauth.GeneratePKCECodeChallenge(codeVerifierA)
-	requestStateA := gofakeit.LetterN(8)
-	requestNonceA := gofakeit.LetterN(8)
+	requestStateA := fake.LetterN(8)
+	requestNonceA := fake.LetterN(8)
 	requestScope := "openid profile"
 
 	destUrlA := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -555,8 +555,8 @@ func TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	httpClientB := createHttpClient(t)
 	codeVerifierB := "code-verifier-b"
 	requestCodeChallengeB := oauth.GeneratePKCECodeChallenge(codeVerifierB)
-	requestStateB := gofakeit.LetterN(8)
-	requestNonceB := gofakeit.LetterN(8)
+	requestStateB := fake.LetterN(8)
+	requestNonceB := fake.LetterN(8)
 
 	// Note: NO prompt=login parameter here
 	destUrlB := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/authserver/tests/integration/authorize_no_session_consent_test.go
+++ b/src/authserver/tests/integration/authorize_no_session_consent_test.go
@@ -9,19 +9,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFullyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -35,7 +35,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -43,7 +43,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -70,9 +70,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -156,7 +156,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPartiallyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -170,7 +170,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -178,7 +178,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -205,9 +205,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -294,7 +294,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsFullyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -308,7 +308,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -316,7 +316,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +325,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}
@@ -344,9 +344,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -434,7 +434,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsPartiallyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -448,7 +448,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -456,7 +456,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -465,7 +465,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}
@@ -484,9 +484,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -578,7 +578,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsFullyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -592,7 +592,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -600,13 +600,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -639,9 +639,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -740,7 +740,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsPartiallyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -754,7 +754,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -762,13 +762,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -801,9 +801,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -906,7 +906,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsFullyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -920,7 +920,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -928,13 +928,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
@@ -957,9 +957,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1059,7 +1059,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsPartiallyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1073,7 +1073,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1081,13 +1081,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
@@ -1110,9 +1110,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1216,7 +1216,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsFullyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1230,7 +1230,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1238,13 +1238,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -1277,9 +1277,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1378,7 +1378,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsPartiallyGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1392,7 +1392,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1400,13 +1400,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -1439,9 +1439,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1544,7 +1544,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1558,7 +1558,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1566,7 +1566,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1575,7 +1575,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -1593,9 +1593,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1674,7 +1674,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1688,7 +1688,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1696,7 +1696,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1705,7 +1705,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}
@@ -1724,9 +1724,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1792,7 +1792,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1806,7 +1806,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1814,13 +1814,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -1853,9 +1853,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -1932,7 +1932,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1946,7 +1946,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -1954,13 +1954,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
@@ -1983,9 +1983,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -2063,7 +2063,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIsRequired_ConsentIsCancelled(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -2077,7 +2077,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -2085,13 +2085,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -2124,9 +2124,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	assignPermissionToUser(t, user.Id, permission1.Id)
 	assignPermissionToUser(t, user.Id, permission2.Id)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email " + resource1.ResourceIdentifier + ":" + permission1.PermissionIdentifier + " " +
 		resource2.ResourceIdentifier + ":" + permission2.PermissionIdentifier
 
@@ -2208,7 +2208,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 // row, which is the part no mock-backed test reaches (#79).
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScopes_DeniedScopeIsNotGranted(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -2222,7 +2222,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScope
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -2230,7 +2230,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScope
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -2239,7 +2239,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScope
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -2259,9 +2259,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScope
 			resource.ResourceIdentifier+":"+permission.PermissionIdentifier)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	// SetScope deduplicates and collapses whitespace but never sorts, so the consent screen's
 	// index space is this order.

--- a/src/authserver/tests/integration/authorize_no_session_no_consent_test.go
+++ b/src/authserver/tests/integration/authorize_no_session_no_consent_test.go
@@ -8,19 +8,19 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -34,7 +34,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -42,7 +42,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -60,9 +60,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -127,7 +127,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIsNotRequired(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -141,7 +141,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -149,7 +149,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -158,7 +158,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 		OTPEnabled:   false,
 	}
@@ -168,9 +168,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -239,7 +239,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsNotRequired(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -253,7 +253,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsN
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -261,13 +261,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsN
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -291,9 +291,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsN
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -373,7 +373,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsN
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentIsNotRequired(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -387,7 +387,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -395,13 +395,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
@@ -415,9 +415,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -498,7 +498,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIsNotRequired(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -512,7 +512,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -520,13 +520,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -550,9 +550,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -632,7 +632,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_PasswordIsIncorrect(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -646,7 +646,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -654,7 +654,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -663,7 +663,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -672,9 +672,9 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -723,7 +723,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentIsNotRequired_OtpCodeIsIncorrect(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -737,7 +737,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -745,13 +745,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
@@ -765,9 +765,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -833,7 +833,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIsNotRequired_OtpIsIncorrect(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -847,7 +847,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -855,13 +855,13 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -885,9 +885,9 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/authserver/tests/integration/authorize_post_test.go
+++ b/src/authserver/tests/integration/authorize_post_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // Verifies OIDC Core 3.1.2.1: the authorization endpoint MUST support POST
@@ -29,7 +29,7 @@ func TestAuthorize_PostRequest(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &models.Client{
-				ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+				ClientIdentifier:         "test-client-" + fake.LetterN(8),
 				Enabled:                  true,
 				AuthorizationCodeEnabled: true,
 				ConsentRequired:          false,
@@ -41,7 +41,7 @@ func TestAuthorize_PostRequest(t *testing.T) {
 
 			redirectUri := &models.RedirectURI{
 				ClientId: client.Id,
-				URI:      gofakeit.URL(),
+				URI:      fake.URL(),
 			}
 			if err := database.CreateRedirectURI(nil, redirectUri); err != nil {
 				t.Fatal(err)
@@ -52,10 +52,10 @@ func TestAuthorize_PostRequest(t *testing.T) {
 			form.Set("redirect_uri", redirectUri.URI)
 			form.Set("response_type", "code")
 			form.Set("code_challenge_method", "S256")
-			form.Set("code_challenge", gofakeit.LetterN(43))
+			form.Set("code_challenge", fake.LetterN(43))
 			form.Set("scope", "openid profile")
-			form.Set("state", gofakeit.LetterN(8))
-			form.Set("nonce", gofakeit.LetterN(8))
+			form.Set("state", fake.LetterN(8))
+			form.Set("nonce", fake.LetterN(8))
 
 			destURL := config.GetAuthServer().BaseURL + tc.path
 

--- a/src/authserver/tests/integration/authorize_prompt_helpers_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_helpers_test.go
@@ -6,12 +6,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // =============================================================================
@@ -44,7 +44,7 @@ func readResponseBody(t *testing.T, resp *http.Response) string {
 // createTestClientAndRedirectURI creates a basic test client and redirect URI
 func createTestClientAndRedirectURI(t *testing.T) (*models.Client, *models.RedirectURI) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -70,7 +70,7 @@ func createTestClientAndRedirectURI(t *testing.T) (*models.Client, *models.Redir
 // createSessionWithAcrLevel1AndPassword creates a session at ACR level 1 and returns the password for re-auth tests
 func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.Client, *models.RedirectURI, *models.User, string) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -84,7 +84,7 @@ func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -92,7 +92,7 @@ func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -110,9 +110,9 @@ func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/authserver/tests/integration/authorize_prompt_implicit_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_implicit_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +41,7 @@ func enableImplicitFlowGlobally(t *testing.T) func() {
 // (for establishing sessions) and implicit flow (for prompt=none implicit tests).
 func createImplicitClientForPromptTests(t *testing.T) (*models.Client, *models.RedirectURI) {
 	client := &models.Client{
-		ClientIdentifier:         "implicit-prompt-test-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "implicit-prompt-test-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true, // Needed for establishing session
 		ImplicitGrantEnabled:     nil,  // Inherit from global (enabled)
@@ -77,7 +77,7 @@ func TestPromptNone_ImplicitResponseTypeToken(t *testing.T) {
 	// Create a client that supports implicit flow
 	client, redirectUri := createImplicitClientForPromptTests(t)
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=token" +
@@ -122,8 +122,8 @@ func TestPromptNone_ImplicitResponseTypeIdToken(t *testing.T) {
 
 	client, redirectUri := createImplicitClientForPromptTests(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := "test-nonce-" + gofakeit.LetterN(16)
+	requestState := fake.LetterN(8)
+	requestNonce := "test-nonce-" + fake.LetterN(16)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=id_token" +
@@ -167,8 +167,8 @@ func TestPromptNone_ImplicitResponseTypeIdTokenToken(t *testing.T) {
 
 	client, redirectUri := createImplicitClientForPromptTests(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := "test-nonce-" + gofakeit.LetterN(16)
+	requestState := fake.LetterN(8)
+	requestNonce := "test-nonce-" + fake.LetterN(16)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=" + url.QueryEscape("id_token token") +
@@ -219,8 +219,8 @@ func TestPromptNone_ImplicitAuthTimeCorrect(t *testing.T) {
 	time.Sleep(1100 * time.Millisecond)
 
 	// Use prompt=none at T2 with implicit flow
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=" + url.QueryEscape("id_token token") +
@@ -264,7 +264,7 @@ func TestPromptNone_ImplicitMissingNonce(t *testing.T) {
 
 	client, redirectUri := createImplicitClientForPromptTests(t)
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	// Missing nonce - required for response_type=id_token
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +

--- a/src/authserver/tests/integration/authorize_prompt_login_consent_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_login_consent_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -15,6 +14,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,7 +26,7 @@ import (
 func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 	// Create client that does NOT require consent normally
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false, // Consent NOT normally required
@@ -47,7 +47,7 @@ func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 	}
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -56,7 +56,7 @@ func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -78,9 +78,9 @@ func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 
 	// Create session first
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -125,9 +125,9 @@ func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 	_, _ = getCodeAndStateFromUrl(t, resp)
 
 	// Now request with prompt=consent - should force consent screen
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -162,8 +162,8 @@ func TestPromptConsent_NoSession_RequiresLoginFirst(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -199,9 +199,9 @@ func TestPromptLoginConsent_Combined(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// Use both prompt=login and prompt=consent
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -252,8 +252,8 @@ func TestPromptLogin_NoSession(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -277,8 +277,8 @@ func TestPromptLogin_MaxAgeIrrelevant(t *testing.T) {
 	// Create very recent session
 	httpClient, client, redirectUri, _, _ := createSessionWithAcrLevel1AndPassword(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Even with max_age=600 (which would normally allow SSO), prompt=login forces re-auth
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -319,9 +319,9 @@ func TestPromptLogin_PreservesAcrLevel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// Request level2_optional with prompt=login
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -364,9 +364,9 @@ func TestPromptLogin_PreservesAcrLevel(t *testing.T) {
 func TestPromptLogin_PreservesNonce(t *testing.T) {
 	httpClient, client, redirectUri, user, password := createSessionWithAcrLevel1AndPassword(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := "test-nonce-" + gofakeit.LetterN(16)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := "test-nonce-" + fake.LetterN(16)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -421,7 +421,7 @@ func TestPromptLogin_PreservesNonce(t *testing.T) {
 
 func TestPromptConsent_UserDeclines(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -441,7 +441,7 @@ func TestPromptConsent_UserDeclines(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +450,7 @@ func TestPromptConsent_UserDeclines(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -459,9 +459,9 @@ func TestPromptConsent_UserDeclines(t *testing.T) {
 	}
 
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -521,9 +521,9 @@ func TestPromptConsent_UserDeclines(t *testing.T) {
 func TestPromptLogin_WrongPassword(t *testing.T) {
 	httpClient, client, redirectUri, user, _ := createSessionWithAcrLevel1AndPassword(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -577,8 +577,8 @@ func TestPromptLogin_UserDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -587,7 +587,7 @@ func TestPromptLogin_UserDisabled(t *testing.T) {
 		"&code_challenge=" + requestCodeChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=login"
 
 	resp, err := httpClient.Get(destUrl)
@@ -619,14 +619,14 @@ func TestPromptLogin_UserDisabled(t *testing.T) {
 // TestPromptLogin_NewAuthTime verifies that prompt=login re-authentication
 // creates a new auth_time in the issued token (not preserving the old one).
 func TestPromptLogin_NewAuthTime(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -650,7 +650,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -659,7 +659,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -670,7 +670,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 	httpClient := createHttpClient(t)
 	codeVerifier := "code-verifier"
 	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	// Login at T1 to establish session
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -680,7 +680,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 		"&code_challenge=" + codeChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
@@ -736,7 +736,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 	// Re-authenticate with prompt=login at T2
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -745,7 +745,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 		"&code_challenge=" + codeChallenge2 +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState2 +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=login"
 
 	resp2, err := httpClient.Get(destUrl2)

--- a/src/authserver/tests/integration/authorize_prompt_none_response_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_none_response_test.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,8 +19,8 @@ func TestPromptNone_Error_QueryModeDefault(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -58,8 +58,8 @@ func TestPromptNone_Error_QueryModeExplicit(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -96,8 +96,8 @@ func TestPromptNone_Error_FragmentMode(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -140,9 +140,9 @@ func TestPromptNone_Error_FragmentMode(t *testing.T) {
 func TestPromptNone_Success_QueryMode(t *testing.T) {
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -185,9 +185,9 @@ func TestPromptNone_Success_QueryMode(t *testing.T) {
 func TestPromptNone_Success_FragmentMode(t *testing.T) {
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -235,9 +235,9 @@ func TestPromptNone_Success_FragmentMode(t *testing.T) {
 func TestPromptNone_Success_FormPostMode(t *testing.T) {
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -276,8 +276,8 @@ func TestPromptNone_Error_FormPostMode(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -314,8 +314,8 @@ func TestPromptNone_StateEchoedOnError(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := "my-custom-state-" + gofakeit.LetterN(16)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := "my-custom-state-" + fake.LetterN(16)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -340,9 +340,9 @@ func TestPromptNone_StateEchoedOnError(t *testing.T) {
 func TestPromptNone_StateEchoedOnSuccess(t *testing.T) {
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := "success-state-" + gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := "success-state-" + fake.LetterN(16)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -373,7 +373,7 @@ func TestPromptNone_NoStateInRequest(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestCodeChallenge := fake.LetterN(43)
 	// No state parameter
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -408,7 +408,7 @@ func TestPromptNone_EmptyStateInRequest(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestCodeChallenge := fake.LetterN(43)
 	// Empty state parameter
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +

--- a/src/authserver/tests/integration/authorize_prompt_none_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_none_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,8 +24,8 @@ import (
 func TestPromptNone_MaxAge0_ReturnsLoginRequired(t *testing.T) {
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// max_age=0 means authentication must have JUST happened, which it hasn't
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -71,8 +71,8 @@ func TestPromptNone_AcrStepUpNeeded_ReturnsInteractionRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Request level2_optional with existing level1 session - requires step-up
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -110,8 +110,8 @@ func TestPromptNone_OtpEnrollmentNeeded_ReturnsInteractionRequired(t *testing.T)
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Request level2_mandatory - requires OTP enrollment (interaction)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -147,8 +147,8 @@ func TestPromptNone_UserDisabled_ReturnsAccessDenied(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -175,7 +175,7 @@ func TestPromptNone_UserDisabled_ReturnsAccessDenied(t *testing.T) {
 func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true, // Consent required
@@ -196,7 +196,7 @@ func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 	}
 
 	// Create user and session
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -205,7 +205,7 @@ func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -215,9 +215,9 @@ func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 
 	// Create session first (normal flow, will ask for consent)
 	httpClient := createHttpClient(t)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -258,8 +258,8 @@ func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 	_ = assertRedirect(t, resp, "/auth/consent")
 
 	// Now try prompt=none - should fail because no consent exists
-	requestState2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -317,7 +317,7 @@ func walkDCRClientToConsentScreen(t *testing.T, clientName string) (*http.Client
 	}
 	redirectUri := &redirectURIs[0]
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -326,7 +326,7 @@ func walkDCRClientToConsentScreen(t *testing.T, clientName string) (*http.Client
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -339,10 +339,10 @@ func walkDCRClientToConsentScreen(t *testing.T, clientName string) (*http.Client
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
@@ -404,9 +404,9 @@ func TestPromptNone_DCRClient_NoConsent_RedirectIsWithheld(t *testing.T) {
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile") +
-		"&state=" + gofakeit.LetterN(8) +
+		"&state=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp, err := httpClient.Get(destUrl)
@@ -439,15 +439,15 @@ func TestPromptNone_DCRClient_ConsentExists_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp, err := httpClient.Get(destUrl)
@@ -483,9 +483,9 @@ func TestPromptNone_MaxAgeSatisfied_Success(t *testing.T) {
 	// Create session - it will be very recent
 	httpClient, client, redirectUri, user := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// max_age=600 (10 minutes) should be satisfied by a session created just now
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -542,8 +542,8 @@ func TestPromptNone_OtpOptionalNoOtp_ReturnsInteractionRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// Request level2_optional with session at level1 - this is an ACR step-up
 	// Even though user has no OTP, prompt=none cannot silently step up ACR levels
@@ -613,8 +613,8 @@ func TestPromptNone_OtpConfigChanged_ReturnsInteractionRequired(t *testing.T) {
 
 	advanceOtpConfigGeneration(t, user.Id)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Request level2_optional - should require interaction because OTP config changed
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -680,12 +680,12 @@ func TestPromptNone_OtpConfigChanged_RefusalWritesNothing(t *testing.T) {
 	snapshotBefore := userSessions[0].OtpConfigGeneration
 
 	silentRequest := func() string {
-		requestState := gofakeit.LetterN(8)
+		requestState := fake.LetterN(8)
 		destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 			"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 			"&response_type=code" +
 			"&code_challenge_method=S256" +
-			"&code_challenge=" + gofakeit.LetterN(43) +
+			"&code_challenge=" + fake.LetterN(43) +
 			"&scope=" + url.QueryEscape("openid profile") +
 			"&state=" + requestState +
 			"&prompt=none" +
@@ -731,9 +731,9 @@ func TestPromptNone_OtpConfigChangedLevel1Target_Success(t *testing.T) {
 
 	advanceOtpConfigGeneration(t, user.Id)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// Request level1 - the OTP config changed flag should be irrelevant
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -781,9 +781,9 @@ func TestPromptNone_ConsentExists_Success(t *testing.T) {
 	// This tests that prompt=none works with a valid session when no consent is needed
 	httpClient, client, redirectUri, user := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// prompt=none with valid session and client that doesn't require consent
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -840,9 +840,9 @@ func TestPromptNone_SessionBumped_Success(t *testing.T) {
 	// Wait a bit to ensure different timestamp
 	time.Sleep(100 * time.Millisecond)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -894,7 +894,7 @@ func TestPromptNone_SessionBumped_Success(t *testing.T) {
 func TestPromptNone_FullConsentCoverage(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -914,7 +914,7 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -923,7 +923,7 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -945,9 +945,9 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 
 	// Create session
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -997,9 +997,9 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 	_, _ = getCodeAndStateFromUrl(t, resp)
 
 	// Now prompt=none should work since consent covers requested scopes
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1038,7 +1038,7 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1058,7 +1058,7 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1067,7 +1067,7 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1089,9 +1089,9 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 
 	// Create session
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1132,8 +1132,8 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 	assertRedirect(t, resp, "/auth/consent")
 
 	// Now prompt=none should fail with consent_required
-	requestState2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1161,7 +1161,7 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1181,7 +1181,7 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1190,7 +1190,7 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1212,9 +1212,9 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 
 	// Create session first (without requesting offline_access)
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1264,8 +1264,8 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 	_, _ = getCodeAndStateFromUrl(t, resp)
 
 	// Now request with offline_access - should fail since not consented
-	requestState2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1293,7 +1293,7 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1313,7 +1313,7 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1322,7 +1322,7 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1344,9 +1344,9 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 
 	// Create session
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1396,9 +1396,9 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 	_, _ = getCodeAndStateFromUrl(t, resp)
 
 	// Now request with offline_access - should succeed since consented
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1437,7 +1437,7 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 	// Create client that requires consent
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -1457,7 +1457,7 @@ func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1466,7 +1466,7 @@ func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1488,9 +1488,9 @@ func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 
 	// Create session
 	httpClient := createHttpClient(t)
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1541,9 +1541,9 @@ func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 	_, _ = getCodeAndStateFromUrl(t, resp)
 
 	// Now request only openid with prompt=none - should succeed
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
-	requestCodeChallenge2 := gofakeit.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1592,7 +1592,7 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 
 	client, redirectUri := createTestClientAndRedirectURI(t)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1601,7 +1601,7 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1611,8 +1611,8 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 	// Note: user does NOT have the permission assigned
 
 	httpClient := createHttpClient(t)
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	// First, create a session by logging in with openid scope
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1622,7 +1622,7 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 		"&code_challenge=" + requestCodeChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
@@ -1658,13 +1658,13 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 	// Now use prompt=none requesting ONLY the custom scope (no openid)
 	// The user does NOT have the permission, so effective scope will be empty
 	customScope := resource.ResourceIdentifier + ":" + permission.PermissionIdentifier
-	requestState2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(customScope) +
 		"&state=" + requestState2 +
 		"&prompt=none"
@@ -1686,13 +1686,13 @@ func TestPromptNone_InvalidScope(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 
 	httpClient := createHttpClient(t)
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid invalid:scope:format") +
 		"&state=" + requestState +
 		"&prompt=none"

--- a/src/authserver/tests/integration/authorize_prompt_none_token_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_none_token_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -15,6 +14,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ func TestPromptNone_ClientDefaultAcrHigher(t *testing.T) {
 
 	// Create a different client with DefaultAcrLevel=level2_optional
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -49,8 +49,8 @@ func TestPromptNone_ClientDefaultAcrHigher(t *testing.T) {
 	}
 
 	// prompt=none without acr_values, client default is level2_optional, session is level1
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -79,9 +79,9 @@ func TestPromptNone_ClientDefaultAcrSatisfied(t *testing.T) {
 	// Client with DefaultAcrLevel=level1, session at level1 - should succeed
 	httpClient, client, redirectUri, _ := createSessionWithAcrLevel1(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -128,7 +128,7 @@ func TestPromptNone_AcrValuesCannotLowerTheClientFloor(t *testing.T) {
 
 	// Create client with DefaultAcrLevel=level2_optional
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -150,9 +150,9 @@ func TestPromptNone_AcrValuesCannotLowerTheClientFloor(t *testing.T) {
 
 	// Ask for less than the client requires. Before the floor this lowered the target to level1,
 	// which the session met, and a code was issued.
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -188,8 +188,8 @@ func TestPromptNone_InvalidRedirectUri(t *testing.T) {
 	client, _ := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Use a redirect_uri that doesn't match the client's registered URIs
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape("https://evil.com/callback") +
@@ -216,8 +216,8 @@ func TestPromptNone_InvalidRedirectUri(t *testing.T) {
 func TestPromptNone_InvalidClientId(t *testing.T) {
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=nonexistent-client-12345" +
 		"&redirect_uri=" + url.QueryEscape("https://example.com/callback") +
 		"&response_type=code" +
@@ -244,8 +244,8 @@ func TestPromptNone_InvalidResponseType(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=invalid_type" +
@@ -275,14 +275,14 @@ func TestPromptNone_InvalidResponseType(t *testing.T) {
 
 func TestPromptNone_CodeExchange(t *testing.T) {
 	// Create a confidential client for token exchange
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -306,7 +306,7 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -315,7 +315,7 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -326,8 +326,8 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 	httpClient := createHttpClient(t)
 	codeVerifier := "code-verifier"
 	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	// Create session via normal login
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -373,8 +373,8 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 	// Now use prompt=none with proper PKCE
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := "test-nonce-" + gofakeit.LetterN(16)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := "test-nonce-" + fake.LetterN(16)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -428,14 +428,14 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 }
 
 func TestPromptNone_SubClaimConsistent(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -459,7 +459,7 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -468,7 +468,7 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -481,8 +481,8 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 	// First login
 	codeVerifier1 := "code-verifier-one"
 	codeChallenge1 := oauth.GeneratePKCECodeChallenge(codeVerifier1)
-	requestState1 := gofakeit.LetterN(8)
-	requestNonce1 := gofakeit.LetterN(8)
+	requestState1 := fake.LetterN(8)
+	requestNonce1 := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -542,8 +542,8 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 	// prompt=none to get token2
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -586,14 +586,14 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 }
 
 func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -617,7 +617,7 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -626,7 +626,7 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -638,8 +638,8 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 
 	codeVerifier1 := "code-verifier-one"
 	codeChallenge1 := oauth.GeneratePKCECodeChallenge(codeVerifier1)
-	requestState1 := gofakeit.LetterN(8)
-	requestNonce1 := gofakeit.LetterN(8)
+	requestState1 := fake.LetterN(8)
+	requestNonce1 := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -701,8 +701,8 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -745,14 +745,14 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 }
 
 func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -776,7 +776,7 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -785,7 +785,7 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -798,8 +798,8 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 	// Create session
 	codeVerifierSession := "session-code-verifier"
 	codeChallengeSession := oauth.GeneratePKCECodeChallenge(codeVerifierSession)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -844,8 +844,8 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 	// prompt=none with PKCE
 	correctVerifier := "correct-verifier"
 	correctChallenge := oauth.GeneratePKCECodeChallenge(correctVerifier)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -895,14 +895,14 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 // TestPromptNone_RefreshWithOfflineAccess verifies that a code obtained via prompt=none
 // with offline_access scope can be exchanged for tokens and then refreshed.
 func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -926,7 +926,7 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -935,7 +935,7 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -958,8 +958,8 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 	httpClient := createHttpClient(t)
 	codeVerifier := "code-verifier"
 	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	// Create session via normal login with offline_access
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1015,8 +1015,8 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 	// Now use prompt=none with offline_access
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1085,14 +1085,14 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 // TestPromptNone_NoncePreserved verifies that the nonce parameter in a prompt=none
 // request is preserved in the issued id_token.
 func TestPromptNone_NoncePreserved(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -1116,7 +1116,7 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1125,7 +1125,7 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1136,7 +1136,7 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 	httpClient := createHttpClient(t)
 	codeVerifier := "code-verifier"
 	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	// Create session via normal login
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1146,7 +1146,7 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 		"&code_challenge=" + codeChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
@@ -1182,8 +1182,8 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 	// Now use prompt=none with a specific nonce
 	codeVerifier2 := "code-verifier-two"
 	codeChallenge2 := oauth.GeneratePKCECodeChallenge(codeVerifier2)
-	requestState2 := gofakeit.LetterN(8)
-	testNonce := "test-nonce-" + gofakeit.LetterN(16)
+	requestState2 := fake.LetterN(8)
+	testNonce := "test-nonce-" + fake.LetterN(16)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1232,14 +1232,14 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 // TestPromptNone_PKCESupported verifies that PKCE works correctly with prompt=none
 // (success case - correct verifier).
 func TestPromptNone_PKCESupported(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:                        "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:                   clientSecretEncrypted,
 		Enabled:                                 true,
 		AuthorizationCodeEnabled:                true,
@@ -1263,7 +1263,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -1272,7 +1272,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -1283,7 +1283,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 	httpClient := createHttpClient(t)
 	codeVerifier := "initial-code-verifier"
 	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	// Create session via normal login
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1293,7 +1293,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 		"&code_challenge=" + codeChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	if err != nil {
@@ -1329,7 +1329,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 	// Now use prompt=none with a NEW PKCE code_challenge/verifier pair
 	pkceVerifier := "pkce-verifier-for-prompt-none-test"
 	pkceChallenge := oauth.GeneratePKCECodeChallenge(pkceVerifier)
-	requestState2 := gofakeit.LetterN(8)
+	requestState2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1338,7 +1338,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 		"&code_challenge=" + pkceChallenge +
 		"&scope=" + url.QueryEscape("openid profile") +
 		"&state=" + requestState2 +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp2, err := httpClient.Get(destUrl2)

--- a/src/authserver/tests/integration/authorize_prompt_validation_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_validation_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,8 +22,8 @@ func TestPromptNone_NoSession_ReturnsLoginRequired(t *testing.T) {
 	// Create fresh HTTP client (no session)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -64,9 +64,9 @@ func TestPromptNone_ValidSession_SilentCodeIssuance(t *testing.T) {
 	// Wait a bit to ensure different timestamps if auth_time was recalculated
 	time.Sleep(100 * time.Millisecond)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -129,9 +129,9 @@ func TestPromptLogin_WithSession_ForcesReAuth(t *testing.T) {
 	// Wait to ensure new auth_time will be different
 	time.Sleep(200 * time.Millisecond)
 
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -194,8 +194,8 @@ func TestPrompt_InvalidValue(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createAuthenticatedHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -224,8 +224,8 @@ func TestPrompt_ConflictNoneLogin(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -254,8 +254,8 @@ func TestPrompt_ConflictNoneConsent(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -284,8 +284,8 @@ func TestPrompt_ConflictNoneLoginConsent(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -313,8 +313,8 @@ func TestPrompt_CaseSensitivityUppercase(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createAuthenticatedHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -342,8 +342,8 @@ func TestPrompt_CaseSensitivityMixed(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createAuthenticatedHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -371,8 +371,8 @@ func TestPrompt_SelectAccountNotImplemented(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createAuthenticatedHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
@@ -400,8 +400,8 @@ func TestPrompt_EmptyParameter(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Empty prompt parameter should be treated as absent (normal flow)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -427,8 +427,8 @@ func TestPrompt_WhitespaceOnlyParameter(t *testing.T) {
 	client, redirectUri := createTestClientAndRedirectURI(t)
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// Whitespace-only prompt parameter should be treated as absent
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -454,8 +454,8 @@ func TestPrompt_UrlEncodedSpaces(t *testing.T) {
 	// With a valid session, "login consent" should work
 	httpClient, client, redirectUri, _, _ := createSessionWithAcrLevel1AndPassword(t)
 
-	requestState := gofakeit.LetterN(8)
-	requestCodeChallenge := gofakeit.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
 	// URL encoded "login consent" - this is valid and should trigger re-auth flow
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +

--- a/src/authserver/tests/integration/authorize_public_client_pkce_test.go
+++ b/src/authserver/tests/integration/authorize_public_client_pkce_test.go
@@ -5,13 +5,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +46,7 @@ func newPublicPKCEClient(t *testing.T, pkceRequired *bool) (*models.Client, stri
 	t.Helper()
 
 	client := &models.Client{
-		ClientIdentifier:         "public-pkce-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "public-pkce-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 true,
@@ -62,14 +62,14 @@ func newPublicPKCEClient(t *testing.T, pkceRequired *bool) (*models.Client, stri
 		URI:      redirectURI,
 	}))
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	require.NoError(t, database.CreateUser(nil, user))
@@ -84,8 +84,8 @@ func authorizeURLWithoutChallenge(clientIdentifier, redirectURI string) string {
 		"&redirect_uri=" + url.QueryEscape(redirectURI) +
 		"&response_type=code" +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 }
 
 // authorizeErrorFromLocation reads the error pair out of an emitted error redirect.
@@ -162,7 +162,7 @@ func TestAuthorize_PublicClient_NullColumnAndGlobalPKCEOff_IsStillRefused(t *tes
 // Without this row every assertion above is satisfied by a server that refuses public clients
 // outright, which is not what the mandate says.
 func TestAuthorize_PublicClient_WithPKCE_CompletesAndIssuesTokens(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email",
 		authCodeOptions{isPublic: true})
 
 	assert.True(t, code.Client.IsPublic, "the fixture must be a public client")
@@ -188,7 +188,7 @@ func TestAuthorize_PublicClient_WithPKCE_CompletesAndIssuesTokens(t *testing.T) 
 // is not about.
 func TestAuthorize_ConfidentialClient_PKCEOff_WithoutCodeChallenge_Succeeds(t *testing.T) {
 	pkceRequired := false
-	_, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
+	_, code := createAuthCode(t, fake.LetterN(32), "openid profile email",
 		authCodeOptions{noPKCE: true, pkceRequired: &pkceRequired})
 
 	assert.False(t, code.Client.IsPublic, "the fixture must be a confidential client")

--- a/src/authserver/tests/integration/authorize_registered_query_state_test.go
+++ b/src/authserver/tests/integration/authorize_registered_query_state_test.go
@@ -6,12 +6,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,10 +53,10 @@ func TestAuthorize_RegisteredQuery_SuccessRedirectCarriesOneState(t *testing.T) 
 		"&redirect_uri=" + url.QueryEscape(registeredQueryRedirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
 		"&state=" + url.QueryEscape(registeredQueryState) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	httpClient := createHttpClient(t)
 
@@ -117,10 +117,10 @@ func TestAuthorize_RegisteredQuery_ErrorRedirectCarriesOneState(t *testing.T) {
 		"&redirect_uri=" + url.QueryEscape(registeredQueryRedirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
 		"&state=" + url.QueryEscape(registeredQueryState) +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	// A fresh cookie jar, so this request carries no session and the silent authentication cannot
@@ -150,7 +150,7 @@ func TestAuthorize_RegisteredQuery_ErrorRedirectCarriesOneState(t *testing.T) {
 // because this file is its only reader.
 func newRegisteredQueryClient(t *testing.T) (*models.Client, *models.User, string) {
 	client := &models.Client{
-		ClientIdentifier:         "registered-query-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "registered-query-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -165,14 +165,14 @@ func newRegisteredQueryClient(t *testing.T) (*models.Client, *models.User, strin
 	})
 	require.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)

--- a/src/authserver/tests/integration/authorize_request_scope_validation_test.go
+++ b/src/authserver/tests/integration/authorize_request_scope_validation_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthorize_ValidateRequest_ResponseTypeIsMissing(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -28,7 +28,7 @@ func TestAuthorize_ValidateRequest_ResponseTypeIsMissing(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -62,7 +62,7 @@ func TestAuthorize_ValidateRequest_ResponseTypeIsMissing(t *testing.T) {
 
 func TestAuthorize_ValidateRequest_ResponseTypeIsInvalid(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -74,7 +74,7 @@ func TestAuthorize_ValidateRequest_ResponseTypeIsInvalid(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -109,7 +109,7 @@ func TestAuthorize_ValidateRequest_ResponseTypeIsInvalid(t *testing.T) {
 func TestAuthorize_ValidateRequest_CodeChallengeMethodIsMissing(t *testing.T) {
 	pkceRequired := true
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		PKCERequired:             &pkceRequired,
@@ -122,7 +122,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeMethodIsMissing(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -157,7 +157,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeMethodIsMissing(t *testing.T) {
 func TestAuthorize_ValidateRequest_CodeChallengeMethodIsInvalid(t *testing.T) {
 	pkceRequired := true
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		PKCERequired:             &pkceRequired,
@@ -170,7 +170,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeMethodIsInvalid(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -205,7 +205,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeMethodIsInvalid(t *testing.T) {
 func TestAuthorize_ValidateRequest_CodeChallengeIsMissing(t *testing.T) {
 	pkceRequired := true
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		PKCERequired:             &pkceRequired,
@@ -218,7 +218,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeIsMissing(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -255,16 +255,16 @@ func TestAuthorize_ValidateRequest_CodeChallengeInvalid(t *testing.T) {
 		codeChallenge string
 	}{
 		// less than 43
-		{codeChallenge: gofakeit.LetterN(42)},
+		{codeChallenge: fake.LetterN(42)},
 
 		// more than 128
-		{codeChallenge: gofakeit.LetterN(129)},
+		{codeChallenge: fake.LetterN(129)},
 	}
 
 	for _, testCase := range testCases {
 		pkceRequired := true
 		client := &models.Client{
-			ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+			ClientIdentifier:         "test-client-" + fake.LetterN(8),
 			Enabled:                  true,
 			AuthorizationCodeEnabled: true,
 			PKCERequired:             &pkceRequired,
@@ -277,7 +277,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeInvalid(t *testing.T) {
 
 		redirectUri := &models.RedirectURI{
 			ClientId: client.Id,
-			URI:      gofakeit.URL(),
+			URI:      fake.URL(),
 		}
 
 		err = database.CreateRedirectURI(nil, redirectUri)
@@ -324,7 +324,7 @@ func TestAuthorize_ValidateRequest_CodeChallengeInvalid(t *testing.T) {
 // withdrawn from this failure altogether, for every request, not postponed.
 func TestAuthorize_ValidateRequest_InvalidResponseMode(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -336,7 +336,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -348,7 +348,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode(t *testing.T) {
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=invalid"
 
 	httpClient := createAuthenticatedHttpClient(t)
@@ -383,7 +383,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode(t *testing.T) {
 // to /auth/level1 would mean the error was parked instead of answered.
 func TestAuthorize_ValidateRequest_InvalidResponseMode_NoSessionIsNotAskedToLogIn(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -395,7 +395,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_NoSessionIsNotAskedToLogI
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -407,7 +407,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_NoSessionIsNotAskedToLogI
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=invalid"
 
 	// Cookieless: no session, and no prompt parameter, which is the combination every other
@@ -442,7 +442,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_NoSessionIsNotAskedToLogI
 // TestAuthorize_ValidateClientAndRedirectURI_RendersInTheRequestedLocale already owns it.
 func TestAuthorize_ValidateRequest_InvalidResponseMode_RendersInTheRequestedLocale(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -454,7 +454,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_RendersInTheRequestedLoca
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -466,7 +466,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_RendersInTheRequestedLoca
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=invalid" +
 		"&ui_locales=pt-BR"
 
@@ -492,7 +492,7 @@ func TestAuthorize_ValidateRequest_InvalidResponseMode_RendersInTheRequestedLoca
 
 func TestAuthorize_ValidateRequest_QueryResponseMode(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -504,7 +504,7 @@ func TestAuthorize_ValidateRequest_QueryResponseMode(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -516,7 +516,7 @@ func TestAuthorize_ValidateRequest_QueryResponseMode(t *testing.T) {
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=query" +
 		"&scope=invalid_scope" // to prevent full authorize execution
 
@@ -544,7 +544,7 @@ func TestAuthorize_ValidateRequest_QueryResponseMode(t *testing.T) {
 
 func TestAuthorize_ValidateRequest_FragmentResponseMode(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -556,7 +556,7 @@ func TestAuthorize_ValidateRequest_FragmentResponseMode(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -568,7 +568,7 @@ func TestAuthorize_ValidateRequest_FragmentResponseMode(t *testing.T) {
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=fragment" +
 		"&scope=invalid_scope" // to prevent full authorize execution
 
@@ -597,7 +597,7 @@ func TestAuthorize_ValidateRequest_FragmentResponseMode(t *testing.T) {
 
 func TestAuthorize_ValidateRequest_FormPostResponseMode(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -609,7 +609,7 @@ func TestAuthorize_ValidateRequest_FormPostResponseMode(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -621,7 +621,7 @@ func TestAuthorize_ValidateRequest_FormPostResponseMode(t *testing.T) {
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=form_post" +
 		"&scope=invalid_scope" // to prevent full authorize execution
 
@@ -653,7 +653,7 @@ func TestAuthorize_ValidateRequest_FormPostResponseMode(t *testing.T) {
 
 func TestAuthorize_ValidateScopes_ScopeIsMissing(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -665,7 +665,7 @@ func TestAuthorize_ValidateScopes_ScopeIsMissing(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -677,7 +677,7 @@ func TestAuthorize_ValidateScopes_ScopeIsMissing(t *testing.T) {
 		"&redirect_uri=" + redirectUri.URI +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43)
+		"&code_challenge=" + fake.LetterN(43)
 
 	httpClient := createAuthenticatedHttpClient(t)
 
@@ -702,7 +702,7 @@ func TestAuthorize_ValidateScopes_ScopeIsMissing(t *testing.T) {
 
 func TestAuthorize_ValidateScopes_UserInfoShouldNotBeIncluded(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -714,7 +714,7 @@ func TestAuthorize_ValidateScopes_UserInfoShouldNotBeIncluded(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -730,7 +730,7 @@ func TestAuthorize_ValidateScopes_UserInfoShouldNotBeIncluded(t *testing.T) {
 	params.Add("redirect_uri", redirectUri.URI)
 	params.Add("response_type", "code")
 	params.Add("code_challenge_method", "S256")
-	params.Add("code_challenge", gofakeit.LetterN(43))
+	params.Add("code_challenge", fake.LetterN(43))
 	params.Add("scope", "openid profile "+userInfoScope)
 
 	destUrl := baseUrl + "?" + params.Encode()
@@ -759,7 +759,7 @@ func TestAuthorize_ValidateScopes_UserInfoShouldNotBeIncluded(t *testing.T) {
 
 func TestAuthorize_ValidateScopes_InvalidScope(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -771,7 +771,7 @@ func TestAuthorize_ValidateScopes_InvalidScope(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -799,7 +799,7 @@ func TestAuthorize_ValidateScopes_InvalidScope(t *testing.T) {
 				"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 				"&response_type=code" +
 				"&code_challenge_method=S256" +
-				"&code_challenge=" + gofakeit.LetterN(43) +
+				"&code_challenge=" + fake.LetterN(43) +
 				"&scope=" + url.QueryEscape(tc.scope)
 
 			httpClient := createAuthenticatedHttpClient(t)
@@ -828,7 +828,7 @@ func TestAuthorize_ValidateScopes_InvalidScope(t *testing.T) {
 
 func TestAuthorize_ValidateScopes_ResourceDoesNotExist(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -840,7 +840,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotExist(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -855,7 +855,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotExist(t *testing.T) {
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(scope)
 
 	httpClient := createAuthenticatedHttpClient(t)
@@ -882,7 +882,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotExist(t *testing.T) {
 
 func TestAuthorize_ValidateScopes_ResourceDoesNotHavePermissionAssociated(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -894,7 +894,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotHavePermissionAssociated(t *tes
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -903,7 +903,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotHavePermissionAssociated(t *tes
 	}
 
 	resource := &models.Resource{
-		ResourceIdentifier: "test-resource-" + gofakeit.LetterN(8),
+		ResourceIdentifier: "test-resource-" + fake.LetterN(8),
 		Description:        "Test Resource",
 	}
 
@@ -919,7 +919,7 @@ func TestAuthorize_ValidateScopes_ResourceDoesNotHavePermissionAssociated(t *tes
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(scope)
 
 	httpClient := createAuthenticatedHttpClient(t)
@@ -969,7 +969,7 @@ func TestAuthorize_ValidateScopes_EmojiScope_FormPostDescriptionIsConformed(t *t
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&response_mode=form_post" +
 		"&scope=" + url.QueryEscape("emoji💣scope")
 

--- a/src/authserver/tests/integration/authorize_revalidate_at_issuance_test.go
+++ b/src/authserver/tests/integration/authorize_revalidate_at_issuance_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -15,6 +14,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,7 +62,7 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "revalidate-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "revalidate-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		// The consent screen is what holds the ceremony still between /auth/completed and
@@ -74,18 +74,18 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 	err = database.CreateClient(nil, client)
 	assert.NoError(t, err)
 
-	redirectURI := &models.RedirectURI{ClientId: client.Id, URI: gofakeit.URL()}
+	redirectURI := &models.RedirectURI{ClientId: client.Id, URI: fake.URL()}
 	err = database.CreateRedirectURI(nil, redirectURI)
 	assert.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 10)
+	password := fake.Password(10)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -116,7 +116,7 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 	// rather than two.
 	httpClient := createHttpClient(t)
 
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectURI.URI) +
 		"&response_type=code" +
@@ -124,7 +124,7 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape(requestScope) +
 		"&state=" + state +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	assert.NoError(t, err)
@@ -173,7 +173,7 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 // only the idle timeout refuses. Before #241 this yielded a usable code, the access token worked,
 // and the first refresh answered invalid_grant.
 func TestSessionExpiredOnConsentScreen_NoCodeIsIssued(t *testing.T) {
-	parked := parkOnConsentScreen(t, "openid profile email", gofakeit.LetterN(32), "code-verifier", nil)
+	parked := parkOnConsentScreen(t, "openid profile email", fake.LetterN(32), "code-verifier", nil)
 	defer func() { _ = parked.consentPage.Body.Close() }()
 
 	sessions, err := database.GetUserSessionsByUserId(nil, parked.user.Id)
@@ -226,7 +226,7 @@ func TestPermissionRevokedOnConsentScreen_TokenLosesTheScope(t *testing.T) {
 	readScope := resource.ResourceIdentifier + ":" + readPermission.PermissionIdentifier
 	writeScope := resource.ResourceIdentifier + ":" + writePermission.PermissionIdentifier
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	parked := parkOnConsentScreen(t, "openid profile "+readScope+" "+writeScope,
 		clientSecret, "code-verifier", []string{readScope, writeScope})
 	defer func() { _ = parked.consentPage.Body.Close() }()
@@ -293,7 +293,7 @@ func TestPermissionRevokedOnConsentScreen_TokenLosesTheScope(t *testing.T) {
 // redirect would be as wrong as a code (RFC 9700 section 4.11.2). The refusal is therefore
 // rendered locally, on the page the error emitter already withholds a redirect through.
 func TestRedirectURIDeletedOnConsentScreen_NothingIsDelivered(t *testing.T) {
-	parked := parkOnConsentScreen(t, "openid profile email", gofakeit.LetterN(32), "code-verifier", nil)
+	parked := parkOnConsentScreen(t, "openid profile email", fake.LetterN(32), "code-verifier", nil)
 	defer func() { _ = parked.consentPage.Body.Close() }()
 
 	resp := postConsent(t, parked.httpClient, parked.consentURL, parked.consentPage, []int{0, 1, 2, 3, 4})
@@ -357,7 +357,7 @@ func TestRedirectURIDeletedOnConsentScreen_NothingIsDelivered(t *testing.T) {
 // The two cases together are the property: whatever a ceremony in progress has to say to a client,
 // it says nothing at all to a callback the client no longer has.
 func TestRedirectURIDeletedOnConsentScreen_CancelIsNotDeliveredEither(t *testing.T) {
-	parked := parkOnConsentScreen(t, "openid profile email", gofakeit.LetterN(32), "code-verifier", nil)
+	parked := parkOnConsentScreen(t, "openid profile email", fake.LetterN(32), "code-verifier", nil)
 	defer func() { _ = parked.consentPage.Body.Close() }()
 
 	// The window opens before the submission here rather than after it, because this refusal is
@@ -409,7 +409,7 @@ func TestPermissionRevokedBeforeConsentSubmission_ConsentRecordNeverHasIt(t *tes
 	readScope := resource.ResourceIdentifier + ":" + readPermission.PermissionIdentifier
 	writeScope := resource.ResourceIdentifier + ":" + writePermission.PermissionIdentifier
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	parked := parkOnConsentScreen(t, "openid profile "+readScope+" "+writeScope,
 		clientSecret, "code-verifier", []string{readScope, writeScope})
 	defer func() { _ = parked.consentPage.Body.Close() }()

--- a/src/authserver/tests/integration/authorize_unsupported_request_params_test.go
+++ b/src/authserver/tests/integration/authorize_unsupported_request_params_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +17,7 @@ func createTestClientWithRedirect(t *testing.T) (*models.Client, *models.Redirec
 	t.Helper()
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 	}
@@ -27,7 +27,7 @@ func createTestClientWithRedirect(t *testing.T) (*models.Client, *models.Redirec
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	if err := database.CreateRedirectURI(nil, redirectUri); err != nil {
 		t.Fatal(err)
@@ -39,7 +39,7 @@ func createTestClientWithRedirect(t *testing.T) (*models.Client, *models.Redirec
 func TestAuthorize_RequestParameter_RejectedAsUnsupported(t *testing.T) {
 	client, redirectUri := createTestClientWithRedirect(t)
 
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 
 	params := url.Values{}
 	params.Set("client_id", client.ClientIdentifier)
@@ -102,7 +102,7 @@ func TestAuthorize_RequestParameter_EmptyValue_RejectedAsUnsupported(t *testing.
 func TestAuthorize_RequestUriParameter_RejectedAsUnsupported(t *testing.T) {
 	client, redirectUri := createTestClientWithRedirect(t)
 
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 
 	params := url.Values{}
 	params.Set("client_id", client.ClientIdentifier)
@@ -141,7 +141,7 @@ func TestAuthorize_RequestParameter_PostBody_RejectedAsUnsupported(t *testing.T)
 	form.Set("redirect_uri", redirectUri.URI)
 	form.Set("response_type", "code")
 	form.Set("scope", "openid")
-	form.Set("state", gofakeit.LetterN(8))
+	form.Set("state", fake.LetterN(8))
 	form.Set("request", "some.jwt.value")
 
 	destURL := config.GetAuthServer().BaseURL + "/auth/authorize"
@@ -203,7 +203,7 @@ func TestAuthorize_RequestParameter_InvalidClient_RendersErrorUi(t *testing.T) {
 func TestAuthorize_RequestParameter_RejectedAcrossResponseModes(t *testing.T) {
 	t.Run("query response mode", func(t *testing.T) {
 		client, redirectUri := createTestClientWithRedirect(t)
-		state := gofakeit.LetterN(8)
+		state := fake.LetterN(8)
 
 		params := url.Values{}
 		params.Set("client_id", client.ClientIdentifier)
@@ -235,7 +235,7 @@ func TestAuthorize_RequestParameter_RejectedAcrossResponseModes(t *testing.T) {
 
 	t.Run("fragment response mode", func(t *testing.T) {
 		client, redirectUri := createTestClientWithRedirect(t)
-		state := gofakeit.LetterN(8)
+		state := fake.LetterN(8)
 
 		params := url.Values{}
 		params.Set("client_id", client.ClientIdentifier)
@@ -269,7 +269,7 @@ func TestAuthorize_RequestParameter_RejectedAcrossResponseModes(t *testing.T) {
 
 	t.Run("form_post response mode", func(t *testing.T) {
 		client, redirectUri := createTestClientWithRedirect(t)
-		state := gofakeit.LetterN(8)
+		state := fake.LetterN(8)
 
 		params := url.Values{}
 		params.Set("client_id", client.ClientIdentifier)
@@ -310,7 +310,7 @@ func TestAuthorize_RequestUriParameter_RejectedAcrossResponseModes(t *testing.T)
 	// we exercise fragment mode since query is already covered by the
 	// non-matrix request_uri test above.
 	client, redirectUri := createTestClientWithRedirect(t)
-	state := gofakeit.LetterN(8)
+	state := fake.LetterN(8)
 
 	params := url.Values{}
 	params.Set("client_id", client.ClientIdentifier)

--- a/src/authserver/tests/integration/browser_session_test.go
+++ b/src/authserver/tests/integration/browser_session_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -16,6 +15,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/sessionstore"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -376,14 +376,14 @@ func newLevel1Actors(t *testing.T) (*models.Client, *models.RedirectURI, *models
 
 	client, redirectUri := newClientAndRedirectUri(t, enums.AcrLevel1)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	require.NoError(t, database.CreateUser(nil, user))
@@ -395,7 +395,7 @@ func newClientAndRedirectUri(t *testing.T, acrLevel enums.AcrLevel) (*models.Cli
 	t.Helper()
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -403,7 +403,7 @@ func newClientAndRedirectUri(t *testing.T, acrLevel enums.AcrLevel) (*models.Cli
 	}
 	require.NoError(t, database.CreateClient(nil, client))
 
-	redirectUri := &models.RedirectURI{ClientId: client.Id, URI: gofakeit.URL()}
+	redirectUri := &models.RedirectURI{ClientId: client.Id, URI: fake.URL()}
 	require.NoError(t, database.CreateRedirectURI(nil, redirectUri))
 
 	return client, redirectUri
@@ -417,10 +417,10 @@ func beginAuthorize(t *testing.T, httpClient *http.Client,
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	require.NoError(t, err)

--- a/src/authserver/tests/integration/cache_directives_test.go
+++ b/src/authserver/tests/integration/cache_directives_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +42,7 @@ func TestCacheDirectives_ThePasswordFormIsNotStorable(t *testing.T) {
 	httpClient := createHttpClient(t)
 
 	resp := loadPage(t, httpClient,
-		authorizeUrlFor(client, redirectUri, "openid profile email", gofakeit.LetterN(8)))
+		authorizeUrlFor(client, redirectUri, "openid profile email", fake.LetterN(8)))
 	redirectLocation := assertRedirect(t, resp, "/auth/level1")
 	_ = resp.Body.Close()
 

--- a/src/authserver/tests/integration/consent_client_display_test.go
+++ b/src/authserver/tests/integration/consent_client_display_test.go
@@ -3,18 +3,18 @@ package integrationtests
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConsent_ClientDisplay_ShowDisplayName(t *testing.T) {
 	// Create client with display name enabled and consent required
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		ShowDisplayName:  true,
 		ShowLogo:         false,
@@ -26,20 +26,20 @@ func TestConsent_ClientDisplay_ShowDisplayName(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -63,7 +63,7 @@ func TestConsent_ClientDisplay_ShowDisplayName(t *testing.T) {
 func TestConsent_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 	// Create client with logo enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		ShowLogo:         true,
 		UploadLogo:       true,
 		ShowDisplayName:  false,
@@ -75,20 +75,20 @@ func TestConsent_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -112,7 +112,7 @@ func TestConsent_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 func TestConsent_ClientDisplay_ShowDescription(t *testing.T) {
 	// Create client with description enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		Description:      "The best app for testing OAuth flows",
 		ShowDescription:  true,
 		ShowLogo:         false,
@@ -124,20 +124,20 @@ func TestConsent_ClientDisplay_ShowDescription(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -161,7 +161,7 @@ func TestConsent_ClientDisplay_ShowDescription(t *testing.T) {
 func TestConsent_ClientDisplay_AllEnabled(t *testing.T) {
 	// Create client with all display settings enabled
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
-		ClientIdentifier: "test-app-" + gofakeit.LetterN(8),
+		ClientIdentifier: "test-app-" + fake.LetterN(8),
 		DisplayName:      "My Awesome Application",
 		Description:      "The best app for testing OAuth flows",
 		WebsiteURL:       "https://example.com",
@@ -176,20 +176,20 @@ func TestConsent_ClientDisplay_AllEnabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -212,7 +212,7 @@ func TestConsent_ClientDisplay_AllEnabled(t *testing.T) {
 
 func TestConsent_ClientDisplay_AllDisabled(t *testing.T) {
 	// Create client with all display settings disabled
-	clientId := "test-app-" + gofakeit.LetterN(8)
+	clientId := "test-app-" + fake.LetterN(8)
 	client := createClientWithDisplaySettings(t, ClientDisplaySettings{
 		ClientIdentifier: clientId,
 		DisplayName:      "My Awesome Application",
@@ -229,20 +229,20 @@ func TestConsent_ClientDisplay_AllDisabled(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err := database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)

--- a/src/authserver/tests/integration/credential_change_revocation_test.go
+++ b/src/authserver/tests/integration/credential_change_revocation_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/authserver/internal/handlers"
@@ -21,6 +20,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,7 +96,7 @@ func (g *offlineGrant) codeFromSameSession(t *testing.T, scope string, codeVerif
 		"&response_type=code&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape(scope) +
-		"&state=" + gofakeit.LetterN(8) + "&nonce=" + gofakeit.LetterN(8) +
+		"&state=" + fake.LetterN(8) + "&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp, err := g.httpClient.Get(destURL)
@@ -138,7 +138,7 @@ func secondSessionFor(t *testing.T, grant *offlineGrant, password string) (strin
 		"&response_type=code&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape(scope) +
-		"&state=" + gofakeit.LetterN(8) + "&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) + "&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destURL)
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func secondOfflineGrantForSameUser(t *testing.T, base *offlineGrant, password st
 		"&response_type=code&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape(scope) +
-		"&state=" + gofakeit.LetterN(8) + "&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) + "&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destURL)
 	require.NoError(t, err)
@@ -316,12 +316,12 @@ func (g *offlineGrant) exchange(t *testing.T, code string, codeVerifier string) 
 func createOfflineGrant(t *testing.T) *offlineGrant {
 	t.Helper()
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	require.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "revoke-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "revoke-client-" + fake.LetterN(8),
 		ClientSecretEncrypted:    clientSecretEncrypted,
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
@@ -340,14 +340,14 @@ func createOfflineGrant(t *testing.T) *offlineGrant {
 	redirectURI := &models.RedirectURI{ClientId: client.Id, URI: "https://example.com/callback"}
 	require.NoError(t, database.CreateRedirectURI(nil, redirectURI))
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        strings.ToLower(gofakeit.LetterN(12)) + "@example.com",
+		Email:        strings.ToLower(fake.LetterN(12)) + "@example.com",
 		PasswordHash: passwordHashed,
 	}
 	require.NoError(t, database.CreateUser(nil, user))
@@ -380,8 +380,8 @@ func createOfflineGrant(t *testing.T) *offlineGrant {
 		"&code_challenge_method=S256" +
 		"&code_challenge=" + codeChallenge +
 		"&scope=" + url.QueryEscape(scope) +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destURL)
 	require.NoError(t, err)
@@ -481,7 +481,7 @@ func (g *offlineGrant) refresh(t *testing.T) map[string]interface{} {
 func resetPasswordFor(t *testing.T, user *models.User, newPassword string) {
 	t.Helper()
 
-	code := gofakeit.LetterN(32)
+	code := fake.LetterN(32)
 	encrypted, err := encryption.EncryptData(code)
 	require.NoError(t, err)
 	codeHash, err := hashutil.HashString(code)

--- a/src/authserver/tests/integration/dcr_consent_test.go
+++ b/src/authserver/tests/integration/dcr_consent_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +33,10 @@ func followAuthChain(t *testing.T, httpClient *http.Client, clientIdentifier str
 		"&redirect_uri=" + url.QueryEscape(redirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(authorizeURL)
 	require.NoError(t, err)

--- a/src/authserver/tests/integration/dcr_refusal_redirect_test.go
+++ b/src/authserver/tests/integration/dcr_refusal_redirect_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -190,7 +190,7 @@ func TestDCR_Refusal_SilentRequestIsNotDeliveredByRedirect(t *testing.T) {
 	httpClient := createHttpClient(t)
 
 	resp, err := httpClient.Get(authorizeURLWithScope(client.ClientIdentifier, redirectURI,
-		"openid nonsense", gofakeit.LetterN(8)) + "&prompt=none")
+		"openid nonsense", fake.LetterN(8)) + "&prompt=none")
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
@@ -208,7 +208,7 @@ func TestDCR_Refusal_SilentAdministratorClientStillRedirects(t *testing.T) {
 	client, redirectUri := createConsentClient(t)
 
 	httpClient := createHttpClient(t)
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	resp, err := httpClient.Get(authorizeURLWithScope(client.ClientIdentifier, redirectUri.URI,
 		"openid nonsense", requestState) + "&prompt=none")
@@ -227,14 +227,14 @@ func TestDCR_Refusal_SilentAdministratorClientStillRedirects(t *testing.T) {
 // caller puts in the scope.
 func authorizeURLWithScope(clientIdentifier string, redirectURI string, scope string, state string) string {
 	if state == "" {
-		state = gofakeit.LetterN(8)
+		state = fake.LetterN(8)
 	}
 	return config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + clientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectURI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape(scope) +
 		"&state=" + state +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 }

--- a/src/authserver/tests/integration/implicit_flow_test.go
+++ b/src/authserver/tests/integration/implicit_flow_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +60,7 @@ func getErrorFromFragment(t *testing.T, resp *http.Response) (errorCode string, 
 // createImplicitFlowClient creates a client configured for implicit flow
 func createImplicitFlowClient(t *testing.T, implicitEnabled *bool) (*models.Client, *models.RedirectURI) {
 	client := &models.Client{
-		ClientIdentifier:         "implicit-test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "implicit-test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: false, // Disable auth code to test implicit-only
 		ImplicitGrantEnabled:     implicitEnabled,
@@ -88,7 +88,7 @@ func createImplicitFlowClient(t *testing.T, implicitEnabled *bool) (*models.Clie
 
 // createTestUser creates a user for testing
 func createTestUserForImplicit(t *testing.T) (*models.User, string) {
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func createTestUserForImplicit(t *testing.T) (*models.User, string) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -126,7 +126,7 @@ func TestImplicitFlow_TokenResponseType(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 	requestScope := "openid"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -203,8 +203,8 @@ func TestImplicitFlow_IdTokenResponseType(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(16) // Required for id_token
+	requestState := fake.LetterN(16)
+	requestNonce := fake.LetterN(16) // Required for id_token
 	requestScope := "openid"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -287,8 +287,8 @@ func TestImplicitFlow_IdTokenTokenResponseType(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
+	requestNonce := fake.LetterN(16)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -369,7 +369,7 @@ func TestImplicitFlow_Disabled_GlobalSetting(t *testing.T) {
 
 	client, redirectUri := createImplicitFlowClient(t, nil) // nil means inherit from global
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -413,7 +413,7 @@ func TestImplicitFlow_ClientOverride_Enabled(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, &implicitEnabled)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -476,7 +476,7 @@ func TestImplicitFlow_ClientOverride_Disabled(t *testing.T) {
 	implicitDisabled := false
 	client, redirectUri := createImplicitFlowClient(t, &implicitDisabled)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -514,7 +514,7 @@ func TestImplicitFlow_MissingNonce_IdToken(t *testing.T) {
 
 	client, redirectUri := createImplicitFlowClient(t, nil)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	// No nonce parameter
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -553,8 +553,8 @@ func TestImplicitFlow_MissingOpenIdScope_IdToken(t *testing.T) {
 
 	client, redirectUri := createImplicitFlowClient(t, nil)
 
-	requestState := gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
+	requestNonce := fake.LetterN(16)
 
 	// No openid scope
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -594,7 +594,7 @@ func TestImplicitFlow_UnsupportedResponseType_HybridFlow(t *testing.T) {
 
 	// Create a client with both auth code and implicit enabled
 	client := &models.Client{
-		ClientIdentifier:         "hybrid-test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "hybrid-test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ImplicitGrantEnabled:     nil,
@@ -611,7 +611,7 @@ func TestImplicitFlow_UnsupportedResponseType_HybridFlow(t *testing.T) {
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	// Try hybrid flow: code token
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -655,7 +655,7 @@ func TestImplicitFlow_ValidateAccessToken(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 	requestScope := "openid profile"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -742,7 +742,7 @@ func TestImplicitFlow_ErrorInFragment(t *testing.T) {
 
 	client, redirectUri := createImplicitFlowClient(t, nil)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	// Missing openid scope for id_token - should return error in fragment
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -792,7 +792,7 @@ func TestImplicitFlow_WithResourcePermissions(t *testing.T) {
 
 	// Create client with consent required
 	client := &models.Client{
-		ClientIdentifier:         "implicit-consent-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "implicit-consent-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: false,
 		ImplicitGrantEnabled:     nil,
@@ -816,7 +816,7 @@ func TestImplicitFlow_WithResourcePermissions(t *testing.T) {
 	permission := createPermission(t, resource.Id)
 	assignPermissionToUser(t, user.Id, permission.Id)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 	// Include resource permission in scope
 	requestScope := "openid profile " + resource.ResourceIdentifier + ":" + permission.PermissionIdentifier
 
@@ -890,8 +890,8 @@ func TestImplicitFlow_AtHashValidation(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
+	requestNonce := fake.LetterN(16)
 	requestScope := "openid"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -984,8 +984,8 @@ func TestImplicitFlow_NoRefreshTokenInResponse(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
-	requestNonce := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
+	requestNonce := fake.LetterN(16)
 	// Request multiple scopes to verify no refresh token is issued
 	requestScope := "openid profile email"
 
@@ -1187,8 +1187,8 @@ func TestImplicitFlow_NonceInIdToken(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestNonce := "unique-nonce-" + gofakeit.LetterN(16)
-	requestState := gofakeit.LetterN(16)
+	requestNonce := "unique-nonce-" + fake.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1258,8 +1258,8 @@ func TestImplicitFlow_AudienceInTokens(t *testing.T) {
 	client, redirectUri := createImplicitFlowClient(t, nil)
 	user, password := createTestUserForImplicit(t)
 
-	requestNonce := gofakeit.LetterN(16)
-	requestState := gofakeit.LetterN(16)
+	requestNonce := fake.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1336,7 +1336,7 @@ func TestImplicitFlow_AuthCodeFlowClient_CanAlsoUseImplicit(t *testing.T) {
 
 	// Create client with BOTH auth code AND implicit enabled
 	client := &models.Client{
-		ClientIdentifier:         "both-flows-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "both-flows-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true, // Auth code enabled
 		ImplicitGrantEnabled:     nil,  // Inherit from global (enabled)
@@ -1355,7 +1355,7 @@ func TestImplicitFlow_AuthCodeFlowClient_CanAlsoUseImplicit(t *testing.T) {
 
 	user, password := createTestUserForImplicit(t)
 
-	requestState := gofakeit.LetterN(16)
+	requestState := fake.LetterN(16)
 
 	// Use implicit flow with this client
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/authserver/tests/integration/reset_password_flow_test.go
+++ b/src/authserver/tests/integration/reset_password_flow_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,7 +40,7 @@ import (
 // reports as broken: Go parses a query with form-urlencoded rules, where '+' decodes to a
 // space, so the address came back mangled and the lookup failed.
 func plusAddress() string {
-	return "reset+tag." + strings.ToLower(gofakeit.LetterN(10)) + "@example.com"
+	return "reset+tag." + strings.ToLower(fake.LetterN(10)) + "@example.com"
 }
 
 // useMailpitSMTP points the deployment's SMTP settings at mailpit for the duration of a test
@@ -74,7 +74,7 @@ func useMailpitSMTP(t *testing.T) func() {
 func createResetTestUser(t *testing.T, email string) (*models.User, string) {
 	t.Helper()
 
-	password := gofakeit.Password(true, true, true, true, false, 12) + "aA1!"
+	password := fake.Password(12) + "aA1!"
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 

--- a/src/authserver/tests/integration/ropc_flow_test.go
+++ b/src/authserver/tests/integration/ropc_flow_test.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -12,6 +11,7 @@ import (
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/leodip/goiabada/core/validators"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +20,7 @@ import (
 func createROPCClient(t *testing.T, clientSecret string, isPublic bool) *models.Client {
 	ropcEnabled := true
 	client := &models.Client{
-		ClientIdentifier: "ropc-client-" + gofakeit.LetterN(8),
+		ClientIdentifier: "ropc-client-" + fake.LetterN(8),
 		Enabled:          true,
 		IsPublic:         isPublic,
 		// Off deliberately, so this is an ROPC-ONLY client. With the authorization code flow
@@ -45,7 +45,7 @@ func createROPCClient(t *testing.T, clientSecret string, isPublic bool) *models.
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.Nil(t, err)
@@ -61,10 +61,10 @@ func createROPCUser(t *testing.T, password string) *models.User {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
-		GivenName:    gofakeit.FirstName(),
-		FamilyName:   gofakeit.LastName(),
+		GivenName:    fake.FirstName(),
+		FamilyName:   fake.LastName(),
 	}
 
 	err = database.CreateUser(nil, user)
@@ -88,7 +88,7 @@ func TestROPC_Success(t *testing.T) {
 	}()
 
 	// Create client and user
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true) // public client
 	user := createROPCUser(t, password)
 
@@ -128,8 +128,8 @@ func TestROPC_ConfidentialClient(t *testing.T) {
 	}()
 
 	// Create confidential client and user
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false) // confidential client
 	user := createROPCUser(t, password)
 
@@ -169,9 +169,9 @@ func TestROPC_GlobalDisabled(t *testing.T) {
 	}()
 
 	// Create client with ROPC set to nil (follows global setting) and user
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := &models.Client{
-		ClientIdentifier:                        "ropc-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "ropc-client-" + fake.LetterN(8),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -217,7 +217,7 @@ func TestROPC_ClientOverrideDisabled(t *testing.T) {
 	// Create client with ROPC disabled at client level
 	ropcDisabled := false
 	client := &models.Client{
-		ClientIdentifier:                        "ropc-disabled-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:                        "ropc-disabled-client-" + fake.LetterN(8),
 		Enabled:                                 true,
 		IsPublic:                                true,
 		AuthorizationCodeEnabled:                true,
@@ -227,7 +227,7 @@ func TestROPC_ClientOverrideDisabled(t *testing.T) {
 	err = database.CreateClient(nil, client)
 	assert.Nil(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	user := createROPCUser(t, password)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -327,7 +327,7 @@ func TestROPC_InvalidCredentials(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true)
 	user := createROPCUser(t, password)
 
@@ -397,7 +397,7 @@ func TestROPC_DisabledUser(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true)
 
 	// Create disabled user
@@ -406,7 +406,7 @@ func TestROPC_DisabledUser(t *testing.T) {
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      false, // Disabled
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -443,7 +443,7 @@ func TestROPC_WithOfflineAccess(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true)
 	user := createROPCUser(t, password)
 
@@ -487,8 +487,8 @@ func TestROPC_ConfidentialClient_MissingSecret(t *testing.T) {
 	}()
 
 	// Create confidential client
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false) // confidential client
 	user := createROPCUser(t, password)
 
@@ -526,8 +526,8 @@ func TestROPC_ConfidentialClient_InvalidSecret(t *testing.T) {
 	}()
 
 	// Create confidential client
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false)
 	user := createROPCUser(t, password)
 
@@ -565,7 +565,7 @@ func TestROPC_UserWith2FAEnabled(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true)
 
 	// Create user with 2FA (OTP) enabled
@@ -574,7 +574,7 @@ func TestROPC_UserWith2FAEnabled(t *testing.T) {
 	user := &models.User{
 		Subject:            uuid.New(),
 		Enabled:            true,
-		Email:              gofakeit.Email(),
+		Email:              fake.Email(),
 		PasswordHash:       passwordHashed,
 		OTPEnabled:         true,               // 2FA enabled
 		OTPSecret:          "JBSWY3DPEHPK3PXP", // Dummy OTP secret
@@ -617,10 +617,10 @@ func TestROPC_WithResourcePermissions(t *testing.T) {
 	}()
 
 	// Create resource and permission
-	resource := createResourceWithId(t, "testapi-"+gofakeit.LetterN(8))
+	resource := createResourceWithId(t, "testapi-"+fake.LetterN(8))
 	permission := createPermissionWithId(t, resource.Id, "read")
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	client := createROPCClient(t, "", true)
 	user := createROPCUser(t, password)
 
@@ -675,8 +675,8 @@ func TestROPC_RefreshToken_OpenIdOnly(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false)
 	user := createROPCUser(t, password)
 
@@ -802,8 +802,8 @@ func TestROPC_RefreshToken_StopsWhenROPCDisabled(t *testing.T) {
 				}
 			}()
 
-			clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-			password := gofakeit.Password(true, true, true, true, false, 12)
+			clientSecret := fake.Password(32)
+			password := fake.Password(12)
 			client := createROPCClient(t, clientSecret, false)
 			user := createROPCUser(t, password)
 

--- a/src/authserver/tests/integration/session_deletion_test.go
+++ b/src/authserver/tests/integration/session_deletion_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +35,7 @@ import (
 func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 	// Step 1: Create a client and user for testing
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -46,19 +46,19 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -67,9 +67,9 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 	// Step 2: Complete a full login to create a session in the database
 	httpClient := createHttpClient(t)
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -130,9 +130,9 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 
 	// Step 5: Start a NEW auth flow with the same httpClient (which still has the old session cookie)
 	// This simulates the user clicking "Login" again after their DB session was deleted
-	requestCodeChallenge2 := gofakeit.LetterN(43)
-	requestState2 := gofakeit.LetterN(8)
-	requestNonce2 := gofakeit.LetterN(8)
+	requestCodeChallenge2 := fake.LetterN(43)
+	requestState2 := fake.LetterN(8)
+	requestNonce2 := fake.LetterN(8)
 
 	destUrl2 := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -211,7 +211,7 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 // on authentication passes and only one keyed on the session refuses.
 func TestSessionEndedOnConsentScreen_NoCodeIsIssued(t *testing.T) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		// The consent screen is what holds the ceremony still between /auth/completed and
@@ -224,19 +224,19 @@ func TestSessionEndedOnConsentScreen_NoCodeIsIssued(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -246,15 +246,15 @@ func TestSessionEndedOnConsentScreen_NoCodeIsIssued(t *testing.T) {
 	// rather than two.
 	httpClient := createHttpClient(t)
 
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	assert.NoError(t, err)
@@ -375,9 +375,9 @@ func TestSessionEndedDuringStepUp_OtpAloneDoesNotRecreateTheSession(t *testing.T
 
 	// A second authorization request on the same browser, asking for level 2. The session
 	// is reused, so this ceremony never reaches the password handler.
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -466,15 +466,15 @@ func TestSessionEndedBeforeIssue_PromptNoneGetsLoginRequired(t *testing.T) {
 
 	// A second authorization on the same browser, silent this time. The client does not
 	// require consent, so with a live session behind it this goes straight to /auth/issue.
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=code" +
 		"&code_challenge_method=S256" +
-		"&code_challenge=" + gofakeit.LetterN(43) +
+		"&code_challenge=" + fake.LetterN(43) +
 		"&scope=" + url.QueryEscape("openid profile email") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp, err := httpClient.Get(destUrl)

--- a/src/authserver/tests/integration/token_amr_test.go
+++ b/src/authserver/tests/integration/token_amr_test.go
@@ -4,8 +4,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ import (
 
 // TestToken_AuthCode_AMR_IsArray verifies that AMR in tokens is a JSON array per OIDC spec
 func TestToken_AuthCode_AMR_IsArray(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -64,7 +64,7 @@ func TestToken_AuthCode_AMR_IsArray(t *testing.T) {
 
 // TestToken_Refresh_AMR_IsArray verifies AMR is preserved as array through refresh
 func TestToken_Refresh_AMR_IsArray(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	// Use "openid profile email" instead of "offline_access" to avoid consent flow
 	// The auth code flow still returns a refresh token with these scopes
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")

--- a/src/authserver/tests/integration/token_authcode_basicauth_test.go
+++ b/src/authserver/tests/integration/token_authcode_basicauth_test.go
@@ -4,8 +4,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,7 @@ import (
 // ============================================================================
 
 func TestToken_AuthCode_ClientSecretBasic_Success(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -42,7 +42,7 @@ func TestToken_AuthCode_ClientSecretBasic_Success(t *testing.T) {
 }
 
 func TestToken_AuthCode_ClientSecretBasic_WrongSecret(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -63,7 +63,7 @@ func TestToken_AuthCode_ClientSecretBasic_WrongSecret(t *testing.T) {
 }
 
 func TestToken_AuthCode_ClientSecretBasic_BothMethodsProvided(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"

--- a/src/authserver/tests/integration/token_authcode_concurrent_test.go
+++ b/src/authserver/tests/integration/token_authcode_concurrent_test.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,7 +53,7 @@ func concurrentTokenPost(client *http.Client, urlStr string, formData url.Values
 // compare-and-set in MarkCodeAsUsed lets exactly one request win the claim; the
 // rest are treated as reuse.
 func TestToken_AuthCode_ConcurrentDoubleSpend_IssuesOnlyOnce(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"

--- a/src/authserver/tests/integration/token_authcode_loopback_port_test.go
+++ b/src/authserver/tests/integration/token_authcode_loopback_port_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -14,6 +13,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,12 +26,12 @@ import (
 // database (core/validators), so neither shows an ephemeral-port callback actually
 // completing. This does (#41).
 func TestToken_AuthCode_LoopbackEphemeralPort(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	require.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "loopback-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "loopback-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -56,21 +56,21 @@ func TestToken_AuthCode_LoopbackEphemeralPort(t *testing.T) {
 	ephemeralPort := reserveEphemeralPort(t)
 	requestedURI := fmt.Sprintf("http://127.0.0.1:%d/callback", ephemeralPort)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
 	require.NoError(t, err)
 
 	codeVerifier := "code-verifier"
-	requestState := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(requestedURI) +
@@ -79,7 +79,7 @@ func TestToken_AuthCode_LoopbackEphemeralPort(t *testing.T) {
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape("openid profile email") +
 		"&state=" + requestState +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&nonce=" + fake.LetterN(8)
 
 	httpClient := createHttpClient(t)
 

--- a/src/authserver/tests/integration/token_authcode_public_client_test.go
+++ b/src/authserver/tests/integration/token_authcode_public_client_test.go
@@ -4,9 +4,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +44,7 @@ func challengelessCode(t *testing.T, clientSecret string) (*models.Code, string)
 // what bound it. Once the secret stops being required the code is bound to nothing, and it has
 // up to 60 seconds of life left in which anybody holding it can spend it.
 func TestToken_AuthCode_ChallengelessCode_RefusedAfterClientBecomesPublic(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	code, destUrl := challengelessCode(t, clientSecret)
 
 	client, err := database.GetClientById(nil, code.ClientId)
@@ -69,7 +69,7 @@ func TestToken_AuthCode_ChallengelessCode_RefusedAfterClientBecomesPublic(t *tes
 // B2. The positive control. The same code, redeemed by the client that still authenticates,
 // still works, so the refusal above is about the client being public and not about the code.
 func TestToken_AuthCode_ChallengelessCode_ConfidentialClientStillSucceeds(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	code, destUrl := challengelessCode(t, clientSecret)
 
 	data := postToTokenEndpoint(t, createHttpClient(t), destUrl, url.Values{
@@ -89,7 +89,7 @@ func TestToken_AuthCode_ChallengelessCode_ConfidentialClientStillSucceeds(t *tes
 // and grant already outstanding: those are still authenticated by the secret, and refusing them
 // would make a security improvement look like an outage.
 func TestToken_AuthCode_ChallengelessCode_SurvivesTurningPKCEOnForAConfidentialClient(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	code, destUrl := challengelessCode(t, clientSecret)
 
 	client, err := database.GetClientById(nil, code.ClientId)

--- a/src/authserver/tests/integration/token_authcode_test.go
+++ b/src/authserver/tests/integration/token_authcode_test.go
@@ -5,16 +5,16 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestToken_AuthCode_MissingCode(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
@@ -22,7 +22,7 @@ func TestToken_AuthCode_MissingCode(t *testing.T) {
 		"grant_type":    {"authorization_code"},
 		"client_id":     {code.Client.ClientIdentifier},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -32,7 +32,7 @@ func TestToken_AuthCode_MissingCode(t *testing.T) {
 }
 
 func TestToken_AuthCode_MissingRedirectURI(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
@@ -40,7 +40,7 @@ func TestToken_AuthCode_MissingRedirectURI(t *testing.T) {
 		"grant_type":    {"authorization_code"},
 		"client_id":     {code.Client.ClientIdentifier},
 		"code":          {code.Code},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -50,7 +50,7 @@ func TestToken_AuthCode_MissingRedirectURI(t *testing.T) {
 }
 
 func TestToken_AuthCode_MissingCodeVerifier(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -70,7 +70,7 @@ func TestToken_AuthCode_MissingCodeVerifier(t *testing.T) {
 }
 
 func TestToken_AuthCode_ClientDoesNotExist(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
@@ -79,7 +79,7 @@ func TestToken_AuthCode_ClientDoesNotExist(t *testing.T) {
 		"client_id":     {"non-existent-client"},
 		"code":          {code.Code},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -89,7 +89,7 @@ func TestToken_AuthCode_ClientDoesNotExist(t *testing.T) {
 }
 
 func TestToken_AuthCode_CodeIsInvalid(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
@@ -98,7 +98,7 @@ func TestToken_AuthCode_CodeIsInvalid(t *testing.T) {
 		"client_id":     {code.Client.ClientIdentifier},
 		"code":          {"invalid_code"},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -108,7 +108,7 @@ func TestToken_AuthCode_CodeIsInvalid(t *testing.T) {
 }
 
 func TestToken_AuthCode_RedirectURIIsInvalid(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
@@ -117,7 +117,7 @@ func TestToken_AuthCode_RedirectURIIsInvalid(t *testing.T) {
 		"client_id":     {code.Client.ClientIdentifier},
 		"code":          {code.Code},
 		"redirect_uri":  {"https://invalid-redirect-uri.com"},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -127,11 +127,11 @@ func TestToken_AuthCode_RedirectURIIsInvalid(t *testing.T) {
 }
 
 func TestToken_AuthCode_WrongClient(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	// Create a new client to use as the wrong client
 	wrongClient := &models.Client{
-		ClientIdentifier:         "wrong-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "wrong-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -147,7 +147,7 @@ func TestToken_AuthCode_WrongClient(t *testing.T) {
 		"client_id":     {wrongClient.ClientIdentifier}, // Use the wrong client ID
 		"code":          {code.Code},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -157,7 +157,7 @@ func TestToken_AuthCode_WrongClient(t *testing.T) {
 }
 
 func TestToken_AuthCode_ConfidentialClient_NoClientSecret(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email")
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email")
 
 	// Ensure the client is not public (confidential)
 	code.Client.IsPublic = false
@@ -171,7 +171,7 @@ func TestToken_AuthCode_ConfidentialClient_NoClientSecret(t *testing.T) {
 		"client_id":     {code.Client.ClientIdentifier},
 		"code":          {code.Code},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 	}
 
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
@@ -182,7 +182,7 @@ func TestToken_AuthCode_ConfidentialClient_NoClientSecret(t *testing.T) {
 }
 
 func TestToken_AuthCode_ConfidentialClient_ClientAuthFailed(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	// Ensure the client is confidential (not public)
@@ -197,7 +197,7 @@ func TestToken_AuthCode_ConfidentialClient_ClientAuthFailed(t *testing.T) {
 		"client_id":     {code.Client.ClientIdentifier},
 		"code":          {code.Code},
 		"redirect_uri":  {code.RedirectURI},
-		"code_verifier": {gofakeit.LetterN(43)},
+		"code_verifier": {fake.LetterN(43)},
 		"client_secret": {"incorrect_secret"}, // Provide an incorrect client secret
 	}
 
@@ -209,7 +209,7 @@ func TestToken_AuthCode_ConfidentialClient_ClientAuthFailed(t *testing.T) {
 }
 
 func TestToken_AuthCode_InvalidCodeVerifier(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	code.Client.IsPublic = false
@@ -234,7 +234,7 @@ func TestToken_AuthCode_InvalidCodeVerifier(t *testing.T) {
 }
 
 func TestToken_AuthCode_SuccessPath(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -265,7 +265,7 @@ func TestToken_AuthCode_SuccessPath(t *testing.T) {
 // RFC 6749 Section 4.1.2: a previously used authorization code MUST be rejected.
 // First exchange succeeds; replaying the same code returns invalid_grant.
 func TestToken_AuthCode_CodeReuse_ReturnsInvalidGrant(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -297,7 +297,7 @@ func TestToken_AuthCode_CodeReuse_ReturnsInvalidGrant(t *testing.T) {
 // revoke any tokens previously issued from that code. This pins the refresh-token
 // half of that requirement.
 func TestToken_AuthCode_CodeReuse_RevokesRefreshToken(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -336,7 +336,7 @@ func TestToken_AuthCode_CodeReuse_RevokesRefreshToken(t *testing.T) {
 // half of the revocation requirement (covers the OIDC conformance scenario
 // oidcc-codereuse-30seconds, which calls /userinfo after replaying a code).
 func TestToken_AuthCode_CodeReuse_AccessTokenNoLongerWorks(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -390,7 +390,7 @@ func TestToken_AuthCode_CodeReuse_AccessTokenNoLongerWorks(t *testing.T) {
 // Deliberately thin, because normalizeScope's exhaustive table lives in the handlers package; this
 // asserts only that refresh benefits from the shared helper.
 func TestToken_Refresh_TabSeparatedDownScopeIsNormalized(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 
 	// Not offline_access: it routes the flow through /auth/consent, which createAuthCode does not
 	// walk, and the auth code grant returns a refresh token with these scopes anyway.

--- a/src/authserver/tests/integration/token_client_id_exact_test.go
+++ b/src/authserver/tests/integration/token_client_id_exact_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func createClientForClientIdComparison(t *testing.T) *models.Client {
 	t.Helper()
 
 	client := &models.Client{
-		ClientIdentifier:         strings.ToLower("test-client-" + gofakeit.LetterN(8)),
+		ClientIdentifier:         strings.ToLower("test-client-" + fake.LetterN(8)),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ClientCredentialsEnabled: true,

--- a/src/authserver/tests/integration/token_clientcred_test.go
+++ b/src/authserver/tests/integration/token_clientcred_test.go
@@ -6,31 +6,31 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestToken_ClientCred_ClientSecretBasic_Success(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	// Create resources and permissions with random identifiers
-	resourceIdentifier := "backend-svc-" + gofakeit.LetterN(8)
+	resourceIdentifier := "backend-svc-" + fake.LetterN(8)
 	resource := createResourceWithId(t, resourceIdentifier)
-	permissionIdentifier := "read-data-" + gofakeit.LetterN(8)
+	permissionIdentifier := "read-data-" + fake.LetterN(8)
 	permission := createPermissionWithId(t, resource.Id, permissionIdentifier)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -63,12 +63,12 @@ func TestToken_ClientCred_ClientSecretBasic_Success(t *testing.T) {
 func TestToken_ClientCred_ClientSecretBasic_WrongSecret(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -97,7 +97,7 @@ func TestToken_ClientCred_FlowIsNotEnabled(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ClientCredentialsEnabled: false, // Client credentials flow is not enabled
@@ -111,7 +111,7 @@ func TestToken_ClientCred_FlowIsNotEnabled(t *testing.T) {
 	formData := url.Values{
 		"grant_type":    {"client_credentials"},
 		"client_id":     {client.ClientIdentifier},
-		"client_secret": {gofakeit.Password(true, true, true, true, false, 32)},
+		"client_secret": {fake.Password(32)},
 	}
 	data := postToTokenEndpoint(t, httpClient, destUrl, formData)
 
@@ -123,7 +123,7 @@ func TestToken_ClientCred_ClientSecretIsMissing(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ClientCredentialsEnabled: true,
@@ -150,12 +150,12 @@ func TestToken_ClientCred_ClientSecretIsMissing(t *testing.T) {
 func TestToken_ClientCred_ClientAuthFailed(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ClientCredentialsEnabled: true,
@@ -183,12 +183,12 @@ func TestToken_ClientCred_InvalidScope(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	// Create a client for testing
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -199,8 +199,8 @@ func TestToken_ClientCred_InvalidScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a resource and permission for the last test cases
-	resourceIdentifier := "backend-svcA-" + gofakeit.LetterN(8)
-	permissionIdentifier := "read-product-" + gofakeit.LetterN(8)
+	resourceIdentifier := "backend-svcA-" + fake.LetterN(8)
+	permissionIdentifier := "read-product-" + fake.LetterN(8)
 	resource := createResourceWithId(t, resourceIdentifier)
 	createPermissionWithId(t, resource.Id, permissionIdentifier)
 
@@ -263,12 +263,12 @@ func TestToken_ClientCred_NoScopesGiven(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	// Create a client for testing
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -279,14 +279,14 @@ func TestToken_ClientCred_NoScopesGiven(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create resources and permissions with random identifiers
-	resourceAIdentifier := "backend-svcA-" + gofakeit.LetterN(8)
+	resourceAIdentifier := "backend-svcA-" + fake.LetterN(8)
 	resourceA := createResourceWithId(t, resourceAIdentifier)
-	permissionAIdentifier := "create-product-" + gofakeit.LetterN(8)
+	permissionAIdentifier := "create-product-" + fake.LetterN(8)
 	permissionA := createPermissionWithId(t, resourceA.Id, permissionAIdentifier)
 
-	resourceBIdentifier := "backend-svcB-" + gofakeit.LetterN(8)
+	resourceBIdentifier := "backend-svcB-" + fake.LetterN(8)
 	resourceB := createResourceWithId(t, resourceBIdentifier)
-	permissionBIdentifier := "read-info-" + gofakeit.LetterN(8)
+	permissionBIdentifier := "read-info-" + fake.LetterN(8)
 	permissionB := createPermissionWithId(t, resourceB.Id, permissionBIdentifier)
 
 	// Assign permissions to the client
@@ -329,12 +329,12 @@ func TestToken_ClientCred_SpecificScope(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	// Create a client for testing
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -345,14 +345,14 @@ func TestToken_ClientCred_SpecificScope(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create resources and permissions with random identifiers
-	resourceAIdentifier := "backend-svcA-" + gofakeit.LetterN(8)
+	resourceAIdentifier := "backend-svcA-" + fake.LetterN(8)
 	resourceA := createResourceWithId(t, resourceAIdentifier)
-	permissionAIdentifier := "create-product-" + gofakeit.LetterN(8)
+	permissionAIdentifier := "create-product-" + fake.LetterN(8)
 	permissionA := createPermissionWithId(t, resourceA.Id, permissionAIdentifier)
 
-	resourceBIdentifier := "backend-svcB-" + gofakeit.LetterN(8)
+	resourceBIdentifier := "backend-svcB-" + fake.LetterN(8)
 	resourceB := createResourceWithId(t, resourceBIdentifier)
-	permissionBIdentifier := "read-info-" + gofakeit.LetterN(8)
+	permissionBIdentifier := "read-info-" + fake.LetterN(8)
 	permissionB := createPermissionWithId(t, resourceB.Id, permissionBIdentifier)
 
 	// Assign permissions to the client
@@ -404,12 +404,12 @@ func TestToken_ClientCred_SpecificScope(t *testing.T) {
 func TestToken_ClientCred_CrossResourcePermissionCollision(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -420,13 +420,13 @@ func TestToken_ClientCred_CrossResourcePermissionCollision(t *testing.T) {
 	assert.NoError(t, err)
 
 	// One permission identifier, defined on two different resources.
-	sharedPermissionIdentifier := "read-product-" + gofakeit.LetterN(8)
+	sharedPermissionIdentifier := "read-product-" + fake.LetterN(8)
 
-	resourceAIdentifier := "billing-api-" + gofakeit.LetterN(8)
+	resourceAIdentifier := "billing-api-" + fake.LetterN(8)
 	resourceA := createResourceWithId(t, resourceAIdentifier)
 	permissionA := createPermissionWithId(t, resourceA.Id, sharedPermissionIdentifier)
 
-	resourceBIdentifier := "reports-api-" + gofakeit.LetterN(8)
+	resourceBIdentifier := "reports-api-" + fake.LetterN(8)
 	resourceB := createResourceWithId(t, resourceBIdentifier)
 	createPermissionWithId(t, resourceB.Id, sharedPermissionIdentifier)
 
@@ -486,12 +486,12 @@ func TestToken_ClientCred_CrossResourcePermissionCollision(t *testing.T) {
 func TestToken_ClientCred_AuthServerScopeNotReachableByCollision(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -502,7 +502,7 @@ func TestToken_ClientCred_AuthServerScopeNotReachableByCollision(t *testing.T) {
 	assert.NoError(t, err)
 
 	// A custom resource whose permission identifier collides with the built-in one.
-	customResourceIdentifier := "billing-api-" + gofakeit.LetterN(8)
+	customResourceIdentifier := "billing-api-" + fake.LetterN(8)
 	customResource := createResourceWithId(t, customResourceIdentifier)
 	customManage := createPermissionWithId(t, customResource.Id, constants.ManagePermissionIdentifier)
 
@@ -577,12 +577,12 @@ func TestToken_ClientCred_AuthServerScopeNotReachableByCollision(t *testing.T) {
 func TestToken_ClientCred_TabSeparatedScopeIsNormalized(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -592,10 +592,10 @@ func TestToken_ClientCred_TabSeparatedScopeIsNormalized(t *testing.T) {
 	err = database.CreateClient(nil, client)
 	assert.NoError(t, err)
 
-	resourceIdentifier := "billing-api-" + gofakeit.LetterN(8)
+	resourceIdentifier := "billing-api-" + fake.LetterN(8)
 	resource := createResourceWithId(t, resourceIdentifier)
-	readPermission := createPermissionWithId(t, resource.Id, "read-"+gofakeit.LetterN(6))
-	writePermission := createPermissionWithId(t, resource.Id, "write-"+gofakeit.LetterN(6))
+	readPermission := createPermissionWithId(t, resource.Id, "read-"+fake.LetterN(6))
+	writePermission := createPermissionWithId(t, resource.Id, "write-"+fake.LetterN(6))
 
 	for _, permission := range []*models.Permission{readPermission, writePermission} {
 		err = database.CreateClientPermission(nil, &models.ClientPermission{
@@ -651,12 +651,12 @@ func TestToken_ClientCred_TabSeparatedScopeIsNormalized(t *testing.T) {
 func TestToken_ClientCred_InvalidScopeWithEmoji_DescriptionIsConformed(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,

--- a/src/authserver/tests/integration/token_general_test.go
+++ b/src/authserver/tests/integration/token_general_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +45,7 @@ func TestToken_InvalidGrantType(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ClientCredentialsEnabled: true,

--- a/src/authserver/tests/integration/token_oidc_claims_test.go
+++ b/src/authserver/tests/integration/token_oidc_claims_test.go
@@ -327,7 +327,14 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 		gender = enums.GenderMale.String()
 	}
 
-	// Create user with full profile data
+	// Create user with full profile data.
+	//
+	// ZoneInfo and Locale are the two profile fields ProfileValidator checks
+	// against a fixed repository list, so both carry a value from those lists
+	// rather than a generated run: a profile the server would refuse at its own
+	// API is a weaker thing for the claim assertions to run against. Nothing
+	// below asserts on either value, only that the claim carries what was
+	// stored (#272).
 	user := &models.User{
 		Subject:             uuid.New(),
 		Enabled:             true,
@@ -341,7 +348,7 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 		Website:             fake.URL(),
 		Gender:              gender,
 		BirthDate:           sql.NullTime{Time: fake.Date(), Valid: true},
-		ZoneInfo:            "tz" + fake.LetterN(6),
+		ZoneInfo:            "America/New_York",
 		Locale:              "en-US",
 		PhoneNumber:         fake.DigitN(10),
 		PhoneNumberVerified: true,

--- a/src/authserver/tests/integration/token_oidc_claims_test.go
+++ b/src/authserver/tests/integration/token_oidc_claims_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
@@ -15,6 +14,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +41,7 @@ func TestToken_IdToken_OIDCClaims_GlobalDisabled(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeWithUserProfile(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -129,7 +129,7 @@ func TestToken_IdToken_OIDCClaims_GlobalEnabled(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeWithUserProfile(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -185,7 +185,7 @@ func TestToken_IdToken_OIDCClaims_ClientOverride_On(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeWithUserProfile(t, clientSecret, "openid profile email")
 
 	// Set client-level override to "on"
@@ -242,7 +242,7 @@ func TestToken_IdToken_OIDCClaims_ClientOverride_Off(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeWithUserProfile(t, clientSecret, "openid profile email")
 
 	// Set client-level override to "off"
@@ -289,7 +289,7 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -305,7 +305,7 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -313,35 +313,43 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// The gender column is 16 characters and the claim is echoed back verbatim,
+	// so the fixture picks one of the two strings enums.Gender.String() returns
+	// rather than a generated run (#272).
+	gender := enums.GenderFemale.String()
+	if fake.Bool() {
+		gender = enums.GenderMale.String()
 	}
 
 	// Create user with full profile data
 	user := &models.User{
 		Subject:             uuid.New(),
 		Enabled:             true,
-		Email:               gofakeit.Email(),
+		Email:               fake.Email(),
 		EmailVerified:       true,
 		PasswordHash:        passwordHashed,
-		GivenName:           gofakeit.FirstName(),
-		FamilyName:          gofakeit.LastName(),
-		MiddleName:          gofakeit.MiddleName(),
-		Nickname:            gofakeit.Username(),
-		Website:             gofakeit.URL(),
-		Gender:              gofakeit.Gender(),
-		BirthDate:           sql.NullTime{Time: gofakeit.Date(), Valid: true},
-		ZoneInfo:            gofakeit.TimeZoneFull(),
+		GivenName:           fake.FirstName(),
+		FamilyName:          fake.LastName(),
+		MiddleName:          fake.MiddleName(),
+		Nickname:            fake.Username(),
+		Website:             fake.URL(),
+		Gender:              gender,
+		BirthDate:           sql.NullTime{Time: fake.Date(), Valid: true},
+		ZoneInfo:            "tz" + fake.LetterN(6),
 		Locale:              "en-US",
-		PhoneNumber:         gofakeit.Phone(),
+		PhoneNumber:         fake.DigitN(10),
 		PhoneNumberVerified: true,
-		AddressLine1:        gofakeit.Street(),
-		AddressLine2:        gofakeit.StreetNumber(),
-		AddressLocality:     gofakeit.City(),
-		AddressRegion:       gofakeit.State(),
-		AddressPostalCode:   gofakeit.Zip(),
+		AddressLine1:        "Street " + fake.LetterN(8),
+		AddressLine2:        fake.DigitN(3),
+		AddressLocality:     "City" + fake.LetterN(6),
+		AddressRegion:       "State" + fake.LetterN(6),
+		AddressPostalCode:   fake.DigitN(5),
 		AddressCountry:      "US",
 	}
 
@@ -352,8 +360,8 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 
 	codeVerifier := "code-verifier"
 	requestCodeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +

--- a/src/authserver/tests/integration/token_refresh_concurrent_test.go
+++ b/src/authserver/tests/integration/token_refresh_concurrent_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +58,7 @@ func refreshTokenJti(t *testing.T, refreshToken string) string {
 // a validation read of already revoked. Those pin the states, not the orderings that
 // produce them, which no mocked test could.
 func TestToken_Refresh_ConcurrentDoubleSpend_IssuesOnlyOnce(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"

--- a/src/authserver/tests/integration/token_refresh_public_client_test.go
+++ b/src/authserver/tests/integration/token_refresh_public_client_test.go
@@ -4,8 +4,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +52,7 @@ func challengelessRefreshToken(t *testing.T, clientSecret string) (string, int64
 
 // C1. The grant outlives the configuration it was issued under, and this is what catches it.
 func TestToken_Refresh_ChallengelessGrant_RefusedOnceTheClientIsPublic(t *testing.T) {
-	refreshToken, clientId, clientIdentifier, destUrl := challengelessRefreshToken(t, gofakeit.LetterN(32))
+	refreshToken, clientId, clientIdentifier, destUrl := challengelessRefreshToken(t, fake.LetterN(32))
 
 	client, err := database.GetClientById(nil, clientId)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestToken_Refresh_ChallengelessGrant_RefusedOnceTheClientIsPublic(t *testin
 // C2. The positive control, on its own grant. The same challenge-less shape still refreshes
 // while the client authenticates.
 func TestToken_Refresh_ChallengelessGrant_ConfidentialClientStillRefreshes(t *testing.T) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	refreshToken, _, clientIdentifier, destUrl := challengelessRefreshToken(t, clientSecret)
 
 	data := postToTokenEndpoint(t, createHttpClient(t), destUrl, url.Values{
@@ -98,7 +98,7 @@ func TestToken_Refresh_ChallengelessGrant_ConfidentialClientStillRefreshes(t *te
 // application whose administrator has just flipped it to public still holds the secret that was
 // deleted server-side. The release note says so.
 func TestToken_Refresh_PublicClient_PresentingASecret_IsRefused(t *testing.T) {
-	httpClient, code := createAuthCode(t, gofakeit.LetterN(32), "openid profile email",
+	httpClient, code := createAuthCode(t, fake.LetterN(32), "openid profile email",
 		authCodeOptions{isPublic: true})
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"

--- a/src/authserver/tests/integration/token_refresh_replay_test.go
+++ b/src/authserver/tests/integration/token_refresh_replay_test.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,7 +103,7 @@ func codeOnSameSessionForNewClient(t *testing.T, httpClient *http.Client, client
 	require.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "second-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "second-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -113,7 +113,7 @@ func codeOnSameSessionForNewClient(t *testing.T, httpClient *http.Client, client
 	}
 	require.NoError(t, database.CreateClient(nil, client))
 
-	redirectURI := &models.RedirectURI{ClientId: client.Id, URI: gofakeit.URL()}
+	redirectURI := &models.RedirectURI{ClientId: client.Id, URI: fake.URL()}
 	require.NoError(t, database.CreateRedirectURI(nil, redirectURI))
 
 	const codeVerifier = "code-verifier-second-client"
@@ -122,7 +122,7 @@ func codeOnSameSessionForNewClient(t *testing.T, httpClient *http.Client, client
 		"&response_type=code&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge(codeVerifier) +
 		"&scope=" + url.QueryEscape(scope) +
-		"&state=" + gofakeit.LetterN(8) + "&nonce=" + gofakeit.LetterN(8) +
+		"&state=" + fake.LetterN(8) + "&nonce=" + fake.LetterN(8) +
 		"&prompt=none"
 
 	resp, err := httpClient.Get(destURL)
@@ -145,7 +145,7 @@ func codeOnSameSessionForNewClient(t *testing.T, httpClient *http.Client, client
 // token and lost the rotation race simply waited and kept using the family, while the
 // legitimate holder was the one locked out. That is the inversion the issue exists to fix.
 func TestToken_Refresh_Replay_ContainsFamily(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	rt1 := exchangeAuthCode(t, httpClient, code.Client.ClientIdentifier, clientSecret,
@@ -178,11 +178,11 @@ func TestToken_Refresh_Replay_ContainsFamily(t *testing.T) {
 // wrong for a refresh token replay, which implicates one grant's client-side storage.
 // Widening it would punish the legitimate user for the thief's access.
 func TestToken_Refresh_Replay_DoesNotContainOtherFamilies(t *testing.T) {
-	secretA := gofakeit.Password(true, true, true, true, false, 32)
+	secretA := fake.Password(32)
 	httpClient, codeA := createAuthCode(t, secretA, "openid profile email")
 
 	// A second client, federated onto the SAME browser session, with its own family.
-	secretB := gofakeit.Password(true, true, true, true, false, 32)
+	secretB := fake.Password(32)
 	clientB, redirectB, rawCodeB := codeOnSameSessionForNewClient(t, httpClient, secretB, "openid profile")
 
 	storedCodeA, err := database.GetCodeById(nil, codeA.Id)
@@ -212,7 +212,7 @@ func TestToken_Refresh_Replay_DoesNotContainOtherFamilies(t *testing.T) {
 
 	// The browser session itself must survive. A third authorization riding the same
 	// session is what proves it: containment must not have deleted or invalidated it.
-	_, _, rawCodeC := codeOnSameSessionForNewClient(t, httpClient, gofakeit.Password(true, true, true, true, false, 32), "openid")
+	_, _, rawCodeC := codeOnSameSessionForNewClient(t, httpClient, fake.Password(32), "openid")
 	storedCodeC := loadCodeFromDatabase(t, rawCodeC)
 	assert.Equal(t, storedCodeA.SessionIdentifier, storedCodeC.SessionIdentifier,
 		"the browser session must survive containment and still serve new authorizations")
@@ -233,8 +233,8 @@ func TestToken_Refresh_Replay_ContainsROPCFamily(t *testing.T) {
 		_ = database.UpdateSettings(nil, settings)
 	}()
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	clientSecret := fake.Password(32)
+	password := fake.Password(12)
 	client := createROPCClient(t, clientSecret, false)
 	user := createROPCUser(t, password)
 
@@ -280,7 +280,7 @@ func TestToken_Refresh_Replay_ContainsROPCFamily(t *testing.T) {
 // (TestHandleTokenPost_Refresh_Replay_AuditsContainment and the already-revoked subtest),
 // not here: this tier cannot see the audit logger.
 func TestToken_Refresh_Replay_RepeatIsANoOp(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	rt1 := exchangeAuthCode(t, httpClient, code.Client.ClientIdentifier, clientSecret,

--- a/src/authserver/tests/integration/token_refresh_test.go
+++ b/src/authserver/tests/integration/token_refresh_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
@@ -20,12 +19,13 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestToken_Refresh_ClientSecretBasic_Success(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -58,7 +58,7 @@ func TestToken_Refresh_ClientSecretBasic_Success(t *testing.T) {
 }
 
 func TestToken_Refresh_ClientSecretBasic_WrongSecret(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -92,12 +92,12 @@ func TestToken_Refresh_ClientSecretBasic_WrongSecret(t *testing.T) {
 func TestToken_Refresh_ClientSecretIsMissing(t *testing.T) {
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		DefaultAcrLevel:          enums.AcrLevel2Optional,
@@ -122,7 +122,7 @@ func TestToken_Refresh_ClientSecretIsMissing(t *testing.T) {
 }
 
 func TestToken_Refresh_ClientAuthFailed(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	// Get the token using the authorization code
@@ -158,7 +158,7 @@ func TestToken_Refresh_ClientAuthFailed(t *testing.T) {
 }
 
 func TestToken_Refresh_MissingRefreshToken(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -191,7 +191,7 @@ func TestToken_Refresh_MissingRefreshToken(t *testing.T) {
 }
 
 func TestToken_Refresh_TokenWithBadSignature(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -256,14 +256,14 @@ func TestToken_Refresh_TokenExpired(t *testing.T) {
 
 	httpClient := createHttpClient(t)
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	settings, err := database.GetSettingsById(nil, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -320,7 +320,7 @@ func TestToken_Refresh_TokenExpired(t *testing.T) {
 }
 
 func TestToken_Refresh_WrongClient(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -341,12 +341,12 @@ func TestToken_Refresh_WrongClient(t *testing.T) {
 	refreshToken := data["refresh_token"].(string)
 
 	// Create a new client
-	wrongClientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	wrongClientSecret := fake.Password(32)
 	wrongClientSecretEncrypted, err := encryption.EncryptData(wrongClientSecret)
 	assert.NoError(t, err)
 
 	wrongClient := &models.Client{
-		ClientIdentifier:         "wrong-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "wrong-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -372,7 +372,7 @@ func TestToken_Refresh_WrongClient(t *testing.T) {
 }
 
 func TestToken_Refresh_WithAdditionalScope(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -393,8 +393,8 @@ func TestToken_Refresh_WithAdditionalScope(t *testing.T) {
 	refreshToken := data["refresh_token"].(string)
 
 	// Create a new resource and permission with randomized identifiers
-	resourceIdentifier := "additional-resource-" + gofakeit.LetterN(8)
-	permissionIdentifier := "read-" + gofakeit.LetterN(8)
+	resourceIdentifier := "additional-resource-" + fake.LetterN(8)
+	permissionIdentifier := "read-" + fake.LetterN(8)
 	resource := createResourceWithId(t, resourceIdentifier)
 	permission := createPermissionWithId(t, resource.Id, permissionIdentifier)
 
@@ -434,12 +434,12 @@ func TestToken_Refresh_WithAdditionalScope(t *testing.T) {
 func TestToken_Refresh_ConsentRemoved(t *testing.T) {
 	// Create a client with consent required
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -452,19 +452,19 @@ func TestToken_Refresh_ConsentRemoved(t *testing.T) {
 	// Create a redirect URI for the client
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
 	// Create a user
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -486,8 +486,8 @@ func TestToken_Refresh_ConsentRemoved(t *testing.T) {
 		"&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge("code-verifier") +
 		"&scope=" + url.QueryEscape(requestScope) +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	assert.NoError(t, err)
@@ -568,12 +568,12 @@ func TestToken_Refresh_ConsentRemoved(t *testing.T) {
 }
 
 func TestToken_Refresh_ConsentDoesNotIncludeScope(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          true,
@@ -585,18 +585,18 @@ func TestToken_Refresh_ConsentDoesNotIncludeScope(t *testing.T) {
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	assert.NoError(t, err)
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 	err = database.CreateUser(nil, user)
@@ -617,8 +617,8 @@ func TestToken_Refresh_ConsentDoesNotIncludeScope(t *testing.T) {
 		"&code_challenge_method=S256" +
 		"&code_challenge=" + oauth.GeneratePKCECodeChallenge("code-verifier") +
 		"&scope=" + url.QueryEscape(initialScope) +
-		"&state=" + gofakeit.LetterN(8) +
-		"&nonce=" + gofakeit.LetterN(8)
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8)
 
 	resp, err := httpClient.Get(destUrl)
 	assert.NoError(t, err)
@@ -688,7 +688,7 @@ func TestToken_Refresh_ConsentDoesNotIncludeScope(t *testing.T) {
 }
 
 func TestToken_Refresh_TokenMarkedAsUsed(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/token/"
@@ -773,7 +773,7 @@ func TestToken_Refresh_TokenMarkedAsUsed(t *testing.T) {
 // only way to reach it. In production it arrives through user deletion, a referential
 // cascade or a database restore.
 func TestToken_Refresh_MissingRowIsInvalidGrant(t *testing.T) {
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	httpClient, code := createAuthCode(t, clientSecret, "openid profile email")
 
 	refreshToken := exchangeAuthCode(t, httpClient, code.Client.ClientIdentifier, clientSecret,

--- a/src/authserver/tests/integration/user_bound_token_test.go
+++ b/src/authserver/tests/integration/user_bound_token_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
@@ -17,6 +16,7 @@ import (
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,17 +58,17 @@ func newUserSubjectValidAsClientIdentifier(t *testing.T) uuid.UUID {
 func createUserWithSubject(t *testing.T, subject uuid.UUID) (*models.User, string) {
 	t.Helper()
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 
 	user := &models.User{
 		Subject:      subject,
 		Enabled:      true,
-		Email:        strings.ToLower(gofakeit.LetterN(10)) + "@example.com",
+		Email:        strings.ToLower(fake.LetterN(10)) + "@example.com",
 		PasswordHash: passwordHashed,
-		GivenName:    gofakeit.FirstName(),
-		FamilyName:   gofakeit.LastName(),
+		GivenName:    fake.FirstName(),
+		FamilyName:   fake.LastName(),
 	}
 	err = database.CreateUser(nil, user)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func createUserWithSubject(t *testing.T, subject uuid.UUID) (*models.User, strin
 func createImpersonatingClientCredentialsToken(t *testing.T, subject uuid.UUID, permissionIdentifier string) string {
 	t.Helper()
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestUserBoundToken_ClientCredentialsCannotActAsUser(t *testing.T) {
 		accessToken := createImpersonatingClientCredentialsToken(t, accountSubject,
 			constants.ManageAccountPermissionIdentifier)
 
-		attemptedEmail := strings.ToLower(gofakeit.LetterN(9)) + "@attacker.example.com"
+		attemptedEmail := strings.ToLower(fake.LetterN(9)) + "@attacker.example.com"
 		resp := makeAPIRequest(t, "PUT", config.GetAuthServer().BaseURL+"/api/v1/account/email",
 			accessToken, api.UpdateAccountEmailRequest{Email: attemptedEmail})
 		defer func() { _ = resp.Body.Close() }()
@@ -230,7 +230,7 @@ func TestUserBoundToken_EveryUserTokenPathStillWorks(t *testing.T) {
 	assertEmailChangeSucceeds := func(t *testing.T, accessToken string, user *models.User) {
 		t.Helper()
 
-		newEmail := strings.ToLower(gofakeit.LetterN(9)) + "@example.com"
+		newEmail := strings.ToLower(fake.LetterN(9)) + "@example.com"
 		resp := makeAPIRequest(t, "PUT", accountEmailUrl, accessToken,
 			api.UpdateAccountEmailRequest{Email: newEmail})
 		defer func() { _ = resp.Body.Close() }()
@@ -292,7 +292,7 @@ func userAccessTokenViaAuthCodeRefresh(t *testing.T) (string, *models.User) {
 	// which createAuthCodeEnsuringUserScope does not walk, and the auth code grant returns a
 	// refresh token with these scopes anyway. Same reasoning as the comment in
 	// token_amr_test.go:TestToken_Refresh_AMR_IsArray.
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	scope := "openid profile email " +
 		constants.AuthServerResourceIdentifier + ":" + constants.ManageAccountPermissionIdentifier
 	httpClient, code := createAuthCodeEnsuringUserScope(t, clientSecret, scope)
@@ -339,10 +339,10 @@ func userAccessTokenViaROPC(t *testing.T) (string, *models.User, string) {
 		_ = database.UpdateSettings(nil, settings)
 	})
 
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	client := createROPCClient(t, clientSecret, false)
 
-	password := gofakeit.Password(true, true, true, true, false, 12)
+	password := fake.Password(12)
 	user, _ := createUserWithSubject(t, uuid.New())
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
@@ -452,7 +452,7 @@ func userAccessTokenViaImplicit(t *testing.T) string {
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
 		"&response_type=token" +
 		"&scope=" + url.QueryEscape(requestScope) +
-		"&state=" + gofakeit.LetterN(16)
+		"&state=" + fake.LetterN(16)
 
 	httpClient := createHttpClient(t)
 	resp, err := httpClient.Get(destUrl)

--- a/src/authserver/tests/integration/utils_test.go
+++ b/src/authserver/tests/integration/utils_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -24,6 +23,7 @@ import (
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
 	"github.com/leodip/goiabada/core/oidc"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -236,7 +236,7 @@ func assertWithinLastXSeconds(t *testing.T, timeToCheck time.Time, seconds float
 
 func createResource(t *testing.T) *models.Resource {
 	resource := &models.Resource{
-		ResourceIdentifier: "res-" + gofakeit.LetterN(8),
+		ResourceIdentifier: "res-" + fake.LetterN(8),
 	}
 	err := database.CreateResource(nil, resource)
 	if err != nil {
@@ -258,7 +258,7 @@ func createResourceWithId(t *testing.T, resourceIdentifier string) *models.Resou
 
 func createPermission(t *testing.T, resourceId int64) *models.Permission {
 	permission := &models.Permission{
-		PermissionIdentifier: "perm-" + gofakeit.LetterN(8),
+		PermissionIdentifier: "perm-" + fake.LetterN(8),
 		ResourceId:           resourceId,
 	}
 	err := database.CreatePermission(nil, permission)
@@ -347,7 +347,7 @@ func createAuthenticatedHttpClient(t *testing.T) *http.Client {
 
 func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *models.RedirectURI, *models.User) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -361,7 +361,7 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -369,7 +369,7 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -378,7 +378,7 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -387,9 +387,9 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -456,7 +456,7 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 
 func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Client, *models.RedirectURI, *models.User) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -470,7 +470,7 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -478,7 +478,7 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
@@ -487,7 +487,7 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 	user := &models.User{
 		Subject:      uuid.New(),
 		Enabled:      true,
-		Email:        gofakeit.Email(),
+		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
 	}
 
@@ -496,9 +496,9 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -569,7 +569,7 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 
 func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Client, *models.RedirectURI, *models.User) {
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		ConsentRequired:          false,
@@ -583,7 +583,7 @@ func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Cl
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -591,13 +591,13 @@ func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Cl
 		t.Fatal(err)
 	}
 
-	password := gofakeit.Password(true, true, true, true, false, 8)
+	password := fake.Password(8)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userEmail := gofakeit.Email()
+	userEmail := fake.Email()
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      "Goiabada",
 		AccountName: userEmail,
@@ -609,7 +609,7 @@ func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Cl
 	user := &models.User{
 		Subject:            uuid.New(),
 		Enabled:            true,
-		Email:              gofakeit.Email(),
+		Email:              fake.Email(),
 		PasswordHash:       passwordHashed,
 		OTPSecret:          key.Secret(),
 		OTPSecretEncrypted: encryptOTPSecretForTest(t, key.Secret()),
@@ -621,9 +621,9 @@ func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Cl
 		t.Fatal(err)
 	}
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -750,7 +750,7 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 opt.isPublic,
@@ -772,7 +772,7 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 
 	redirectUri := &models.RedirectURI{
 		ClientId: client.Id,
-		URI:      gofakeit.URL(),
+		URI:      fake.URL(),
 	}
 
 	err = database.CreateRedirectURI(nil, redirectUri)
@@ -783,7 +783,7 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 	password := opt.userPassword
 	user := opt.user
 	if user == nil {
-		password = gofakeit.Password(true, true, true, true, false, 8)
+		password = fake.Password(8)
 		passwordHashed, err := hashutil.HashPassword(password)
 		if err != nil {
 			t.Fatal(err)
@@ -792,7 +792,7 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 		user = &models.User{
 			Subject:      uuid.New(),
 			Enabled:      true,
-			Email:        gofakeit.Email(),
+			Email:        fake.Email(),
 			PasswordHash: passwordHashed,
 		}
 
@@ -804,8 +804,8 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 
 	codeVerifier := "code-verifier"
 	requestCodeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -874,7 +874,7 @@ func createAuthCodeEnsuringUserScope(t *testing.T, clientSecret string, scope st
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "acctscope-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "acctscope-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
 		IsPublic:                 false,
@@ -888,20 +888,20 @@ func createAuthCodeEnsuringUserScope(t *testing.T, clientSecret string, scope st
 		t.Fatal(err)
 	}
 
-	redirectUri := &models.RedirectURI{ClientId: client.Id, URI: gofakeit.URL()}
+	redirectUri := &models.RedirectURI{ClientId: client.Id, URI: fake.URL()}
 	err = database.CreateRedirectURI(nil, redirectUri)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Create a user and pre-grant all custom resource scopes requested
-	password := gofakeit.Password(true, true, true, true, false, 10)
+	password := fake.Password(10)
 	passwordHashed, err := hashutil.HashPassword(password)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user := &models.User{Subject: uuid.New(), Enabled: true, Email: gofakeit.Email(), PasswordHash: passwordHashed}
+	user := &models.User{Subject: uuid.New(), Enabled: true, Email: fake.Email(), PasswordHash: passwordHashed}
 	err = database.CreateUser(nil, user)
 	if err != nil {
 		t.Fatal(err)
@@ -949,8 +949,8 @@ func createAuthCodeEnsuringUserScope(t *testing.T, clientSecret string, scope st
 
 	codeVerifier := "code-verifier"
 	requestCodeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
 		"&redirect_uri=" + url.QueryEscape(redirectUri.URI) +
@@ -1006,7 +1006,7 @@ func createAuthCodeEnsuringUserScope(t *testing.T, clientSecret string, scope st
 // createUserAccessTokenWithScope issues an access token for a user making sure requested
 // custom scopes are granted to that user before the flow. Returns (accessToken, *user).
 func createUserAccessTokenWithScope(t *testing.T, scope string) (string, *models.User) {
-	clientSecret := gofakeit.LetterN(32)
+	clientSecret := fake.LetterN(32)
 	httpClient, code := createAuthCodeEnsuringUserScope(t, clientSecret, scope)
 
 	// Exchange code for tokens
@@ -1108,13 +1108,13 @@ func dumpResponseBody(t *testing.T, response *http.Response) {
 // createAdminClientWithToken creates a client with admin permissions and returns an access token
 func createAdminClientWithToken(t *testing.T) (string, *models.Client) {
 	// Generate client secret
-	clientSecret := gofakeit.Password(true, true, true, true, false, 32)
+	clientSecret := fake.Password(32)
 	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
 	assert.NoError(t, err)
 
 	// Create client with admin permissions
 	client := &models.Client{
-		ClientIdentifier:         "admin-test-client-" + gofakeit.LetterN(8),
+		ClientIdentifier:         "admin-test-client-" + fake.LetterN(8),
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -1496,9 +1496,9 @@ func navigateToPasswordScreen(t *testing.T, httpClient *http.Client, client *mod
 // but appends an ui_locales query parameter (space-separated BCP 47 tags) when
 // non-empty, exercising the OIDC hint preservation across the redirect chain.
 func navigateToPasswordScreenWithUILocales(t *testing.T, httpClient *http.Client, client *models.Client, redirectUri, uiLocales string) *http.Response {
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1535,9 +1535,9 @@ func navigateToPasswordScreenWithUILocales(t *testing.T, httpClient *http.Client
 func navigateToOtpScreen(t *testing.T, httpClient *http.Client, client *models.Client, user *models.User,
 	password string, redirectUri string) *http.Response {
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +
@@ -1589,9 +1589,9 @@ func navigateToOtpScreen(t *testing.T, httpClient *http.Client, client *models.C
 func navigateToConsentScreen(t *testing.T, httpClient *http.Client, client *models.Client,
 	user *models.User, password string, redirectUri string) *http.Response {
 
-	requestCodeChallenge := gofakeit.LetterN(43)
-	requestState := gofakeit.LetterN(8)
-	requestNonce := gofakeit.LetterN(8)
+	requestCodeChallenge := fake.LetterN(43)
+	requestState := fake.LetterN(8)
+	requestNonce := fake.LetterN(8)
 	requestScope := "openid profile email"
 
 	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + client.ClientIdentifier +

--- a/src/core/communication/email_sender_test.go
+++ b/src/core/communication/email_sender_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/testutil"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +25,7 @@ func TestSendEmail(t *testing.T) {
 		SMTPFromEmail:         "sender@example.com",
 	})
 
-	recipient := gofakeit.Email()
+	recipient := fake.Email()
 
 	input := &SendEmailInput{
 		To:       recipient,

--- a/src/core/go.mod
+++ b/src/core/go.mod
@@ -4,7 +4,6 @@ go 1.27.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/go-chi/cors v1.2.2
 	github.com/go-chi/httprate v0.16.0

--- a/src/core/go.sum
+++ b/src/core/go.sum
@@ -17,8 +17,6 @@ github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.1.0 h1:ChaYjBR63fr4LFyGn8E8nt7dBSt3MiU3zMOZqFvVkHo=
 github.com/boombuler/barcode v1.1.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
-github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/src/core/hashutil/hashutil_test.go
+++ b/src/core/hashutil/hashutil_test.go
@@ -3,7 +3,7 @@ package hashutil
 import (
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 func TestHashString(t *testing.T) {
@@ -61,8 +61,8 @@ func TestHashPassword(t *testing.T) {
 	}{
 		{"Normal password", "password123", false},
 		{"Empty password", "", false},
-		{"Max length password", gofakeit.LetterN(72), false},
-		{"Exceeds max length", gofakeit.LetterN(73), true},
+		{"Max length password", fake.LetterN(72), false},
+		{"Exceeds max length", fake.LetterN(73), true},
 	}
 
 	for _, tt := range tests {

--- a/src/core/otp/generator_test.go
+++ b/src/core/otp/generator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	pquernaotp "github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
@@ -92,8 +92,8 @@ func TestGenerateOTPSecret(t *testing.T) {
 
 	t.Run("Input length restrictions", func(t *testing.T) {
 		t.Run("Valid lengths", func(t *testing.T) {
-			email := gofakeit.LetterN(58) + "@b.com" // 64 characters
-			appName := gofakeit.LetterN(32)
+			email := fake.LetterN(58) + "@b.com" // 64 characters
+			appName := fake.LetterN(32)
 
 			keyURL, err := generator.GenerateOTPSecret(email, appName)
 

--- a/src/core/testutil/fake/fake.go
+++ b/src/core/testutil/fake/fake.go
@@ -62,24 +62,47 @@ func intn(n int) int {
 	return int(v.Int64())
 }
 
+// mustDraw returns s unless it is short of the n characters that were asked
+// for, which is how the stringutil helpers report a CSPRNG failure: they
+// swallow the error and return "" to preserve a contract their production
+// callers were written against. A fixture that degrades to a constant instead
+// produces tests that pass while every username is the same string, which is
+// exactly the collision #136 describes, so the draw fails closed here rather
+// than propagating an invalid value into a fixture (#272).
+//
+// The alphabets are ASCII, so a byte count is a character count.
+func mustDraw(s string, n uint, who string) string {
+	if uint(len(s)) != n {
+		panic("fake: " + who + " could not draw " + strconv.FormatUint(uint64(n), 10) +
+			" characters: crypto/rand is unavailable")
+	}
+	return s
+}
+
 // LetterN returns n characters drawn from [A-Za-z]. n == 0 returns one
 // character, matching what the call sites were written against.
+//
+// It panics on a CSPRNG failure, like intn. Removing the mustDraw guard breaks
+// TestLetterN_PanicsOnEntropyFailure.
 func LetterN(n uint) string {
 	if n == 0 {
 		n = 1
 	}
-	return stringutil.GenerateRandomLetterString(int(n))
+	return mustDraw(stringutil.GenerateRandomLetterString(int(n)), n, "LetterN")
 }
 
 // DigitN returns n characters drawn from [0-9]. It stands in for the phone
 // numbers, postcodes and street numbers the fixtures used to ask for by name:
 // nothing parses those fields, only the column width constrains them, so a digit
 // run of the right length is the whole requirement (#272).
+//
+// It panics on a CSPRNG failure, like intn. Removing the mustDraw guard breaks
+// TestDigitN_PanicsOnEntropyFailure.
 func DigitN(n uint) string {
 	if n == 0 {
 		n = 1
 	}
-	return stringutil.GenerateRandomNumberString(int(n))
+	return mustDraw(stringutil.GenerateRandomNumberString(int(n)), n, "DigitN")
 }
 
 // Password returns an n-character password containing at least one lowercase

--- a/src/core/testutil/fake/fake.go
+++ b/src/core/testutil/fake/fake.go
@@ -1,0 +1,226 @@
+// Package fake supplies the random values the repository's tests write into
+// fixtures: usernames, passwords, emails, redirect URIs, names, dates and plain
+// letter runs. It exists only for _test.go files. Nothing a binary links reaches
+// it, and no function here takes a *testing.T, so a call sits wherever a literal
+// would: inside a composite literal, a table row, or an argument list.
+//
+// It replaces the third-party faker this repository used to depend on, retired
+// in #272 because a test-only module in three go.mod files is a supply-chain
+// cost with no production value. Two properties differ from that library on
+// purpose, and both are why call sites can trust these values without checking
+// them:
+//
+//   - Every value is drawn from crypto/rand, so nothing is reproducible from a
+//     seed. A seed only replays a value if the whole package re-runs in source
+//     order, because the draw count before the failing test selects the value;
+//     `go test -run TestX` reproduces nothing. Test failures already print the
+//     generated value they compared, which is the replay that gets used.
+//   - Values are drawn from the full character space rather than from a small
+//     word corpus, so two draws colliding is unreachable rather than merely
+//     unlikely. That is what closes #136: a corpus of a few thousand surnames
+//     collides inside a test database of a few thousand rows.
+package fake
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/stringutil"
+)
+
+const (
+	lowerChars   = "abcdefghijklmnopqrstuvwxyz"
+	upperChars   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	digitChars   = "0123456789"
+	specialChars = "@#$&?!-_*."
+	// passwordChars is what the length beyond the four guaranteed characters is
+	// drawn from. Keeping the four classes in one alphabet makes each remaining
+	// position uniform over the whole space rather than over a rotation of it.
+	passwordChars = lowerChars + upperChars + digitChars + specialChars
+)
+
+// intn returns a uniform value in [0, n) read from crypto/rand. Every draw in
+// this package that is not a letter or a digit run goes through it, which is why
+// the package holds no global source, no seed and no mutex: crypto/rand.Reader
+// is safe for concurrent use and needs no initialisation.
+//
+// It panics on a CSPRNG failure rather than returning a zero. A fixture that
+// silently degrades to a constant produces tests that pass while generating the
+// same username every time, which is exactly the failure #136 describes.
+func intn(n int) int {
+	if n <= 0 {
+		panic("fake: intn needs a positive bound")
+	}
+	v, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	if err != nil {
+		panic("fake: crypto/rand is unavailable: " + err.Error())
+	}
+	return int(v.Int64())
+}
+
+// LetterN returns n characters drawn from [A-Za-z]. n == 0 returns one
+// character, matching what the call sites were written against.
+func LetterN(n uint) string {
+	if n == 0 {
+		n = 1
+	}
+	return stringutil.GenerateRandomLetterString(int(n))
+}
+
+// DigitN returns n characters drawn from [0-9]. It stands in for the phone
+// numbers, postcodes and street numbers the fixtures used to ask for by name:
+// nothing parses those fields, only the column width constrains them, so a digit
+// run of the right length is the whole requirement (#272).
+func DigitN(n uint) string {
+	if n == 0 {
+		n = 1
+	}
+	return stringutil.GenerateRandomNumberString(int(n))
+}
+
+// Password returns an n-character password containing at least one lowercase
+// letter, one uppercase letter, one digit and one of "@#$&?!-_*.".
+//
+// The guarantee is not decorative. Integration tests run under the seeded
+// password policy "low", which requires none of those classes, so an unguaranteed
+// draw passes today; raising a test to the "high" policy would then flake, and at
+// eight characters roughly one draw in four lacks a special character. Four lines
+// here are cheaper than a flake nobody can reproduce (#272). Removing them
+// breaks TestPassword_AllClassesPresent.
+//
+// It panics below 4, which cannot be satisfied. The shortest length any call site
+// asks for is 8.
+func Password(n int) string {
+	if n < 4 {
+		panic("fake: Password needs at least 4 characters to carry all four classes")
+	}
+
+	out := make([]byte, 0, n)
+	out = append(out, lowerChars[intn(len(lowerChars))])
+	out = append(out, upperChars[intn(len(upperChars))])
+	out = append(out, digitChars[intn(len(digitChars))])
+	out = append(out, specialChars[intn(len(specialChars))])
+	for len(out) < n {
+		out = append(out, passwordChars[intn(len(passwordChars))])
+	}
+
+	// Fisher-Yates, so the four guaranteed characters do not always sit in the
+	// first four positions.
+	for i := len(out) - 1; i > 0; i-- {
+		j := intn(i + 1)
+		out[i], out[j] = out[j], out[i]
+	}
+	return string(out)
+}
+
+// Email returns a 24-character address of the form "<12 lowercase letters>@example.com".
+// It satisfies the address regex in EmailValidator.ValidateEmailAddress and sits
+// well under the 60-character cap ValidateEmailUpdate applies.
+func Email() string {
+	return strings.ToLower(LetterN(12)) + "@example.com"
+}
+
+// URL returns an absolute https URI with a host and no fragment, which is what
+// ValidateClientAndRedirectURI requires of a value registered as a client
+// redirect URI and then presented at /auth/authorize.
+func URL() string {
+	return "https://" + strings.ToLower(LetterN(10)) + ".example.com/" + strings.ToLower(LetterN(6))
+}
+
+// UUID returns a random UUID string. Nothing in the fixtures parses one; they
+// are session identifiers, JTIs and key identifiers written straight to a column.
+func UUID() string {
+	return uuid.NewString()
+}
+
+// Username returns "user" followed by 12 lowercase letters: 16 characters, well
+// inside the 32-character column.
+//
+// The length is the fix for #136. TestSearchUsersPaginated asserts that a freshly
+// generated username matches exactly one row, over a LIKE across six columns of a
+// table the server-backed engines never reset. Drawing from 26^12 rather than from
+// a few thousand surnames takes the birthday expectation at a few thousand rows
+// from around one collision to around 1e-15, and a 16-character lowercase run
+// cannot appear inside an email or a name generated here either. Shortening it
+// re-opens the flake; TestUsername_Distinct is what notices.
+func Username() string {
+	return "user" + strings.ToLower(LetterN(12))
+}
+
+// nameWord returns one capitalised run of 6 to 8 letters, which fits every
+// varchar(64) name column in the schema.
+func nameWord() string {
+	return strings.ToUpper(LetterN(1)) + strings.ToLower(LetterN(uint(5+intn(3))))
+}
+
+// FirstName returns a capitalised 6-to-8-letter run.
+func FirstName() string { return nameWord() }
+
+// LastName returns a capitalised 6-to-8-letter run.
+func LastName() string { return nameWord() }
+
+// MiddleName returns a capitalised 6-to-8-letter run.
+func MiddleName() string { return nameWord() }
+
+// Name returns a first and last name joined by one space.
+func Name() string { return FirstName() + " " + LastName() }
+
+// IPv4Address returns a dotted-quad address. Fixtures store it as a session's
+// device address; nothing routes to it.
+func IPv4Address() string {
+	octets := make([]string, 4)
+	for i := range octets {
+		octets[i] = strconv.Itoa(intn(256))
+	}
+	return strings.Join(octets, ".")
+}
+
+// Bool returns true or false with equal probability.
+func Bool() bool {
+	return intn(2) == 1
+}
+
+// Number returns a value in [min, max], inclusive at both ends. It panics when
+// max is below min, which is a caller mistake rather than an empty range.
+func Number(min, max int) int {
+	if max < min {
+		panic("fake: Number needs max >= min")
+	}
+	return min + intn(max-min+1)
+}
+
+var (
+	dateStart = time.Date(1950, time.January, 1, 0, 0, 0, 0, time.UTC)
+	dateEnd   = time.Date(2010, time.December, 31, 23, 59, 59, 0, time.UTC)
+)
+
+// Date returns a UTC instant between 1950-01-01 and 2010-12-31 with a zero
+// sub-second part.
+//
+// Whole seconds are load-bearing: the same value is written to a MySQL datetime,
+// a SQL Server datetime2 and a SQLite text column and then compared with what was
+// stored, and the callers that do apply Truncate(time.Microsecond). A value with
+// nanoseconds round-trips differently per engine and the comparison fails on one
+// of the four (#272). The year range keeps every engine's minimum well behind it.
+func Date() time.Time {
+	span := int(dateEnd.Unix() - dateStart.Unix())
+	return time.Unix(dateStart.Unix()+int64(intn(span+1)), 0).UTC()
+}
+
+// Sentence returns the given number of lowercase letter runs, each 3 to 8
+// characters, joined by single spaces. It stands in for the prose the fixtures
+// used to ask a corpus for, none of which is ever parsed.
+func Sentence(words int) string {
+	if words <= 0 {
+		return ""
+	}
+	out := make([]string, words)
+	for i := range out {
+		out[i] = strings.ToLower(LetterN(uint(3 + intn(6))))
+	}
+	return strings.Join(out, " ")
+}

--- a/src/core/testutil/fake/fake_test.go
+++ b/src/core/testutil/fake/fake_test.go
@@ -1,6 +1,8 @@
 package fake
 
 import (
+	"crypto/rand"
+	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -58,6 +60,55 @@ func TestDigitN(t *testing.T) {
 			}
 		}
 	}
+}
+
+// brokenReader stands in for a system CSPRNG that has stopped answering. It is
+// the only way to reach the branch stringutil takes when crypto/rand fails,
+// because that helper swallows the error and returns "".
+type brokenReader struct{}
+
+func (brokenReader) Read([]byte) (int, error) {
+	return 0, errors.New("fake_test: entropy source is unavailable")
+}
+
+// withBrokenEntropy runs fn with crypto/rand.Reader replaced, and restores it
+// however fn leaves: these cases expect a panic, and a reader left broken would
+// take every later case in the package down with it. No test in this repository
+// calls t.Parallel(), so swapping the package variable for the length of one
+// case races with nothing.
+func withBrokenEntropy(t *testing.T, fn func()) {
+	t.Helper()
+	saved := rand.Reader
+	rand.Reader = brokenReader{}
+	defer func() { rand.Reader = saved }()
+	fn()
+}
+
+// TestLetterN_PanicsOnEntropyFailure and its DigitN twin pin the fail-closed
+// contract the package documents: a generator either produces its shape or stops
+// the test. stringutil returns "" on a CSPRNG failure, so without the mustDraw
+// guard LetterN hands a fixture an empty username and the suite goes green while
+// every generated value is identical (#272).
+func TestLetterN_PanicsOnEntropyFailure(t *testing.T) {
+	withBrokenEntropy(t, func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("LetterN(8) with a broken CSPRNG: want a panic, got none")
+			}
+		}()
+		_ = LetterN(8)
+	})
+}
+
+func TestDigitN_PanicsOnEntropyFailure(t *testing.T) {
+	withBrokenEntropy(t, func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("DigitN(8) with a broken CSPRNG: want a panic, got none")
+			}
+		}()
+		_ = DigitN(8)
+	})
 }
 
 // TestPassword_AllClassesPresent is the pin for the guarantee Password documents:

--- a/src/core/testutil/fake/fake_test.go
+++ b/src/core/testutil/fake/fake_test.go
@@ -1,0 +1,304 @@
+package fake
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/urlutil"
+	"github.com/leodip/goiabada/core/validators"
+)
+
+// draws is how many times each property below is exercised. Every generator here
+// is random, so a single draw proves almost nothing: the properties that matter
+// (a password carrying all four classes, a bool taking both values) are the ones
+// an unlucky implementation satisfies once in a while by accident.
+const draws = 1000
+
+func isFrom(s, alphabet string) bool {
+	for _, r := range s {
+		if !strings.ContainsRune(alphabet, r) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestLetterN(t *testing.T) {
+	for _, n := range []uint{1, 6, 8, 12, 43, 73, 129} {
+		for i := 0; i < draws; i++ {
+			got := LetterN(n)
+			if uint(len(got)) != n {
+				t.Fatalf("LetterN(%d): got %d characters, want %d", n, len(got), n)
+			}
+			if !isFrom(got, lowerChars+upperChars) {
+				t.Fatalf("LetterN(%d): %q is not all letters", n, got)
+			}
+		}
+	}
+	for i := 0; i < draws; i++ {
+		if got := LetterN(0); len(got) != 1 {
+			t.Fatalf("LetterN(0): got %q, want one character", got)
+		}
+	}
+}
+
+func TestDigitN(t *testing.T) {
+	for _, n := range []uint{1, 2, 3, 5, 10} {
+		for i := 0; i < draws; i++ {
+			got := DigitN(n)
+			if uint(len(got)) != n {
+				t.Fatalf("DigitN(%d): got %d characters, want %d", n, len(got), n)
+			}
+			if !isFrom(got, digitChars) {
+				t.Fatalf("DigitN(%d): %q is not all digits", n, got)
+			}
+		}
+	}
+}
+
+// TestPassword_AllClassesPresent is the pin for the guarantee Password documents:
+// every draw carries a lowercase letter, an uppercase letter, a digit and a
+// special character, at every length asked for. Removing the four per-class draws
+// leaves this failing within a few dozen iterations at n = 8.
+func TestPassword_AllClassesPresent(t *testing.T) {
+	for _, n := range []int{4, 8, 32, 64} {
+		for i := 0; i < draws; i++ {
+			got := Password(n)
+			if len(got) != n {
+				t.Fatalf("Password(%d): got %d characters, want %d", n, len(got), n)
+			}
+			if !isFrom(got, passwordChars) {
+				t.Fatalf("Password(%d): %q holds a character outside the alphabet", n, got)
+			}
+			for _, class := range []struct {
+				name     string
+				alphabet string
+			}{
+				{"lowercase", lowerChars},
+				{"uppercase", upperChars},
+				{"digit", digitChars},
+				{"special", specialChars},
+			} {
+				if !strings.ContainsAny(got, class.alphabet) {
+					t.Fatalf("Password(%d): %q has no %s character", n, got, class.name)
+				}
+			}
+		}
+	}
+}
+
+func TestPassword_PanicsBelowFour(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Password(3): want a panic, got none")
+		}
+	}()
+	_ = Password(3)
+}
+
+// TestEmail checks the address against the validator the handlers apply rather
+// than against a regex copied here. ValidateEmailAddress reads no database, so a
+// nil one is enough to construct the validator.
+func TestEmail(t *testing.T) {
+	val := validators.NewEmailValidator(nil)
+	for i := 0; i < draws; i++ {
+		got := Email()
+		if len(got) != 24 {
+			t.Fatalf("Email(): %q is %d characters, want 24", got, len(got))
+		}
+		if got != strings.ToLower(got) {
+			t.Fatalf("Email(): %q is not lowercase", got)
+		}
+		if err := val.ValidateEmailAddress(got); err != nil {
+			t.Fatalf("Email(): %q rejected by the validator: %v", got, err)
+		}
+	}
+}
+
+// TestURL holds the value to the predicate ValidateClientAndRedirectURI applies
+// to a registered redirect URI, which is stricter than url.Parse: absolute, with
+// a host, and no fragment.
+func TestURL(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := URL()
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("URL(): %q does not parse: %v", got, err)
+		}
+		if !u.IsAbs() || u.Host == "" {
+			t.Fatalf("URL(): %q is not absolute with a host", got)
+		}
+		if !urlutil.IsAbsoluteRedirectURI(got) {
+			t.Fatalf("URL(): %q is not a usable redirect URI", got)
+		}
+	}
+}
+
+func TestUUID(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := UUID()
+		if _, err := uuid.Parse(got); err != nil {
+			t.Fatalf("UUID(): %q does not parse: %v", got, err)
+		}
+	}
+}
+
+// TestUsername_Distinct is the #136 pin. Ten thousand draws with no repeat is not
+// a probabilistic hope at 26^12; it fails immediately if the generated part is
+// ever shortened to something a test database could collide on.
+func TestUsername_Distinct(t *testing.T) {
+	const usernameDraws = 10000
+	seen := make(map[string]struct{}, usernameDraws)
+	for i := 0; i < usernameDraws; i++ {
+		got := Username()
+		if len(got) != 16 {
+			t.Fatalf("Username(): %q is %d characters, want 16", got, len(got))
+		}
+		if !strings.HasPrefix(got, "user") {
+			t.Fatalf("Username(): %q does not start with \"user\"", got)
+		}
+		if !isFrom(got, lowerChars) {
+			t.Fatalf("Username(): %q is not all lowercase letters", got)
+		}
+		if _, dup := seen[got]; dup {
+			t.Fatalf("Username(): %q drawn twice in %d draws", got, usernameDraws)
+		}
+		seen[got] = struct{}{}
+	}
+}
+
+func TestNames(t *testing.T) {
+	for _, fn := range []struct {
+		name string
+		gen  func() string
+	}{
+		{"FirstName", FirstName},
+		{"LastName", LastName},
+		{"MiddleName", MiddleName},
+	} {
+		for i := 0; i < draws; i++ {
+			got := fn.gen()
+			if len(got) < 6 || len(got) > 8 {
+				t.Fatalf("%s(): %q is %d characters, want 6 to 8", fn.name, got, len(got))
+			}
+			if !isFrom(got[:1], upperChars) {
+				t.Fatalf("%s(): %q does not start uppercase", fn.name, got)
+			}
+			if !isFrom(got[1:], lowerChars) {
+				t.Fatalf("%s(): %q is not lowercase after the first character", fn.name, got)
+			}
+		}
+	}
+}
+
+func TestName(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := Name()
+		parts := strings.Split(got, " ")
+		if len(parts) != 2 {
+			t.Fatalf("Name(): %q is not two space-separated words", got)
+		}
+		for _, part := range parts {
+			if len(part) < 6 || len(part) > 8 || !isFrom(part[:1], upperChars) {
+				t.Fatalf("Name(): %q holds a malformed part %q", got, part)
+			}
+		}
+	}
+}
+
+func TestIPv4Address(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := IPv4Address()
+		ip := net.ParseIP(got)
+		if ip == nil {
+			t.Fatalf("IPv4Address(): %q does not parse", got)
+		}
+		if ip.To4() == nil {
+			t.Fatalf("IPv4Address(): %q is not a v4 address", got)
+		}
+	}
+}
+
+// TestBool_BothValues pins that Bool is a draw rather than a constant: an
+// implementation returning one value always passes any single-draw assertion.
+func TestBool_BothValues(t *testing.T) {
+	var sawTrue, sawFalse bool
+	for i := 0; i < draws; i++ {
+		if Bool() {
+			sawTrue = true
+		} else {
+			sawFalse = true
+		}
+	}
+	if !sawTrue || !sawFalse {
+		t.Fatalf("Bool(): over %d draws saw true=%v false=%v, want both", draws, sawTrue, sawFalse)
+	}
+}
+
+func TestNumber(t *testing.T) {
+	var sawMin, sawMax bool
+	for i := 0; i < draws; i++ {
+		got := Number(1, 3)
+		if got < 1 || got > 3 {
+			t.Fatalf("Number(1, 3): got %d, want 1 to 3", got)
+		}
+		if got == 1 {
+			sawMin = true
+		}
+		if got == 3 {
+			sawMax = true
+		}
+	}
+	if !sawMin || !sawMax {
+		t.Fatalf("Number(1, 3): over %d draws saw 1=%v 3=%v, want both ends", draws, sawMin, sawMax)
+	}
+	if got := Number(5, 5); got != 5 {
+		t.Fatalf("Number(5, 5): got %d, want 5", got)
+	}
+}
+
+func TestNumber_PanicsOnInvertedRange(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Number(3, 1): want a panic, got none")
+		}
+	}()
+	_ = Number(3, 1)
+}
+
+func TestDate(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := Date()
+		if got.Before(dateStart) || got.After(dateEnd) {
+			t.Fatalf("Date(): %v is outside [%v, %v]", got, dateStart, dateEnd)
+		}
+		if got.Nanosecond() != 0 {
+			t.Fatalf("Date(): %v carries a sub-second part", got)
+		}
+		if got.Location() != time.UTC {
+			t.Fatalf("Date(): %v is in %v, want UTC", got, got.Location())
+		}
+	}
+}
+
+func TestSentence(t *testing.T) {
+	for i := 0; i < draws; i++ {
+		got := Sentence(5)
+		words := strings.Split(got, " ")
+		if len(words) != 5 {
+			t.Fatalf("Sentence(5): %q has %d words, want 5", got, len(words))
+		}
+		for _, w := range words {
+			if len(w) < 3 || len(w) > 8 {
+				t.Fatalf("Sentence(5): %q holds a %d-character word %q, want 3 to 8", got, len(w), w)
+			}
+			if !isFrom(w, lowerChars) {
+				t.Fatalf("Sentence(5): %q holds a non-lowercase word %q", got, w)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #272. Closes #136.

## What this is for

`github.com/brianvoe/gofakeit/v6` is a direct requirement of `core` and `authserver`, reaching
`adminconsole` through `core`, and it is used by nothing but `_test.go` files: 114 of them, 1508
calls, to draw random letters, passwords, emails, redirect URIs, UUIDs and a handful of profile
fields. Every generated value is opaque to the test that draws it. Only a validator, a column width
or a parser ever constrained one, and the tree already has a `crypto/rand` letters generator in
`core/stringutil`.

This change replaces the library with a small package, `src/core/testutil/fake`, standard library
plus `core/stringutil` and `google/uuid`, whose functions satisfy the consumers by construction:
`LetterN` is letters only, `Password(n)` always carries all four character classes so a test
raising the policy to `High` cannot flake, `Email` and `URL` are shapes the validators accept.

It also closes #136. `TestSearchUsersPaginated` asserted that a fresh `gofakeit.Username()` matched
exactly one row in a MySQL table that is never reset, and that generator's value space is about
4.7 million: at the row count #136 measured, a duplicate was expected. `fake.Username()` is
`"user"` plus 12 random letters, 52^12 values, so the collision is unreachable.

## The rule it establishes

Test fixtures draw random values from `core/testutil/fake`. No test-only faker library comes
back; the compiler guards it once the two `go.mod` files stop requiring one.

## Status

Complete, and ready for review. Both stages have landed and the whole change has been reviewed.
`grep -rl gofakeit src` returns nothing, no `go.mod` requires the module and no `go.sum` lists it.
The check suite is green at `9a8a8b87` on all twelve jobs, which is where the four-engine data and
integration result lives.

## What has landed

### Stage 1: the `fake` package and its unit table

Landed in `e71fd694`. `src/core/testutil/fake` holds the whole surface the agreement's design lists:
`LetterN`, `DigitN`, `Password`, `Email`, `URL`, `UUID`, `Username`, the three name generators plus
`Name`, `IPv4Address`, `Bool`, `Number`, `Date` and `Sentence`. `LetterN` and `DigitN` delegate to
`core/stringutil`, so the tree gains no second letters generator; every other draw goes through one
private `intn` over `crypto/rand.Int`, so the package carries no global, no seed and no mutex.

Three properties are load-bearing rather than incidental. `Password(n)` guarantees a lowercase
letter, an uppercase letter, a digit and a special character at every length, because the
integration tests run under the seeded `low` policy that requires none of them and a test raised to
`high` would otherwise flake. `Username()` is `"user"` plus 12 lowercase letters, which is the fix
for #136: a few thousand surnames collide inside a test database of a few thousand rows and 26^12
does not. `Date()` is whole seconds, so the same value round-trips unchanged through MySQL
`datetime`, SQL Server `datetime2` and SQLite.

Tiers: unit green in the dev container, 61 packages ok, 0 fail. Data and integration are not
applicable — nothing outside the package's own test imports it, so no query, route or handler can
reach it. Four mutations run and all four caught: `Password`'s per-class draws removed, `Username`'s
entropy shrunk to a 676-value space at the same 16 characters, `Bool` pinned to `true`, and a
fragment appended to `URL`'s literal.

Two departures from the plan, both recorded in full in the run log: `strconv` joined the import list
the plan named, since rendering an IPv4 octet as decimal needs it and the plan listed neither it nor
`fmt`; and the `Username` mutation was padded back to 16 characters so that only the
10000-draw distinctness assertion could catch it, rather than the length assertion catching it
first.

### Stage 2: rewrite the 114 call-site files, drop the requirement, one line in CLAUDE.md

Landed in `f3b41f20`. 120 files changed: the 114 test files, two `go.mod` files, three `go.sum`
files and `CLAUDE.md`.

The 22 calls with no counterpart in `fake` went first, by hand, before any `sed` could bury them.
All 22 sit in the three profile fixtures that write a whole `models.User` through the database and
read it back, so each became a prefixed letter run sized against the column it lands in, read from
`mysqldb/schema.golden`: `"City" + fake.LetterN(6)` for `address_locality`, `"tz" + fake.LetterN(6)`
for `zone_info`, `strings.ToUpper(fake.LetterN(2))` for the two country columns, and so on.
`compareUsers` reads every one of those columns back, so a value a column truncated would fail the
data tier on the engine that truncated it. `Gender` is picked from `enums.GenderFemale` and
`enums.GenderMale` rather than generated, since the column is 16 characters and the value is echoed
back as an OIDC claim.

The remaining 1486 calls moved by four mechanical shapes, each safe because the corpus was uniform
rather than merely usually uniform: the import line had one spelling in all 114 files, all 178
`Password` calls carried the identical five booleans, and both `Numerify` calls were `"##"`.
`LoremIpsumSentence` became `Sentence`; `Numerify`, `Phone`, `Zip` and `StreetNumber` became
`DigitN` at the length each column wants. `gofmt -w` then reordered the import blocks. Only after
the last import was gone did `go mod tidy` run, in `core`, `authserver` and `adminconsole`; it
removed the gofakeit lines and nothing else, 8 deletions across the five files.

No assertion changed anywhere.

Tiers, run against the tree **before** the rewrite as well as after, which is what makes the claim
a comparison rather than a green suite: unit 1453 ok 0 fail, data green on mysql, postgres, mssql
and sqlite at 1631 ok 0 fail, integration on sqlite 1012 ok 0 fail. All three counts are identical
before and after, so the rewrite added, removed and skipped no test. No mutation was owed: this
stage adds no test, and stage 1's table already pins every generator these call sites now stand on.

Three deviations, recorded in full in the run log. Two of the agreement's code anchors cited the
`gofakeit` requirement line, which no longer exists in either `go.mod`, so both now anchor on the
file's `module` line with a note saying why. `Gender` needed a statement rather than the expression
the plan sketched, since Go cannot branch inside a composite literal. And the plan's two counts for
the `createTestUserOn` fixture, 24 and 8, count different things — every non-`LetterN` call against
the hand-rewrite subset — which is a wording point rather than a discrepancy in the work.

### After the review: the CSPRNG guard

Landed in `9a8a8b87`, answering final review round 1. `stringutil`'s letters and digits helpers
return `""` when the system CSPRNG is unavailable, a contract their production callers were written
against. Inherited by `fake`, it meant a broken CSPRNG turned `Username()` into the constant `"user"`
for every call and the suite still went green — the exact collision shape this change exists to
close. A `mustDraw` helper now panics unless a draw is the length asked for, and both wrappers route
through it. Two cases pin it by swapping `crypto/rand.Reader` for a reader that only errors.
`stringutil` itself was left alone: its `""` is load-bearing for two production call sites and
changing it is a question this change has no mandate for. The same round prompted one fixture value
to become the constant `"America/New_York"`; the regression claim behind it was refuted, and the
demonstration is in the review comment.

## How it was verified

| Tier | Where it ran | Coverage | Result |
|---|---|---|---|
| unit | locally, dev container, at `9a8a8b87` | all three modules | 5397 pass, 0 fail |
| data | locally, dev container, at `9a8a8b87` | sqlite, mysql, postgres, mssql | 2208 pass, 0 fail |
| integration | locally, dev container, at `9a8a8b87` | sqlite | 1333 pass, 0 fail |
| all of the above, plus lint, vulnerabilities, versions and build | **the check suite**, at `9a8a8b87` | four engines in parallel | [green, 12 of 12](https://github.com/leodip/goiabada/actions/runs/34235792672) |

The four-engine **integration** result exists only in the check suite; locally only sqlite was run.
Six mutations across the run, all six caught. Test counts before and after the rewrite are identical
except for the two entropy cases the review added, so nothing was dropped, skipped or renamed.

### Review

Reviewed by `openai-codex/gpt-5.6-sol` at effort `xhigh`, 3 rounds: 1 at the plan gate and 2 over
the whole branch. No stage was reviewed on its own — this run used `LEO_REVIEW_MODE=end`.

| Gate | Round | Findings | Blocking | Outcome |
|---|---|---|---|---|
| plan | 1 | 2 | 0 | both fixed in the plan before any code was written |
| final | 1 | 2 | 0 | 1 fixed in `9a8a8b87`, 1 refuted with the improvement taken anyway |
| final | 2 | 0 | 0 | clean, all three axes reviewed |

- **significant, quality:** `LetterN` and `DigitN` suppressed a CSPRNG failure, so a broken CSPRNG
  made `Username()` a constant and the suite went green. Fixed in `9a8a8b87`: a `mustDraw` guard
  that panics on a short draw, plus two regression cases; both guard-removal mutations caught.
- **significant, conformance:** the OIDC fixture's `zoneinfo` was claimed to be a new regression.
  Refuted — `gofakeit.TimeZoneFull()` drew 108 Windows display strings, never IANA identifiers, so
  the old value failed the same validator. The improvement was taken anyway in `9a8a8b87`:
  `"America/New_York"`, matching the already-constant `Locale` beside it.
- **significant, quality (plan):** the table had no `Bool` case, so a constant implementation would
  pass. Fixed in the plan; the constant-`true` mutation was later run and caught.
- **significant, conformance (plan):** the `URL` case asserted `url.Parse` and a host where the
  authorization endpoint applies `urlutil.IsAbsoluteRedirectURI`, which also refuses a fragment.
  Fixed in the plan; the fragment mutation was later run and caught.

Full account, with the evidence and both `unchecked` dispositions, in
[this comment](https://github.com/leodip/goiabada/pull/306#issuecomment-5586702888).

## The record

- [Deferred decisions](https://github.com/leodip/goiabada/pull/306#issuecomment-5586669379) — none;
  all four decisions were settled with the user before the agreement was sealed.
- [Follow-ups, fold-ins and ceilings](https://github.com/leodip/goiabada/pull/306#issuecomment-5586674584)
  — one follow-up to file (OIDC `phone_number` is not E.164), two fold-ins, no ceilings.
- [Review account](https://github.com/leodip/goiabada/pull/306#issuecomment-5586702888) — all three
  rounds, what each found and what answered it.

Nothing here asks an operator to do anything on upgrade: the change is confined to `_test.go` files,
one new package no binary imports, and the `go.mod`/`go.sum` lines that required a test-only module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
