### PR TITLE
refactor(core): retire go-i18n, the catalogs are a flat map and a text/template

### DIFF
--- a/src/adminconsole/go.mod
+++ b/src/adminconsole/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/microsoft/go-mssqldb v1.10.0 // indirect
 	github.com/mileusna/useragent v1.3.5 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/nicksnyder/go-i18n/v2 v2.6.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/src/adminconsole/go.sum
+++ b/src/adminconsole/go.sum
@@ -73,8 +73,6 @@ github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNG
 github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
-github.com/nicksnyder/go-i18n/v2 v2.6.1/go.mod h1:Vee0/9RD3Quc/NmwEjzzD7VTZ+Ir7QbXocrkhOzmUKA=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/src/authserver/go.mod
+++ b/src/authserver/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mileusna/useragent v1.3.5 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/nicksnyder/go-i18n/v2 v2.6.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/src/authserver/go.sum
+++ b/src/authserver/go.sum
@@ -86,8 +86,6 @@ github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNG
 github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
-github.com/nicksnyder/go-i18n/v2 v2.6.1/go.mod h1:Vee0/9RD3Quc/NmwEjzzD7VTZ+Ir7QbXocrkhOzmUKA=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/src/core/go.mod
+++ b/src/core/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/mileusna/useragent v1.3.5
-	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
 	github.com/stretchr/testify v1.12.1

--- a/src/core/go.sum
+++ b/src/core/go.sum
@@ -76,8 +76,6 @@ github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNG
 github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nicksnyder/go-i18n/v2 v2.6.1 h1:JDEJraFsQE17Dut9HFDHzCoAWGEQJom5s0TRd17NIEQ=
-github.com/nicksnyder/go-i18n/v2 v2.6.1/go.mod h1:Vee0/9RD3Quc/NmwEjzzD7VTZ+Ir7QbXocrkhOzmUKA=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/src/core/i18n/catalog_hygiene_test.go
+++ b/src/core/i18n/catalog_hygiene_test.go
@@ -3,32 +3,48 @@ package i18n
 import (
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// loadCatalogFlat parses an embedded catalog TOML into a flat key->value map.
-// The catalogs use quoted dotted keys (e.g. "auth.pwd.title"), which TOML
-// treats as literal single keys, so a flat map[string]string is correct.
+// loadCatalogFlat parses an embedded catalog TOML into a flat key->value map,
+// through the loader's own parser, so the assertions below hold the embedded
+// catalogs to exactly the rules LoadBundle enforces at startup. The catalogs
+// use quoted dotted keys (e.g. "auth.pwd.title"), which TOML treats as literal
+// single keys, so a flat map[string]string is correct.
 func loadCatalogFlat(t *testing.T, name string) map[string]string {
 	t.Helper()
 	data, err := embeddedCatalogs.ReadFile("catalogs/" + name)
 	require.NoError(t, err, "reading %s", name)
-	m := map[string]string{}
-	require.NoError(t, toml.Unmarshal(data, &m), "parsing %s", name)
+	_, m, err := parseCatalog(name, data)
+	require.NoError(t, err, "parsing %s", name)
 	require.NotEmpty(t, m, "%s parsed to zero keys", name)
 	return m
 }
 
-// TestCatalog_NoEmptyValues guards against the "empty_prefix" class of bug:
-// go-i18n drops a message whose value is "" and then reports it identically to
-// a missing key, so T() falls back to the visible-miss policy and renders the
-// raw key onto the page. An intentionally-empty slot can therefore never work.
+// TestParseCatalog_RefusesATableValue pins decision 3 of #273: a [table]
+// section, which is how go-i18n spelled plural forms, fails the load naming
+// the file and the key rather than being tolerated into one form rendered for
+// every count.
+func TestParseCatalog_RefusesATableValue(t *testing.T) {
+	const table = `[greeting]
+other = "hi"
+`
+	_, _, err := parseCatalog("active.xx.toml", []byte(table))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active.xx.toml")
+	assert.Contains(t, err.Error(), `"greeting"`)
+}
+
+// TestCatalog_NoEmptyValues guards against the "empty_prefix" class of bug: an
+// empty value means "no translation here", so the loader removes the key from
+// that locale and T() renders English. In the English catalog itself that
+// leaves nothing to render but the key. An intentionally-empty slot can
+// therefore never work.
 func TestCatalog_NoEmptyValues(t *testing.T) {
 	for _, name := range []string{"active.en.toml", "active.pt-BR.toml"} {
 		for k, v := range loadCatalogFlat(t, name) {
-			assert.NotEmptyf(t, v, "%s: key %q has an empty value; go-i18n treats it as missing and leaks the key in the UI", name, k)
+			assert.NotEmptyf(t, v, "%s: key %q has an empty value; the loader treats it as absent, so the key renders English or leaks into the UI", name, k)
 		}
 	}
 }

--- a/src/core/i18n/catalogs/active.en.toml
+++ b/src/core/i18n/catalogs/active.en.toml
@@ -3,8 +3,8 @@
 # Every key referenced by code or templates must have an entry here.
 # Other locales are translations of this file.
 #
-# Format: simple "key" = "value" (go-i18n parses dotted keys via TOML
-# string keys). Use [section]\nother = "..." for plural forms when needed.
+# Format: simple "key" = "value". Values are plain strings; {{.name}}
+# placeholders render with Go text/template. A [table] is refused at startup.
 
 # --- Common shared strings ---------------------------------------------------
 

--- a/src/core/i18n/error.go
+++ b/src/core/i18n/error.go
@@ -2,8 +2,6 @@ package i18n
 
 import (
 	"context"
-
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 )
 
 // LocalizedError carries a stable error code and template arguments. The
@@ -40,33 +38,16 @@ func (e *LocalizedError) EnglishFallback() string {
 	if defaultBundle == nil {
 		return e.Code
 	}
-	return localize(defaultBundle.english, e.Code, e.Args)
+	return defaultBundle.english.render(e.Code, e.Args)
 }
 
 // Localize renders e against the locale carried on ctx, with e.Args
 // substituted. Falls back to EnglishFallback() if the key is missing in
 // the resolved locale.
 func (e *LocalizedError) Localize(ctx context.Context) string {
-	loc := Localizer(ctx)
-	out, err := loc.Localize(buildConfig(e.Code, e.Args))
-	if err != nil {
+	out, ok := Localizer(ctx).renderOrMiss(e.Code, e.Args)
+	if !ok {
 		return e.EnglishFallback()
 	}
 	return out
-}
-
-func localize(loc *i18n.Localizer, code string, args map[string]any) string {
-	out, err := loc.Localize(buildConfig(code, args))
-	if err != nil {
-		return code
-	}
-	return out
-}
-
-func buildConfig(code string, args map[string]any) *i18n.LocalizeConfig {
-	cfg := &i18n.LocalizeConfig{MessageID: code}
-	if len(args) > 0 {
-		cfg.TemplateData = args
-	}
-	return cfg
 }

--- a/src/core/i18n/error_test.go
+++ b/src/core/i18n/error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalizedError_EnglishFallback(t *testing.T) {
@@ -21,20 +22,30 @@ func TestLocalizedError_ErrorReturnsEnglishFallback(t *testing.T) {
 
 func TestLocalizedError_LocalizePtBR(t *testing.T) {
 	le := NewLocalizedError(ErrCodeLoginAuthFailed, nil)
-	r := DefaultBundle().localizerFor([]string{"pt-BR"})
-	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
-	assert.Equal(t, "Falha na autenticação.", le.Localize(ctx))
+	assert.Equal(t, "Falha na autenticação.", le.Localize(ctxFor("pt-BR")))
 }
 
 func TestLocalizedError_LocalizeFallsThroughToEnglishWhenLocaleMissesKey(t *testing.T) {
-	// pt-BR catalog stub doesn't include arbitrary keys — go-i18n falls
-	// through to English via the bundle's default tag.
-	le := NewLocalizedError("validator.login.email_required", nil)
-	r := DefaultBundle().localizerFor([]string{"pt-BR"})
-	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
-	// "validator.login.email_required" IS in pt-BR stub, so this assertion
-	// confirms localization works for keys present in the resolved locale.
-	assert.Equal(t, "O e-mail é obrigatório.", le.Localize(ctx))
+	// The embedded catalogs are held to identical key sets, so the fallback
+	// needs a locale that genuinely misses the key: an override-only fr
+	// catalog carrying nothing but the title.
+	require.NoError(t, loadBundleWithOverrides(t, map[string]string{
+		"active.fr.toml": `"auth.pwd.title" = "Connexion"` + "\n",
+	}))
+
+	le := NewLocalizedError(ErrCodeLoginAuthFailed, nil)
+	assert.Equal(t, "Authentication failed.", le.Localize(ctxFor("fr")))
+}
+
+func TestLocalizedError_ArgsSubstituteInEveryRendering(t *testing.T) {
+	// 15 production constructors pass Args; all three renderings must
+	// substitute them, in the resolved locale and in English.
+	le := NewLocalizedError(ErrCodeEmailTooLong, map[string]any{"max": 60})
+	const english = "The email address cannot exceed a maximum length of 60 characters."
+	assert.Equal(t, english, le.EnglishFallback())
+	assert.Equal(t, english, le.Error())
+	assert.Equal(t, "O endereço de e-mail não pode ter mais que 60 caracteres.",
+		le.Localize(ctxFor("pt-BR")))
 }
 
 func TestLocalizedError_UnknownCodeReturnsCodeString(t *testing.T) {

--- a/src/core/i18n/i18n.go
+++ b/src/core/i18n/i18n.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
 )
 
@@ -41,12 +42,43 @@ const (
 	ctxKeyLocaleTag
 )
 
-// Bundle wraps go-i18n's bundle plus the precomputed English localizer
-// used as the always-available fallback.
+// message is one catalog entry. raw is the verbatim catalog string, which
+// Raw() hands to the JS bootstrap; tmpl is the compiled template T() renders,
+// present only for values carrying a "{{" placeholder.
+type message struct {
+	raw  string
+	tmpl *template.Template
+	// bad marks a value that looks templated but does not parse as one. The
+	// JS bootstrap strings are the known case: their {{param}} placeholders
+	// are substituted client-side by tFormat(), so text/template reads them
+	// as calls to unknown functions. T() renders the key for those, which is
+	// what it did before, and Raw() still returns raw verbatim (#273).
+	bad bool
+}
+
+// Bundle holds every catalog, keyed by language tag, plus the matcher that
+// turns a request's preferences into one of those tags.
 type Bundle struct {
-	inner   *i18n.Bundle
-	english *i18n.Localizer
-	tags    []language.Tag
+	// tags is English first, then catalogs in load order with override-only
+	// locales last. The matcher indexes into it, so the two must stay aligned.
+	tags     []language.Tag
+	matcher  language.Matcher
+	messages map[language.Tag]map[string]*message
+	english  *Translator
+}
+
+// Translator renders keys against one resolved language tag, falling back to
+// English. It is the type carried on the request context; Localizer(ctx)
+// returns it.
+type Translator struct {
+	bundle *Bundle
+	tag    language.Tag
+}
+
+// catalogFile is one parsed catalog awaiting the merge, in load order.
+type catalogFile struct {
+	tag      language.Tag
+	messages map[string]string
 }
 
 // defaultBundle is set by LoadBundle and read by T/Localizer/EnglishFallback.
@@ -58,39 +90,105 @@ var defaultBundle *Bundle
 // as the package default so T() can be called without threading a bundle
 // through every handler. Call exactly once at process startup.
 func LoadBundle() (*Bundle, error) {
-	b := i18n.NewBundle(language.English)
-	b.RegisterUnmarshalFunc("toml", toml.Unmarshal)
-
-	tags, err := loadEmbeddedCatalogs(b)
+	files, err := loadEmbeddedCatalogs()
 	if err != nil {
 		return nil, err
 	}
 
-	// Parallel raw (un-templated) copy of the catalogs for the JS bootstrap.
-	rawCatalogs = map[string]map[string]string{}
-	if err := loadRawEmbeddedCatalogs(); err != nil {
-		return nil, err
-	}
-
 	if dir := strings.TrimSpace(os.Getenv("GOIABADA_I18N_OVERRIDES_DIR")); dir != "" {
-		overrideTags, err := loadOverrideCatalogs(b, dir)
+		overrides, err := loadOverrideCatalogs(dir)
 		if err != nil {
 			return nil, err
 		}
-		tags = mergeTags(tags, overrideTags)
-		if err := loadRawOverrideCatalogs(dir); err != nil {
-			return nil, err
+		files = append(files, overrides...)
+	}
+
+	b := &Bundle{messages: map[language.Tag]map[string]*message{}}
+	fileTags := make([]language.Tag, 0, len(files))
+	for _, f := range files {
+		fileTags = append(fileTags, f.tag)
+		locale := b.messages[f.tag]
+		if locale == nil {
+			locale = map[string]*message{}
+			b.messages[f.tag] = locale
+		}
+		for k, v := range f.messages {
+			// An empty value means "no translation here", so a later file
+			// removes an earlier one's key rather than shadowing it with a
+			// blank. The key then renders English, which is what a
+			// self-hoster blanking a line in an override file is asking for
+			// (#273).
+			if v == "" {
+				delete(locale, k)
+				continue
+			}
+			locale[k] = &message{raw: v}
 		}
 	}
+	// English leads the tag list because it is the source-of-truth catalog and
+	// the matcher's answer when nothing else matches.
+	b.tags = mergeTags([]language.Tag{language.English}, fileTags)
+	b.matcher = language.NewMatcher(b.tags)
+	b.english = &Translator{bundle: b, tag: language.English}
+	compileTemplates(b)
 
-	bundle := &Bundle{
-		inner:   b,
-		english: i18n.NewLocalizer(b, language.English.String()),
-		tags:    tags,
+	defaultBundle = b
+
+	return b, nil
+}
+
+// compileTemplates parses every value carrying a "{{" placeholder, once, after
+// the last file has been merged. The result is immutable for the process
+// lifetime, so rendering needs no lock and no cache.
+func compileTemplates(b *Bundle) {
+	for _, locale := range b.messages {
+		for key, m := range locale {
+			if !strings.Contains(m.raw, "{{") {
+				continue
+			}
+			tmpl, err := template.New(key).Option("missingkey=default").Parse(m.raw)
+			if err != nil {
+				m.bad = true
+				continue
+			}
+			m.tmpl = tmpl
+		}
 	}
-	defaultBundle = bundle
+}
 
-	return bundle, nil
+// parseCatalog reads one catalog file into a flat key->value map and derives
+// its language tag from the file name ("active.pt-BR.toml" -> pt-BR).
+//
+// Catalog values are plain strings. A value of any other type — a [table]
+// section in particular, which is how go-i18n used to spell plural forms —
+// fails the whole load naming the file and the key, so the process does not
+// start rendering one plural form for every count (#273).
+//
+// An empty value is returned as it stands: the merge in LoadBundle needs to
+// see it to remove the key, and the catalog hygiene test needs to see it to
+// forbid it in the embedded catalogs.
+func parseCatalog(name string, data []byte) (language.Tag, map[string]string, error) {
+	var parsed map[string]any
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		return language.Tag{}, nil, fmt.Errorf("i18n: parse %s: %w", name, err)
+	}
+	out := make(map[string]string, len(parsed))
+	for k, v := range parsed {
+		s, ok := v.(string)
+		if !ok {
+			return language.Tag{}, nil, fmt.Errorf(
+				"i18n: %s: key %q is a %T, not a string; catalog values are plain strings and [table] sections are not supported",
+				name, k, v)
+		}
+		out[k] = s
+	}
+	return language.Make(localeFromCatalogFile(filepath.Base(name))), out, nil
+}
+
+// localeFromCatalogFile maps "active.pt-BR.toml" -> "pt-BR", matching the
+// tag string LocaleTag() carries on the request context.
+func localeFromCatalogFile(name string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(name, "active."), ".toml")
 }
 
 // mergeTags appends extras into base, dropping duplicates. Order is preserved
@@ -118,12 +216,12 @@ func mergeTags(base, extras []language.Tag) []language.Tag {
 	return out
 }
 
-func loadEmbeddedCatalogs(b *i18n.Bundle) ([]language.Tag, error) {
+func loadEmbeddedCatalogs() ([]catalogFile, error) {
 	entries, err := fs.ReadDir(embeddedCatalogs, "catalogs")
 	if err != nil {
 		return nil, fmt.Errorf("i18n: read embedded catalogs dir: %w", err)
 	}
-	var tags []language.Tag
+	var out []catalogFile
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
 			continue
@@ -133,15 +231,13 @@ func loadEmbeddedCatalogs(b *i18n.Bundle) ([]language.Tag, error) {
 		if err != nil {
 			return nil, fmt.Errorf("i18n: read %s: %w", path, err)
 		}
-		mf, err := b.ParseMessageFileBytes(data, e.Name())
+		tag, messages, err := parseCatalog(path, data)
 		if err != nil {
-			return nil, fmt.Errorf("i18n: parse %s: %w", path, err)
+			return nil, err
 		}
-		if mf != nil {
-			tags = append(tags, mf.Tag)
-		}
+		out = append(out, catalogFile{tag: tag, messages: messages})
 	}
-	return tags, nil
+	return out, nil
 }
 
 // SupportedTags returns the language tags loaded into the bundle, in
@@ -152,21 +248,79 @@ func (b *Bundle) SupportedTags() []language.Tag {
 	return out
 }
 
-// English returns the bundle's English localizer.
-func (b *Bundle) English() *i18n.Localizer { return b.english }
-
-// localizerFor builds a localizer that prefers the supplied tags, in order.
-// go-i18n falls through to English (the bundle's default tag) if none match.
-func (b *Bundle) localizerFor(tags []string) *i18n.Localizer {
+// localizerFor builds a translator for the supplied preferences, each of which
+// may be a full Accept-Language list. Every preference is parsed with
+// language.ParseAcceptLanguage — which drops q=0 ranges and orders the rest by
+// quality — unparseable ones are skipped, and the bundle's matcher picks one
+// tag from what is left. RFC 9110 section 12.5.4 leaves the matching scheme to
+// the implementation; this is the one go-i18n applied, kept verbatim.
+func (b *Bundle) localizerFor(tags []string) *Translator {
 	if len(tags) == 0 {
 		return b.english
 	}
-	return i18n.NewLocalizer(b.inner, tags...)
+	var parsed []language.Tag
+	for _, s := range tags {
+		ts, _, err := language.ParseAcceptLanguage(s)
+		if err != nil {
+			continue
+		}
+		parsed = append(parsed, ts...)
+	}
+	if len(parsed) == 0 {
+		return b.english
+	}
+	_, idx, _ := b.matcher.Match(parsed...)
+	return &Translator{bundle: b, tag: b.tags[idx]}
 }
 
-// DefaultBundle returns the package-level bundle established by LoadBundle.
-// Returns nil if LoadBundle has not yet run (tests, very early init).
-func DefaultBundle() *Bundle { return defaultBundle }
+// lookup finds key in the translator's own locale, then in English. The
+// English hop is what makes a locale that is missing a key render the English
+// text rather than the key itself, as concepts/localization.mdx promises
+// (#273).
+func (l *Translator) lookup(key string) (*message, bool) {
+	if l == nil || l.bundle == nil {
+		return nil, false
+	}
+	if m, ok := l.bundle.messages[l.tag][key]; ok {
+		return m, true
+	}
+	if l.tag != language.English {
+		if m, ok := l.bundle.messages[language.English][key]; ok {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+// renderOrMiss renders key with data, reporting whether the key was found at
+// all. A found-but-unrenderable message (one that failed to parse, or whose
+// execution failed) renders the key, which is the visible-miss policy, but is
+// still reported as found: English would render it no better.
+func (l *Translator) renderOrMiss(key string, data map[string]any) (string, bool) {
+	m, ok := l.lookup(key)
+	if !ok {
+		return "", false
+	}
+	if m.bad {
+		return key, true
+	}
+	if m.tmpl == nil {
+		return m.raw, true
+	}
+	var sb strings.Builder
+	if err := m.tmpl.Execute(&sb, data); err != nil {
+		return key, true
+	}
+	return sb.String(), true
+}
+
+func (l *Translator) render(key string, data map[string]any) string {
+	out, ok := l.renderOrMiss(key, data)
+	if !ok {
+		return key
+	}
+	return out
+}
 
 // T translates key against the localizer carried on ctx, falling back to
 // the English catalog when the key is missing in the resolved locale. If
@@ -176,19 +330,13 @@ func DefaultBundle() *Bundle { return defaultBundle }
 // args[0], when present, must be a map[string]any holding template data
 // for parameterized messages. Other arg shapes are silently ignored.
 func T(ctx context.Context, key string, args ...any) string {
-	loc := Localizer(ctx)
-	cfg := &i18n.LocalizeConfig{MessageID: key}
+	var data map[string]any
 	if len(args) > 0 {
 		if td, ok := args[0].(map[string]any); ok {
-			cfg.TemplateData = td
+			data = td
 		}
 	}
-	out, err := loc.Localize(cfg)
-	if err != nil {
-		// Visible-miss: emit the key so the gap is obvious in dev.
-		return key
-	}
-	return out
+	return Localizer(ctx).render(key, data)
 }
 
 // LocaleTag returns the BCP 47 language tag attached to ctx by the locale
@@ -206,16 +354,16 @@ func LocaleTag(ctx context.Context) string {
 	return "en"
 }
 
-// Localizer returns the *i18n.Localizer attached to ctx by the locale
+// Localizer returns the *Translator attached to ctx by the locale
 // middleware (or by the per-handler refinement helpers). Returns the
-// bundle's English localizer if none is attached (test contexts, background
-// jobs that never went through middleware). Returns a localizer over an
+// bundle's English translator if none is attached (test contexts, background
+// jobs that never went through middleware). Returns a translator over an
 // empty bundle if LoadBundle has not been called — in that case every key
 // resolves to itself.
-func Localizer(ctx context.Context) *i18n.Localizer {
+func Localizer(ctx context.Context) *Translator {
 	if ctx != nil {
 		if v := ctx.Value(ctxKeyLocalizer); v != nil {
-			if loc, ok := v.(*i18n.Localizer); ok {
+			if loc, ok := v.(*Translator); ok {
 				return loc
 			}
 		}
@@ -223,6 +371,5 @@ func Localizer(ctx context.Context) *i18n.Localizer {
 	if defaultBundle != nil {
 		return defaultBundle.english
 	}
-	emptyBundle := i18n.NewBundle(language.English)
-	return i18n.NewLocalizer(emptyBundle, language.English.String())
+	return &Translator{bundle: &Bundle{}, tag: language.English}
 }

--- a/src/core/i18n/i18n_test.go
+++ b/src/core/i18n/i18n_test.go
@@ -58,6 +58,31 @@ func TestLocalizer_NoCtxFallsBackToEnglish(t *testing.T) {
 	assert.Equal(t, "Login", T(context.Background(), "auth.pwd.title"))
 }
 
+func TestRenderingBeforeLoadBundle_ResolvesEveryKeyToItself(t *testing.T) {
+	// Anything that renders on the way to LoadBundle — a config failure, a
+	// startup error path — reaches the four public rendering surfaces with
+	// defaultBundle still nil. Each must return its visible key or code.
+	// Localizer in particular must return a usable translator rather than
+	// nil, because T dereferences it without checking (#273).
+	//
+	// TestMain loads the bundle before any test in this package runs, so
+	// this is the only case that reaches those arms; it is sequential, and
+	// the cleanup puts the shared bundle back.
+	saved := defaultBundle
+	t.Cleanup(func() { defaultBundle = saved })
+	defaultBundle = nil
+
+	loc := Localizer(context.Background())
+	require.NotNil(t, loc, "Localizer must not return nil before LoadBundle: T dereferences it")
+
+	assert.Equal(t, "auth.pwd.title", T(context.Background(), "auth.pwd.title"))
+	assert.Equal(t, "js.error.unexpected", Raw(context.Background(), "js.error.unexpected"))
+
+	le := NewLocalizedError(ErrCodeLoginAuthFailed, nil)
+	assert.Equal(t, ErrCodeLoginAuthFailed, le.EnglishFallback())
+	assert.Equal(t, ErrCodeLoginAuthFailed, le.Localize(context.Background()))
+}
+
 func TestOverrideDir_MergesOnTopOfEmbedded(t *testing.T) {
 	// Build a minimal override layout in a temp dir, point the env var at it,
 	// reload, and verify the override wins.
@@ -210,10 +235,25 @@ func TestT_ValueThatIsNotAGoTemplateRendersTheKey(t *testing.T) {
 	assert.Equal(t, "js.error.unexpected", T(context.Background(), "js.error.unexpected"))
 }
 
-// TestLocalizerFor_MatchesAsGoI18nDid holds every row of the parity table in
-// docs/issue-273-retire-go-i18n/probe/matcher.out, which ran go-i18n's
-// Localizer and this matcher side by side over the same inputs. The rows that
-// decide it, because nothing else observes them: a later range winning
+func TestT_TemplatedValueThatFailsToExecuteRendersTheKey(t *testing.T) {
+	// A value that parses can still fail while evaluating its data: {{.x.Y}}
+	// reaches for a field on an int. That is the fifth rendering outcome, and
+	// it renders the key like the parse failure above rather than the half
+	// string Execute wrote before it failed. Missing data is not this case —
+	// missingkey=default renders <no value> and returns no error (#273).
+	require.NoError(t, loadBundleWithOverrides(t, map[string]string{
+		"active.pt-BR.toml": "\"auth.pwd.title\" = \"{{.x.Y}}\"\n",
+	}))
+
+	ctx := ctxFor("pt-BR")
+	assert.Equal(t, "auth.pwd.title", T(ctx, "auth.pwd.title", map[string]any{"x": 1}))
+}
+
+// TestLocalizerFor_MatchesAsGoI18nDid is the parity table for the matcher that
+// replaced go-i18n's: every row was derived by running go-i18n's Localizer and
+// this one side by side over the same input, and every row is self-contained
+// here. The rows that decide it, because nothing else observes them: a later
+// range winning
 // ("fr-FR,pt;q=0.8"), a q=0 range being excluded, quality reordering the list,
 // unparseable input falling to English, and the ui_locales shape where the
 // first tag is unsupported.

--- a/src/core/i18n/i18n_test.go
+++ b/src/core/i18n/i18n_test.go
@@ -31,15 +31,15 @@ func TestT_EnglishKeyResolves(t *testing.T) {
 
 func TestT_PtBRKeyResolves(t *testing.T) {
 	// Build a localizer that prefers pt-BR — exercising the loaded stub catalog.
-	r := DefaultBundle().localizerFor([]string{"pt-BR"})
+	r := defaultBundle.localizerFor([]string{"pt-BR"})
 	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
 	assert.Equal(t, "Entrar", T(ctx, "auth.pwd.title"))
 }
 
 func TestT_UnknownLocaleFallsBackToEnglish(t *testing.T) {
-	// "xx" is not a registered locale; go-i18n falls back to the bundle's
-	// default tag (English).
-	r := DefaultBundle().localizerFor([]string{"xx"})
+	// "xx" is not a registered locale; the matcher falls back to the tag at
+	// index 0, which is English.
+	r := defaultBundle.localizerFor([]string{"xx"})
 	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
 	assert.Equal(t, "Login", T(ctx, "auth.pwd.title"))
 }
@@ -79,7 +79,7 @@ func TestOverrideDir_MergesOnTopOfEmbedded(t *testing.T) {
 	_, err := LoadBundle()
 	require.NoError(t, err)
 
-	r := DefaultBundle().localizerFor([]string{"pt-BR"})
+	r := defaultBundle.localizerFor([]string{"pt-BR"})
 	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
 	assert.Equal(t, "Acesse", T(ctx, "auth.pwd.title"))
 
@@ -122,7 +122,7 @@ func TestOverrideOnlyLocale_AppearsInSupportedTags(t *testing.T) {
 	require.NoError(t, err)
 
 	tagStrings := make([]string, 0)
-	for _, tag := range DefaultBundle().SupportedTags() {
+	for _, tag := range defaultBundle.SupportedTags() {
 		tagStrings = append(tagStrings, tag.String())
 	}
 	assert.Contains(t, tagStrings, "fr",
@@ -133,13 +133,13 @@ func TestOverrideOnlyLocale_AppearsInSupportedTags(t *testing.T) {
 	assert.Contains(t, tagStrings, "pt-BR")
 
 	// And the override translation actually works.
-	r := DefaultBundle().localizerFor([]string{"fr"})
+	r := defaultBundle.localizerFor([]string{"fr"})
 	ctx := context.WithValue(context.Background(), ctxKeyLocalizer, r)
 	assert.Equal(t, "Connexion", T(ctx, "auth.pwd.title"))
 }
 
 func TestSupportedTags_ContainsEnAndPtBR(t *testing.T) {
-	tags := DefaultBundle().SupportedTags()
+	tags := defaultBundle.SupportedTags()
 	require.NotEmpty(t, tags)
 	tagStrings := make([]string, 0, len(tags))
 	for _, t := range tags {
@@ -147,4 +147,129 @@ func TestSupportedTags_ContainsEnAndPtBR(t *testing.T) {
 	}
 	assert.Contains(t, tagStrings, "en")
 	assert.Contains(t, tagStrings, "pt-BR")
+}
+
+// ctxFor builds a context carrying the translator the default bundle resolves
+// for prefs — the shape MiddlewareLocale produces, without the HTTP layer.
+func ctxFor(prefs ...string) context.Context {
+	return context.WithValue(context.Background(), ctxKeyLocalizer, defaultBundle.localizerFor(prefs))
+}
+
+// loadBundleWithOverrides writes each name->content under a temp overrides
+// directory, reloads the package bundle from it, and restores the
+// embedded-only bundle when the test ends. The load error is returned rather
+// than asserted so the refusal cases can read it.
+func loadBundleWithOverrides(t *testing.T, files map[string]string) error {
+	t.Helper()
+	dir := t.TempDir()
+	cataDir := filepath.Join(dir, "catalogs")
+	require.NoError(t, os.MkdirAll(cataDir, 0o755))
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(cataDir, name), []byte(content), 0o644))
+	}
+
+	t.Setenv("GOIABADA_I18N_OVERRIDES_DIR", dir)
+	t.Cleanup(func() {
+		_ = os.Unsetenv("GOIABADA_I18N_OVERRIDES_DIR")
+		_, _ = LoadBundle()
+	})
+
+	_, err := LoadBundle()
+	return err
+}
+
+func TestT_KeyMissingInMatchedLocaleFallsBackToEnglish(t *testing.T) {
+	// A self-hoster ships an fr catalog holding one key. Every other key must
+	// render the English text, which is what concepts/localization.mdx
+	// promises; T used to render the key itself here (#273).
+	require.NoError(t, loadBundleWithOverrides(t, map[string]string{
+		"active.fr.toml": "\"auth.pwd.title\" = \"Connexion\"\n",
+	}))
+
+	ctx := ctxFor("fr")
+	assert.Equal(t, "Connexion", T(ctx, "auth.pwd.title"))
+	assert.Equal(t, "Password", T(ctx, "auth.pwd.password_label"))
+}
+
+func TestT_TemplatedValueRendersItsData(t *testing.T) {
+	assert.Equal(t, "The email address cannot exceed a maximum length of 60 characters.",
+		T(context.Background(), "validator.email.too_long", map[string]any{"max": 60}))
+}
+
+func TestT_TemplatedValueWithoutDataRendersNoValue(t *testing.T) {
+	// text/template's missingkey=default, which is what go-i18n configured
+	// too: an absent field renders <no value> rather than failing the render.
+	assert.Equal(t, "The email address cannot exceed a maximum length of <no value> characters.",
+		T(context.Background(), "validator.email.too_long"))
+}
+
+func TestT_ValueThatIsNotAGoTemplateRendersTheKey(t *testing.T) {
+	// The JS bootstrap strings carry {{param}} placeholders that tFormat()
+	// substitutes client-side, so text/template cannot parse them. T renders
+	// the key for those; Raw() is what the bootstrap calls (#273).
+	assert.Equal(t, "js.error.unexpected", T(context.Background(), "js.error.unexpected"))
+}
+
+// TestLocalizerFor_MatchesAsGoI18nDid holds every row of the parity table in
+// docs/issue-273-retire-go-i18n/probe/matcher.out, which ran go-i18n's
+// Localizer and this matcher side by side over the same inputs. The rows that
+// decide it, because nothing else observes them: a later range winning
+// ("fr-FR,pt;q=0.8"), a q=0 range being excluded, quality reordering the list,
+// unparseable input falling to English, and the ui_locales shape where the
+// first tag is unsupported.
+func TestLocalizerFor_MatchesAsGoI18nDid(t *testing.T) {
+	const (
+		en = "Login"
+		pt = "Entrar"
+	)
+	for _, tc := range []struct {
+		prefs []string
+		want  string
+	}{
+		{[]string{"pt-BR"}, pt},
+		{[]string{"pt"}, pt},
+		{[]string{"pt-PT"}, pt},
+		{[]string{"en"}, en},
+		{[]string{"en-US"}, en},
+		{[]string{"xx"}, en},
+		{[]string{"fr"}, en},
+		{[]string{"fr-FR"}, en},
+		{[]string{""}, en},
+		{[]string{"pt-BR,en;q=0.9"}, pt},
+		{[]string{"fr-FR,pt;q=0.8"}, pt},
+		{[]string{"garbage!!"}, en},
+		{[]string{"*"}, en},
+		{[]string{"fr", "pt-BR"}, pt},
+		{[]string{"xx", "pt-BR"}, pt},
+		{[]string{"pt-BR;q=0"}, en},
+		{[]string{"en;q=0.1,pt-BR;q=0.9"}, pt},
+	} {
+		assert.Equalf(t, tc.want, T(ctxFor(tc.prefs...), "auth.pwd.title"),
+			"locale resolution moved for %q", tc.prefs)
+	}
+}
+
+func TestOverrideDir_TableValueIsRefusedNamingFileAndKey(t *testing.T) {
+	// A [section] table is how go-i18n spelled plural forms. The loader has
+	// no plural machinery, so it refuses the file at startup rather than
+	// rendering one form for every count (#273).
+	err := loadBundleWithOverrides(t, map[string]string{
+		"active.pt-BR.toml": "[section]\nother = \"x\"\n",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active.pt-BR.toml")
+	assert.Contains(t, err.Error(), `"section"`)
+}
+
+func TestOverrideDir_EmptyValueRemovesTheTranslation(t *testing.T) {
+	// A blanked line in an override file means "use English" — the key is
+	// removed from that locale rather than shadowed with a blank (#273).
+	require.NoError(t, loadBundleWithOverrides(t, map[string]string{
+		"active.pt-BR.toml": "\"auth.pwd.title\" = \"\"\n",
+	}))
+
+	ctx := ctxFor("pt-BR")
+	assert.Equal(t, "Login", T(ctx, "auth.pwd.title"))
+	// Neighbouring keys are untouched by the removal.
+	assert.Equal(t, "Senha", T(ctx, "auth.pwd.password_label"))
 }

--- a/src/core/i18n/middleware.go
+++ b/src/core/i18n/middleware.go
@@ -9,7 +9,6 @@ import (
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
-	"github.com/nicksnyder/go-i18n/v2/i18n"
 )
 
 // AuthContextReader matches the subset of *handlerhelpers.AuthHelper that
@@ -132,7 +131,8 @@ func resolveLocale(ctx context.Context, r *http.Request, authHelper AuthContextR
 		}
 	}
 
-	// (3) Accept-Language. go-i18n parses the header per RFC 7231.
+	// (3) Accept-Language, parsed per RFC 9110 section 12.5.4 and matched
+	// against the loaded catalogs (see Bundle.localizerFor).
 	if al := r.Header.Get("Accept-Language"); al != "" {
 		return attachLocale(ctx, bundle.localizerFor([]string{al}), al, false)
 	}
@@ -247,7 +247,7 @@ func RefineLocalizerWithUILocales(r *http.Request, uiLocales []string) *http.Req
 // (the first preference used to build the localizer; "en" for the bundle's
 // English fallback). The tag is used by the CLDR-backed display helpers
 // (RefCountry/RefPhoneCountry/RefTimezone).
-func attachLocale(ctx context.Context, loc *i18n.Localizer, tag string, explicit bool) context.Context {
+func attachLocale(ctx context.Context, loc *Translator, tag string, explicit bool) context.Context {
 	ctx = context.WithValue(ctx, ctxKeyLocalizer, loc)
 	ctx = context.WithValue(ctx, ctxKeyLocaleTag, primaryTag(tag))
 	ctx = context.WithValue(ctx, ctxKeyExplicitIntent, explicit)

--- a/src/core/i18n/overrides.go
+++ b/src/core/i18n/overrides.go
@@ -6,17 +6,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/nicksnyder/go-i18n/v2/i18n"
-	"golang.org/x/text/language"
 )
 
 // loadOverrideCatalogs walks $GOIABADA_I18N_OVERRIDES_DIR/catalogs/ and
-// merges each *.toml message file on top of the embedded set. Override
-// files win on conflict (this is by design — self-hosters need to be able
-// to fix typos or ship locales without rebuilding the binary).
+// returns each *.toml message file in directory order, for the caller to
+// merge on top of the embedded set. Override files win on conflict (this is
+// by design — self-hosters need to be able to fix typos or ship locales
+// without rebuilding the binary), and an empty value removes the embedded
+// translation so the key renders English.
 //
-// Returns the language tags parsed from override files so the caller can
+// The language tags come back on the returned catalogs so the caller can
 // merge them into Bundle.tags. A locale that's only present via the
 // override directory must still surface from SupportedTags() so callers
 // like the locale picker see it.
@@ -26,7 +25,7 @@ import (
 // reference-data layer: country and phone-country names come from CLDR, and
 // timezone labels are assembled from the CLDR-localized country name, IANA
 // zone ID, and optional English comment (see RefCountry/RefPhoneCountry/RefTimezone).
-func loadOverrideCatalogs(b *i18n.Bundle, dir string) ([]language.Tag, error) {
+func loadOverrideCatalogs(dir string) ([]catalogFile, error) {
 	catalogsDir := filepath.Join(dir, "catalogs")
 	info, err := os.Stat(catalogsDir)
 	if err != nil {
@@ -44,7 +43,7 @@ func loadOverrideCatalogs(b *i18n.Bundle, dir string) ([]language.Tag, error) {
 	if err != nil {
 		return nil, fmt.Errorf("i18n: read override catalogs dir: %w", err)
 	}
-	var tags []language.Tag
+	var out []catalogFile
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
 			continue
@@ -54,15 +53,13 @@ func loadOverrideCatalogs(b *i18n.Bundle, dir string) ([]language.Tag, error) {
 		if err != nil {
 			return nil, fmt.Errorf("i18n: read override catalog %s: %w", path, err)
 		}
-		mf, err := b.ParseMessageFileBytes(data, e.Name())
+		tag, messages, err := parseCatalog(path, data)
 		if err != nil {
-			return nil, fmt.Errorf("i18n: parse override catalog %s: %w", path, err)
+			return nil, err
 		}
-		if mf != nil {
-			tags = append(tags, mf.Tag)
-		}
+		out = append(out, catalogFile{tag: tag, messages: messages})
 		slog.Info("i18n: loaded override catalog (overrides win over embedded)",
 			slog.String("path", path))
 	}
-	return tags, nil
+	return out, nil
 }

--- a/src/core/i18n/raw.go
+++ b/src/core/i18n/raw.go
@@ -2,109 +2,33 @@ package i18n
 
 import (
 	"context"
-	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/BurntSushi/toml"
 )
-
-// rawCatalogs holds the un-templated catalog strings keyed by [locale][key].
-//
-// T() renders each message as a text/template, which is correct for
-// server-side strings but wrong for the JS bootstrap: JS message templates use
-// {{param}} placeholders substituted client-side by tFormat(), and running
-// those through T() fails (text/template sees {{param}} as a call to an unknown
-// function) and leaks the key into window.i18n. The bootstrap reads raw strings
-// via Raw() instead, so the placeholders survive to the browser.
-var rawCatalogs map[string]map[string]string
-
-// localeFromCatalogFile maps "active.pt-BR.toml" -> "pt-BR", matching the
-// tag string LocaleTag() carries on the request context.
-func localeFromCatalogFile(name string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(name, "active."), ".toml")
-}
-
-func mergeRawCatalog(locale string, m map[string]string) {
-	if rawCatalogs[locale] == nil {
-		rawCatalogs[locale] = map[string]string{}
-	}
-	for k, v := range m {
-		rawCatalogs[locale][k] = v
-	}
-}
-
-// loadRawEmbeddedCatalogs parses the embedded catalog TOMLs into rawCatalogs.
-func loadRawEmbeddedCatalogs() error {
-	entries, err := fs.ReadDir(embeddedCatalogs, "catalogs")
-	if err != nil {
-		return fmt.Errorf("i18n: read embedded catalogs dir (raw): %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
-			continue
-		}
-		data, err := fs.ReadFile(embeddedCatalogs, "catalogs/"+e.Name())
-		if err != nil {
-			return fmt.Errorf("i18n: read %s (raw): %w", e.Name(), err)
-		}
-		m := map[string]string{}
-		if err := toml.Unmarshal(data, &m); err != nil {
-			return fmt.Errorf("i18n: parse %s (raw): %w", e.Name(), err)
-		}
-		mergeRawCatalog(localeFromCatalogFile(e.Name()), m)
-	}
-	return nil
-}
-
-// loadRawOverrideCatalogs merges override catalog TOMLs over the embedded raw
-// set (override wins), mirroring loadOverrideCatalogs. A missing catalogs/
-// subdir is not an error.
-func loadRawOverrideCatalogs(dir string) error {
-	catalogsDir := filepath.Join(dir, "catalogs")
-	entries, err := os.ReadDir(catalogsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("i18n: read override catalogs dir (raw): %w", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(catalogsDir, e.Name()))
-		if err != nil {
-			return fmt.Errorf("i18n: read override catalog %s (raw): %w", e.Name(), err)
-		}
-		m := map[string]string{}
-		if err := toml.Unmarshal(data, &m); err != nil {
-			return fmt.Errorf("i18n: parse override catalog %s (raw): %w", e.Name(), err)
-		}
-		mergeRawCatalog(localeFromCatalogFile(e.Name()), m)
-	}
-	return nil
-}
 
 // Raw returns the un-templated catalog string for key against the locale
 // carried on ctx, falling back to English, then to the key itself. Unlike T()
 // it does not execute the string as a template, so {{param}} placeholders are
 // preserved for client-side substitution (used by the JS bootstrap).
+//
+// It resolves the locale exactly as T() does, off the translator the locale
+// middleware attached, so a page and its JS strings can never disagree about
+// which locale they are in. Without a translator on the context — the
+// EmailContext and bare-test-context cases — it resolves from LocaleTag(ctx)
+// through the same matcher (#273).
 func Raw(ctx context.Context, key string) string {
-	tag := LocaleTag(ctx)
-	if m, ok := rawCatalogs[tag]; ok {
-		if v := m[key]; v != "" {
-			return v
+	var loc *Translator
+	if ctx != nil {
+		if v, ok := ctx.Value(ctxKeyLocalizer).(*Translator); ok {
+			loc = v
 		}
 	}
-	if tag != "en" {
-		if m, ok := rawCatalogs["en"]; ok {
-			if v := m[key]; v != "" {
-				return v
-			}
+	if loc == nil {
+		if defaultBundle == nil {
+			return key
 		}
+		loc = defaultBundle.localizerFor([]string{LocaleTag(ctx)})
+	}
+	if m, ok := loc.lookup(key); ok {
+		return m.raw
 	}
 	return key
 }

--- a/src/core/i18n/raw_test.go
+++ b/src/core/i18n/raw_test.go
@@ -2,6 +2,8 @@ package i18n
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,8 +14,8 @@ func TestRaw_PreservesPlaceholdersAndLocalizes(t *testing.T) {
 	_, err := LoadBundle()
 	require.NoError(t, err)
 
-	en := attachLocale(context.Background(), defaultBundle.english, "en", false)
-	pt := attachLocale(context.Background(), defaultBundle.english, "pt-BR", false)
+	en := ctxFor("en")
+	pt := ctxFor("pt-BR")
 
 	// A parameterized JS key: the {{detail}} placeholder must survive verbatim
 	// for client-side tFormat(). T() leaks the key here; Raw() must not.
@@ -27,8 +29,46 @@ func TestRaw_PreservesPlaceholdersAndLocalizes(t *testing.T) {
 	assert.Equal(t, "Enviar", Raw(pt, "js.image_upload.upload_button"))
 	assert.NotEmpty(t, Raw(en, "js.image_upload.upload_button"))
 
-	// pt-BR falls back to English when a key is absent only in pt-BR — but the
-	// parity test guarantees that shouldn't happen; here just assert the miss
-	// policy: an unknown key returns the key itself.
+	// Miss policy: an unknown key returns the key itself.
 	assert.Equal(t, "no.such.key.zzz", Raw(en, "no.such.key.zzz"))
+}
+
+// TestRaw_ResolvesTheLocaleTheSameWayTAsDoes is the case that fails under the
+// old Raw, which indexed the catalogs by the request's primary tag string:
+// "pt" and "pt-PT" matched no catalog, so the page rendered in pt-BR while the
+// JS bootstrap strings came back in English (#273).
+func TestRaw_ResolvesTheLocaleTheSameWayTAsDoes(t *testing.T) {
+	for _, tc := range []struct {
+		acceptLanguage string
+		wantRaw        string
+		wantT          string
+	}{
+		{"pt-BR", "Enviar", "Entrar"},
+		{"pt", "Enviar", "Entrar"},
+		{"pt-PT", "Enviar", "Entrar"},
+		// The primary tag is fr-FR, which matches no catalog, while the
+		// matcher takes the second range: the page is pt-BR, so the JS
+		// strings must be too.
+		{"fr-FR,pt;q=0.8", "Enviar", "Entrar"},
+		// English outranks pt-BR here, and both surfaces must say so.
+		{"en-US,pt-BR;q=0.5", "Upload", "Login"},
+	} {
+		req := httptest.NewRequest(http.MethodGet, "/auth/pwd", nil)
+		req.Header.Set("Accept-Language", tc.acceptLanguage)
+
+		var gotRaw, gotT string
+		MiddlewareLocale(nil)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			gotRaw = Raw(r.Context(), "js.image_upload.upload_button")
+			gotT = T(r.Context(), "auth.pwd.title")
+		})).ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.Equalf(t, tc.wantRaw, gotRaw, "Raw for Accept-Language %q", tc.acceptLanguage)
+		assert.Equalf(t, tc.wantT, gotT, "T for Accept-Language %q", tc.acceptLanguage)
+	}
+}
+
+func TestRaw_NoLocalizerOnContextResolvesFromLocaleTag(t *testing.T) {
+	// EmailContext and bare test contexts carry the tag but no translator.
+	ctx := context.WithValue(context.Background(), ctxKeyLocaleTag, "pt-BR")
+	assert.Equal(t, "Enviar", Raw(ctx, "js.image_upload.upload_button"))
 }


### PR DESCRIPTION
Closes #273.

## What this is for

`core/i18n` renders its message catalogs through `github.com/nicksnyder/go-i18n/v2`, of which it
uses one thing: the lookup of a flat `"key" = "value"` TOML file by a locale matched from
`Accept-Language`, with Go `text/template` placeholders. No plural table exists in either catalog
and no caller sets a plural count, so the library's plural machinery is dead weight, and the
package already parses every catalog a second time into a raw map for the JS bootstrap.

This change drops the dependency. The catalogs stay exactly as they are: a flat map parsed once with
`BurntSushi/toml`, locales matched with `golang.org/x/text/language` the same way go-i18n did, and
`{{.name}}` values compiled once at startup with `text/template`. Every public signature in the
package is unchanged, so no caller, template or JS file moves.

## The rule it establishes

A catalog value is a plain string. A value that is anything else, a `[table]` in particular, is
refused at startup with the file name and key, so a plural form can never render silently as one
form on a page. An empty value means "use English". And a key the active locale lacks renders the
English text, as `concepts/localization.mdx` has always said, on every path: page strings, the JS
bootstrap, and localized errors alike.

## Status

**Complete.** Both stages landed, the final review is clean, and the check suite is green on the
head commit. Ready for review.

## What has landed

### Stage 1: `core/i18n` renders its catalogs with a flat map and `text/template`

Landed in `df672c5b`.

One parser reads every catalog file once into `map[string]string`; `LoadBundle` merges per key with
the later file winning, builds a `language.NewMatcher` over the bundle's tags with English at index
0, and compiles every `{{`-carrying value into a `*template.Template` that is immutable for the
process lifetime, so rendering needs no lock and no cache. The parallel raw catalogs and their
second parse of every file are gone, as are `Bundle.English()` and `DefaultBundle()`, neither of
which had a caller outside the package. `go-i18n` is out of `src/core/go.mod`.

Locale resolution is go-i18n's algorithm kept verbatim — `language.ParseAcceptLanguage` per
preference, then `matcher.Match` — and `TestLocalizerFor_MatchesAsGoI18nDid` holds all 17 rows of a
probe table that ran the old library and the new matcher side by side over the same inputs,
including the ones nothing else observes: a later range winning, a `q=0` range excluded, quality
reordering the list, unparseable input falling to English, and the `ui_locales` shape whose first
tag is unsupported.

Two defects inside the rewritten functions were fixed rather than re-implemented:

* **`T` rendered the key** for a key the matched locale lacks, while `LocalizedError.Localize`,
  `Raw` and the docs all promised English. The English hop now happens on lookup, before any
  failure can turn it into the key. It was invisible on a stock install only because the hygiene
  test forces `en` and `pt-BR` to have identical key sets — it is exactly the path a self-hoster
  shipping one override catalog takes.
* **`Raw` and `T` could disagree on the locale.** `Raw` indexed by the request's primary tag string
  while `T` went through the matcher, so `Accept-Language: pt`, `pt-PT` or `fr-FR,pt;q=0.8` gave a
  pt-BR page with English JS strings. `Raw` now reads the same translator, falling back to the
  request tag only when none is attached (the `EmailContext` path).

Unit tier green on all three modules, 5408 pass / 0 fail across 61 packages. Six mutations run
against the new cases — the English hop, `Raw`'s locale source, the empty-value delete, the matcher
over all parsed tags, and `Args` in both error renderings — all caught. Data and integration are not
applicable: no query, handler, route or schema is touched.

### Stage 2: go-i18n leaves both binaries' module graphs

Landed in `9fa733b3`.

`go mod tidy` in `src/core` (a no-op, already tidy from stage 1), then `src/authserver` and
`src/adminconsole`, which is the order their manifests require: each binary module resolves its
indirect set from core's imports. That dropped `github.com/nicksnyder/go-i18n/v2 v2.6.1 // indirect`
and its two `go.sum` lines from both binaries. `go mod graph` now has no edge into go-i18n in any of
the three modules, and the retirement reaches the shipped binaries and not just the manifests:
`go list -deps ./cmd/...` names 0 `nicksnyder` packages, of 396 for `authserver` and 377 for
`adminconsole`.

**`go.yaml.in/yaml/v3` does not leave, and the issue text expects it to.** go-i18n was not its only
requirer: `stretchr/testify v1.12.1` pulls it through `testify/assert/yaml` in all three modules, so
the `// indirect` line stays in every `go.mod` while the module leaves the *production* import graph
(0 packages in `go list -deps ./cmd/...` for both binaries). Anyone reading this change as "yaml is
gone" will go looking for a line that is still there.

Unit tier green on all three modules, 5408 pass / 0 fail, 34s. Seam 5's 19 middleware cases and the
45 `core/i18n` tests are the guard that pruning the manifests pruned nothing the code still resolves.
Data and integration are not applicable: only `go.mod` and `go.sum` changed, so neither tier can
reach anything this stage touched. No new test, so no mutation to run.

### Follow-up commit: `31a96d7b`

The final review's two findings, both about test coverage rather than shipped behaviour. No
production code changed; see the Review section below.

## Testing

| Tier | Where it ran | Result |
|---|---|---|
| Unit, all three modules + setup | locally in the dev container at each stage, and the check suite at every commit | green, 5408 pass / 0 fail across 61 packages |
| Data, four engines (sqlite, mysql, postgres, mssql) | **the check suite only** | green at `31a96d7b` |
| Integration, four engines | **the check suite only** | green at `31a96d7b` |
| Lint, Vulnerabilities, Versions, Build validation | **the check suite only** | green at `31a96d7b` |

The data and integration tiers were not run locally at any point, deliberately: this change touches
no query, handler, route, migration or schema, so neither tier can reach anything it changed. The
four-engine result is the check suite's, and it is green on the head commit —
[run 34275670015](https://github.com/leodip/goiabada/actions/runs/34275670015), all twelve jobs.

Mutation testing stood in for the coverage the absent tiers would not have provided anyway: ten
mutations across the two stages and the review round, every one caught.

## Deviations from the agreement

None in substance. Two decisions were added during the run rather than at the interview, both at the
plan gate and both settled against the code without escalating:

* **Decision 8** — the planned `type Localizer` and the retained `func Localizer` are a Go
  redeclaration. The getter keeps its name (as section 6 had already fixed) and the struct is
  `Translator`. Invisible outside the package.
* **Decision 9** — an empty value in a later catalog file *deletes* the key rather than being
  skipped at parse, which is what decision 7's own worked case requires.

No stage was narrowed, nothing in section 2's goal went unbuilt, and no scope was added beyond it.

## For the release notes

**Only relevant to a self-hoster using `GOIABADA_I18N_OVERRIDES_DIR`.** A stock install is
unaffected: the shipped `en` and `pt-BR` catalogs are held to identical key sets by a hygiene test,
so none of the three changes below can be observed without an override catalog.

* **A non-string value in a catalog now stops the server.** A `[table]` — the shape a go-i18n plural
  form took — fails `LoadBundle` at startup with the offending file name and key, so the process
  does not start. Previously go-i18n accepted it and could render one plural form for every count.
  If you carry a plural table in an override catalog, flatten it to a single `"key" = "value"` line
  before upgrading, or the server will refuse to boot. There is no plural support to move it to;
  that is the point of the change.
* **A key missing from your override catalog now renders the English text, not the key name.** This
  is what `concepts/localization.mdx` has always documented, and it is now true on every path. If
  you were relying on seeing the raw key to spot untranslated strings, that signal is gone — diff
  your catalog against `active.en.toml` instead.
* **An empty value in an override catalog now means "use English".** Previously it left whatever the
  embedded catalog held for that locale, so a blank line in an override of a shipped locale kept the
  shipped translation. Now it removes the key and falls through to English.

Nothing else changes for an operator: no configuration, no schema, no endpoint, no wire behaviour.

## Review

Reviewed by `openai-codex/gpt-5.6-sol` at effort `xhigh`. Three rounds: one at the plan gate, two at
the final gate over the whole branch. No stage was reviewed on its own — `LEO_REVIEW_MODE=end`, so
the final gate is the only reading the code got.

| Round | Gate | Findings | Blocking | Outcome |
|---|---|---|---|---|
| 1 | plan | 4 | 1 | all confirmed, all resolved in the plan before any code was written |
| 1 | final | 2 | 0 | both confirmed, both fixed, `31a96d7b` |
| 2 | final | 0 | 0 | clean, every axis reviewed, `unchecked` empty |

- **blocking, conformance (plan):** `func Localizer` and `type Localizer` cannot coexist in one Go
  package namespace. Resolved as decision 8 before implementation: the getter keeps its name, the
  struct is `Translator`.
- **significant, conformance (plan):** an empty override value would have been discarded at parse,
  leaving the embedded translation instead of falling through to English. Resolved as decision 9.
- **significant, conformance (plan):** the locale parity table was not pinned — a first-range
  matcher passed every planned case. Resolved by a table-driven test over all 17 probe rows.
- **significant, quality (plan):** parameterized `LocalizedError` rendering was not owned by its
  seam; two mutations dropping template data survived. Resolved by `Args` cases on all three paths.
- **significant, quality (final):** the template *execution*-error branch of `renderOrMiss` had no
  regression test — changing it to return the raw value left the suite green. Fixed in `31a96d7b`:
  `TestT_TemplatedValueThatFailsToExecuteRendersTheKey`.
- **significant, quality (final):** every pre-`LoadBundle` rendering fallback could regress
  unnoticed, because `TestMain` loads the bundle before any test runs. Fixed in `31a96d7b`:
  `TestRenderingBeforeLoadBundle_ResolvesEveryKeyToItself`.

Neither final-gate finding was a defect in shipped behaviour: the reviewer confirmed the code
returns the right answer in both cases, so `31a96d7b` changed no production code. Nothing was
refuted in any round.

Full account, with the mutation tables and the evidence,
[in this comment](https://github.com/leodip/goiabada/pull/307#issuecomment-5591652340).

## Closing comments

* [Deferred decisions](https://github.com/leodip/goiabada/pull/307#issuecomment-5591631377) — none;
  nothing is waiting on you.
* [Follow-ups, fold-ins and ceilings](https://github.com/leodip/goiabada/pull/307#issuecomment-5591635198)
  — no issues to file, two defects folded in, no ceilings left behind.
* [Review account](https://github.com/leodip/goiabada/pull/307#issuecomment-5591652340) — all three
  rounds in full.
