### PR TITLE
refactor(core): replace google/uuid with a stdlib uuidutil, and fail closed on CSPRNG failure

### DIFF
--- a/src/adminconsole/internal/handlers/admingrouphandlers/handler_admin_group_members_add.go
+++ b/src/adminconsole/internal/handlers/admingrouphandlers/handler_admin_group_members_add.go
@@ -126,7 +126,7 @@ func HandleAdminGroupMembersSearchGet(
 		for _, user := range users {
 			usersResult = append(usersResult, UserResult{
 				Id:           user.Id,
-				Subject:      user.Subject.String(),
+				Subject:      user.Subject,
 				Username:     user.Username,
 				Email:        user.Email,
 				GivenName:    user.GivenName,

--- a/src/adminconsole/internal/handlers/adminresourcehandlers/handler_admin_resource_users_with_permission.go
+++ b/src/adminconsole/internal/handlers/adminresourcehandlers/handler_admin_resource_users_with_permission.go
@@ -476,7 +476,7 @@ func HandleAdminResourceUsersWithPermissionSearchGet(
 		for _, u := range annotatedUsers {
 			usersResult = append(usersResult, UserResult{
 				Id:            u.Id,
-				Subject:       u.Subject.String(),
+				Subject:       u.Subject,
 				Username:      u.Username,
 				Email:         u.Email,
 				GivenName:     u.GivenName,

--- a/src/adminconsole/internal/rendertest/render_test.go
+++ b/src/adminconsole/internal/rendertest/render_test.go
@@ -297,9 +297,7 @@ func TestRender_AdminClientWebOrigins(t *testing.T) {
 func TestRender_AdminUsersPaginator(t *testing.T) {
 	out := render(t, "/admin_users.html", map[string]interface{}{
 		"pageResult": adminuserhandlers.PageResult{
-			// Subject is left at its zero UUID: the row only has to render, and
-			// importing google/uuid for it would make adminconsole a direct
-			// consumer of a module it otherwise only inherits.
+			// Subject is left empty: the row only has to render.
 			Users:    []models.User{{Id: 1, Username: "alice", Email: "alice@example.com"}},
 			Total:    73,
 			Query:    "",

--- a/src/authserver/go.mod
+++ b/src/authserver/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/leodip/goiabada/core v0.0.0
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/pkg/errors v0.9.1
@@ -27,6 +26,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/huandu/go-sqlbuilder v1.43.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_email.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_email.go
@@ -54,7 +54,7 @@ func HandleAPIAccountEmailPut(
 
 		// Validate email (server-side rules; confirmation is a UI concern)
 		email := strings.ToLower(strings.TrimSpace(req.Email))
-		if err := emailValidator.ValidateEmailChange(email, user.Subject.String()); err != nil {
+		if err := emailValidator.ValidateEmailChange(email, user.Subject); err != nil {
 			writeValidationError(w, r, err)
 			return
 		}

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_profile.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_profile.go
@@ -105,7 +105,7 @@ func HandleAPIAccountProfilePut(
 			ZoneInfoCountryName: req.ZoneInfoCountryName,
 			ZoneInfo:            req.ZoneInfo,
 			Locale:              req.Locale,
-			Subject:             user.Subject.String(),
+			Subject:             user.Subject,
 		}
 
 		if err := profileValidator.ValidateProfile(input); err != nil {

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_profile_picture.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_profile_picture.go
@@ -119,7 +119,7 @@ func HandleAPIAccountProfilePicturePost(
 		// Return success response
 		response := map[string]interface{}{
 			"success":    true,
-			"pictureUrl": config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject.String(),
+			"pictureUrl": config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -223,7 +223,7 @@ func HandleAPIAccountProfilePictureGet(
 		}
 
 		if hasPicture {
-			response["pictureUrl"] = config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject.String()
+			response["pictureUrl"] = config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/src/authserver/internal/handlers/apihandlers/handler_api_account_profile_picture_test.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_account_profile_picture_test.go
@@ -14,13 +14,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/uuid"
 	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
 	"github.com/leodip/goiabada/core/constants"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -114,7 +114,7 @@ func TestHandleAPIAccountProfilePictureGet_UserNotFound(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureGet(database)
 
-	sub := uuid.New().String()
+	sub := fake.UUID()
 	req, _ := http.NewRequest("GET", "/api/v1/account/profile-picture", nil)
 	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
@@ -132,13 +132,13 @@ func TestHandleAPIAccountProfilePictureGet_HasPicture(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureGet(database)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	req, _ := http.NewRequest("GET", "/api/v1/account/profile-picture", nil)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("UserHasProfilePicture", (*sql.Tx)(nil), user.Id).Return(true, nil)
 
 	handler.ServeHTTP(rr, req)
@@ -149,7 +149,7 @@ func TestHandleAPIAccountProfilePictureGet_HasPicture(t *testing.T) {
 	err := json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.True(t, response["hasPicture"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), sub.String())
+	assert.Contains(t, response["pictureUrl"].(string), sub)
 
 	database.AssertExpectations(t)
 }
@@ -159,13 +159,13 @@ func TestHandleAPIAccountProfilePictureGet_NoPicture(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureGet(database)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	req, _ := http.NewRequest("GET", "/api/v1/account/profile-picture", nil)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("UserHasProfilePicture", (*sql.Tx)(nil), user.Id).Return(false, nil)
 
 	handler.ServeHTTP(rr, req)
@@ -201,7 +201,7 @@ func TestHandleAPIAccountProfilePicturePost_UserNotFound(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New().String()
+	sub := fake.UUID()
 	pictureData := createTestPNG(100, 100)
 	req, err := createMultipartRequest("POST", "/api/v1/account/profile-picture", "picture", pictureData)
 	assert.NoError(t, err)
@@ -222,15 +222,15 @@ func TestHandleAPIAccountProfilePicturePost_NoFile(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("POST", "/api/v1/account/profile-picture", nil)
 	req.Header.Set("Content-Type", "multipart/form-data")
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 
 	handler.ServeHTTP(rr, req)
 
@@ -243,17 +243,17 @@ func TestHandleAPIAccountProfilePicturePost_InvalidImage(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 
 	// Create a request with invalid image data
 	invalidImageData := []byte("not a valid image")
 	req, err := createMultipartRequest("POST", "/api/v1/account/profile-picture", "picture", invalidImageData)
 	assert.NoError(t, err)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 
 	handler.ServeHTTP(rr, req)
 
@@ -271,16 +271,16 @@ func TestHandleAPIAccountProfilePicturePost_CreateNew(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 
 	pictureData := createTestPNG(100, 100)
 	req, err := createMultipartRequest("POST", "/api/v1/account/profile-picture", "picture", pictureData)
 	assert.NoError(t, err)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("GetUserProfilePictureByUserId", (*sql.Tx)(nil), user.Id).Return(nil, nil)
 	database.On("CreateUserProfilePicture", (*sql.Tx)(nil), mock.MatchedBy(func(pp *models.UserProfilePicture) bool {
 		return pp.UserId == user.Id && pp.ContentType == "image/png"
@@ -298,7 +298,7 @@ func TestHandleAPIAccountProfilePicturePost_CreateNew(t *testing.T) {
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.True(t, response["success"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), sub.String())
+	assert.Contains(t, response["pictureUrl"].(string), sub)
 
 	database.AssertExpectations(t)
 	auditLogger.AssertExpectations(t)
@@ -310,7 +310,7 @@ func TestHandleAPIAccountProfilePicturePost_UpdateExisting(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 	existingPicture := &models.UserProfilePicture{
 		Id:          1,
@@ -322,10 +322,10 @@ func TestHandleAPIAccountProfilePicturePost_UpdateExisting(t *testing.T) {
 	pictureData := createTestPNG(100, 100)
 	req, err := createMultipartRequest("POST", "/api/v1/account/profile-picture", "picture", pictureData)
 	assert.NoError(t, err)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("GetUserProfilePictureByUserId", (*sql.Tx)(nil), user.Id).Return(existingPicture, nil)
 	database.On("UpdateUserProfilePicture", (*sql.Tx)(nil), mock.MatchedBy(func(pp *models.UserProfilePicture) bool {
 		return pp.Id == existingPicture.Id && pp.ContentType == "image/png"
@@ -370,7 +370,7 @@ func TestHandleAPIAccountProfilePictureDelete_UserNotFound(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureDelete(httpHelper, database, auditLogger)
 
-	sub := uuid.New().String()
+	sub := fake.UUID()
 	req, _ := http.NewRequest("DELETE", "/api/v1/account/profile-picture", nil)
 	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
@@ -390,14 +390,14 @@ func TestHandleAPIAccountProfilePictureDelete_Success(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureDelete(httpHelper, database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("DELETE", "/api/v1/account/profile-picture", nil)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("DeleteUserProfilePicture", (*sql.Tx)(nil), user.Id).Return(nil)
 
 	auditLogger.On("Log", constants.AuditDeletedOwnProfilePicture, mock.MatchedBy(func(details map[string]interface{}) bool {
@@ -424,14 +424,14 @@ func TestHandleAPIAccountProfilePictureDelete_DatabaseError(t *testing.T) {
 
 	handler := HandleAPIAccountProfilePictureDelete(httpHelper, database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 1, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("DELETE", "/api/v1/account/profile-picture", nil)
-	req = setTokenContext(req, sub.String())
+	req = setTokenContext(req, sub)
 	rr := httptest.NewRecorder()
 
-	database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+	database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 	database.On("DeleteUserProfilePicture", (*sql.Tx)(nil), user.Id).Return(assert.AnError)
 
 	handler.ServeHTTP(rr, req)

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_email.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_email.go
@@ -61,7 +61,7 @@ func HandleAPIUserEmailPut(
 		input := &validators.ValidateEmailInput{
 			Email:             strings.ToLower(strings.TrimSpace(req.Email)),
 			EmailConfirmation: strings.ToLower(strings.TrimSpace(req.Email)),
-			Subject:           user.Subject.String(),
+			Subject:           user.Subject,
 		}
 
 		err = emailValidator.ValidateEmailUpdate(input)

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_profile.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_profile.go
@@ -76,7 +76,7 @@ func HandleAPIUserProfilePut(
 			ZoneInfoCountryName: zoneInfoCountry,
 			ZoneInfo:            zoneInfo,
 			Locale:              req.Locale,
-			Subject:             user.Subject.String(),
+			Subject:             user.Subject,
 		}
 
 		err = profileValidator.ValidateProfile(input)

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_profile_picture.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_profile_picture.go
@@ -128,7 +128,7 @@ func HandleAPIUserProfilePicturePost(
 		// Return success response
 		response := map[string]interface{}{
 			"success":    true,
-			"pictureUrl": config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject.String(),
+			"pictureUrl": config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -239,7 +239,7 @@ func HandleAPIUserProfilePictureGet(
 		}
 
 		if hasPicture {
-			response["pictureUrl"] = config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject.String()
+			response["pictureUrl"] = config.GetAuthServer().BaseURL + "/userinfo/picture/" + user.Subject
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/src/authserver/internal/handlers/apihandlers/handler_api_users_profile_picture_test.go
+++ b/src/authserver/internal/handlers/apihandlers/handler_api_users_profile_picture_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
 	"github.com/leodip/goiabada/core/constants"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -100,7 +100,7 @@ func TestHandleAPIUserProfilePictureGet_HasPicture(t *testing.T) {
 
 	handler := HandleAPIUserProfilePictureGet(database)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("GET", "/api/v1/admin/users/123/profile-picture", nil)
@@ -118,7 +118,7 @@ func TestHandleAPIUserProfilePictureGet_HasPicture(t *testing.T) {
 	err := json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.True(t, response["hasPicture"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), sub.String())
+	assert.Contains(t, response["pictureUrl"].(string), sub)
 
 	database.AssertExpectations(t)
 }
@@ -128,7 +128,7 @@ func TestHandleAPIUserProfilePictureGet_NoPicture(t *testing.T) {
 
 	handler := HandleAPIUserProfilePictureGet(database)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("GET", "/api/v1/admin/users/123/profile-picture", nil)
@@ -222,7 +222,7 @@ func TestHandleAPIUserProfilePicturePost_InvalidImage(t *testing.T) {
 
 	handler := HandleAPIUserProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
 
 	invalidImageData := []byte("not a valid image")
@@ -249,9 +249,9 @@ func TestHandleAPIUserProfilePicturePost_CreateNew(t *testing.T) {
 
 	handler := HandleAPIUserProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
-	adminSub := uuid.New().String()
+	adminSub := fake.UUID()
 
 	pictureData := createTestPNG(100, 100)
 	req, err := createMultipartRequest("POST", "/api/v1/admin/users/123/profile-picture", "picture", pictureData)
@@ -278,7 +278,7 @@ func TestHandleAPIUserProfilePicturePost_CreateNew(t *testing.T) {
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.True(t, response["success"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), sub.String())
+	assert.Contains(t, response["pictureUrl"].(string), sub)
 
 	database.AssertExpectations(t)
 	auditLogger.AssertExpectations(t)
@@ -290,7 +290,7 @@ func TestHandleAPIUserProfilePicturePost_UpdateExisting(t *testing.T) {
 
 	handler := HandleAPIUserProfilePicturePost(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
 	existingPicture := &models.UserProfilePicture{
 		Id:          1,
@@ -298,7 +298,7 @@ func TestHandleAPIUserProfilePicturePost_UpdateExisting(t *testing.T) {
 		Picture:     []byte("old picture data"),
 		ContentType: "image/jpeg",
 	}
-	adminSub := uuid.New().String()
+	adminSub := fake.UUID()
 
 	pictureData := createTestPNG(100, 100)
 	req, err := createMultipartRequest("POST", "/api/v1/admin/users/123/profile-picture", "picture", pictureData)
@@ -399,9 +399,9 @@ func TestHandleAPIUserProfilePictureDelete_Success(t *testing.T) {
 
 	handler := HandleAPIUserProfilePictureDelete(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
-	adminSub := uuid.New().String()
+	adminSub := fake.UUID()
 
 	req, _ := http.NewRequest("DELETE", "/api/v1/admin/users/123/profile-picture", nil)
 	req = setChiURLParam(req, "id", "123")
@@ -434,7 +434,7 @@ func TestHandleAPIUserProfilePictureDelete_DatabaseError(t *testing.T) {
 
 	handler := HandleAPIUserProfilePictureDelete(database, auditLogger)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	user := &models.User{Id: 123, Subject: sub, Enabled: true}
 
 	req, _ := http.NewRequest("DELETE", "/api/v1/admin/users/123/profile-picture", nil)

--- a/src/authserver/internal/handlers/handler_auth_issue.go
+++ b/src/authserver/internal/handlers/handler_auth_issue.go
@@ -159,7 +159,7 @@ func HandleIssueGet(
 				httpHelper.InternalServerError(w, r, err)
 				return
 			}
-			if user == nil || user.Subject.String() != authContext.IdTokenHintSub {
+			if user == nil || user.Subject != authContext.IdTokenHintSub {
 				// Cannot issue tokens for a different user than the hint identifies.
 				//
 				// An error redirect carries the client it is answering, so its provenance has to

--- a/src/authserver/internal/handlers/handler_auth_issue_test.go
+++ b/src/authserver/internal/handlers/handler_auth_issue_test.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/customerrors"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -53,7 +53,7 @@ func armIssueGate(database *mocks_data.Database, userSessionManager *mocks_user.
 			client.RedirectURIs = []models.RedirectURI{{URI: redirectURI}}
 		}).Return(nil).Maybe()
 	database.On("GetUserById", mock.Anything, mock.Anything).
-		Return(&models.User{Id: 1, Subject: uuid.New()}, nil).Maybe()
+		Return(&models.User{Id: 1, Subject: fake.UUID()}, nil).Maybe()
 	userSessionManager.On("HasValidUserSession", mock.Anything, mock.Anything, mock.Anything).
 		Return(true).Maybe()
 	permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", mock.Anything, mock.Anything).
@@ -1329,7 +1329,7 @@ func TestHandleIssueGet_ForeignAmbientSession(t *testing.T) {
 		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").
 			Return(&models.Client{Id: 1, ClientIdentifier: "test-client", Enabled: true}, nil)
 		database.On("GetUserById", mock.Anything, int64(123)).
-			Return(&models.User{Id: 123, Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111"), Enabled: true}, nil)
+			Return(&models.User{Id: 123, Subject: "11111111-1111-1111-1111-111111111111", Enabled: true}, nil)
 
 		tokenIssuer.On("GenerateTokenResponseForImplicit", mock.Anything, mock.MatchedBy(func(input *oauth.ImplicitGrantInput) bool {
 			return input.User.Id == int64(123) && input.SessionIdentifier == liveSessionIdentifier
@@ -1786,7 +1786,7 @@ func TestHandleIssueGet_ImplicitFlow(t *testing.T) {
 		// Mock user lookup
 		mockUser := &models.User{
 			Id:      123,
-			Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			Subject: "11111111-1111-1111-1111-111111111111",
 			Email:   "test@example.com",
 			Enabled: true,
 		}
@@ -1877,7 +1877,7 @@ func TestHandleIssueGet_ImplicitFlow(t *testing.T) {
 
 		mockUser := &models.User{
 			Id:      123,
-			Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			Subject: "11111111-1111-1111-1111-111111111111",
 			Email:   "test@example.com",
 			Enabled: true,
 		}
@@ -1961,7 +1961,7 @@ func TestHandleIssueGet_ImplicitFlow(t *testing.T) {
 
 		mockUser := &models.User{
 			Id:      123,
-			Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			Subject: "11111111-1111-1111-1111-111111111111",
 			Email:   "test@example.com",
 			Enabled: true,
 		}
@@ -2037,7 +2037,7 @@ func TestHandleIssueGet_ImplicitFlow(t *testing.T) {
 		mockClient := &models.Client{Id: 1, ClientIdentifier: "test-client", Enabled: true}
 		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(mockClient, nil)
 
-		mockUser := &models.User{Id: 123, Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111")}
+		mockUser := &models.User{Id: 123, Subject: "11111111-1111-1111-1111-111111111111"}
 		database.On("GetUserById", mock.Anything, int64(123)).Return(mockUser, nil)
 
 		tokenResponse := &oauth.ImplicitGrantResponse{
@@ -2200,7 +2200,7 @@ func TestHandleIssueGet_ImplicitFlow(t *testing.T) {
 		mockClient := &models.Client{Id: 1, ClientIdentifier: "test-client", Enabled: true}
 		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(mockClient, nil)
 
-		mockUser := &models.User{Id: 123, Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111")}
+		mockUser := &models.User{Id: 123, Subject: "11111111-1111-1111-1111-111111111111"}
 		database.On("GetUserById", mock.Anything, int64(123)).Return(mockUser, nil)
 
 		tokenError := errors.New("token generation failed")
@@ -2573,7 +2573,7 @@ func TestHandleIssueGet_ImplicitFlow_DatabaseErrors(t *testing.T) {
 		mockClient := &models.Client{Id: 1, ClientIdentifier: "test-client", Enabled: true}
 		database.On("GetClientByClientIdentifier", mock.Anything, "test-client").Return(mockClient, nil)
 
-		mockUser := &models.User{Id: 123, Subject: uuid.MustParse("11111111-1111-1111-1111-111111111111")}
+		mockUser := &models.User{Id: 123, Subject: "11111111-1111-1111-1111-111111111111"}
 		database.On("GetUserById", mock.Anything, int64(123)).Return(mockUser, nil)
 
 		tokenResponse := &oauth.ImplicitGrantResponse{
@@ -3360,7 +3360,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// Create authContext with IdTokenHintSub matching the user's subject
-		userSubject := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+		userSubject := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 		authContext := &oauth.AuthContext{
 			AuthState:      oauth.AuthStateReadyToIssueCode,
 			Scope:          "openid profile",
@@ -3370,7 +3370,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 			ResponseType:   "code",
 			RedirectURI:    "https://example.com/callback",
 			State:          "test-state",
-			IdTokenHintSub: userSubject.String(),
+			IdTokenHintSub: userSubject,
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 
@@ -3444,8 +3444,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// Create authContext with IdTokenHintSub for user A
-		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		userASubject := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		userBSubject := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 		authContext := &oauth.AuthContext{
 			AuthState:      oauth.AuthStateReadyToIssueCode,
 			Scope:          "openid profile",
@@ -3455,7 +3455,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 			ResponseType:   "code",
 			RedirectURI:    "https://example.com/callback",
 			State:          "test-state",
-			IdTokenHintSub: userASubject.String(), // Hint says user A
+			IdTokenHintSub: userASubject, // Hint says user A
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 		stubClientProvenanceLookup(database)
@@ -3525,8 +3525,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 
-		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		userASubject := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		userBSubject := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 		authContext := &oauth.AuthContext{
 			AuthState:      oauth.AuthStateReadyToIssueCode,
 			Scope:          "openid profile",
@@ -3536,7 +3536,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 			ResponseType:   "code",
 			RedirectURI:    "https://example.com/callback",
 			State:          "test-state",
-			IdTokenHintSub: userASubject.String(),
+			IdTokenHintSub: userASubject,
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 		stubClientProvenanceLookup(database)
@@ -3602,8 +3602,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 
-		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		userASubject := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		userBSubject := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 		authContext := &oauth.AuthContext{
 			AuthState:      oauth.AuthStateReadyToIssueCode,
 			Scope:          "openid profile",
@@ -3613,7 +3613,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 			ResponseType:   "code",
 			RedirectURI:    "https://example.com/callback",
 			State:          "test-state",
-			IdTokenHintSub: userASubject.String(),
+			IdTokenHintSub: userASubject,
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 		stubClientProvenanceLookup(database)
@@ -3671,8 +3671,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 
-		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		userASubject := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		userBSubject := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 		authContext := &oauth.AuthContext{
 			AuthState:      oauth.AuthStateReadyToIssueCode,
 			Scope:          "openid profile",
@@ -3682,7 +3682,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 			ResponseType:   "code",
 			RedirectURI:    "https://example.com/callback",
 			State:          "test-state",
-			IdTokenHintSub: userASubject.String(),
+			IdTokenHintSub: userASubject,
 		}
 		authHelper.On("GetAuthContext", req).Return(authContext, nil)
 		stubClientProvenanceLookup(database)
@@ -3811,8 +3811,8 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 
-		userASubject := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-		userBSubject := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		userASubject := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		userBSubject := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
 		var savedAuthContext *oauth.AuthContext
 
@@ -3827,7 +3827,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 				ResponseType:   "code",
 				RedirectURI:    "https://example.com/callback",
 				State:          "test-state",
-				IdTokenHintSub: userASubject.String(),
+				IdTokenHintSub: userASubject,
 				Prompt:         "login",
 			}
 		}).Return(func(r *http.Request) *oauth.AuthContext {
@@ -3865,7 +3865,7 @@ func TestHandleIssueGet_IdTokenHintSubMatching(t *testing.T) {
 		assert.Contains(t, location, "state=test-state")
 
 		assert.NotNil(t, savedAuthContext, "AuthContext should have been created")
-		assert.Equal(t, userASubject.String(), savedAuthContext.IdTokenHintSub, "IdTokenHintSub should persist from authorize request")
+		assert.Equal(t, userASubject, savedAuthContext.IdTokenHintSub, "IdTokenHintSub should persist from authorize request")
 		assert.Equal(t, int64(99), savedAuthContext.UserId, "UserId should be set to authenticated user (user B)")
 
 		codeIssuer.AssertNotCalled(t, "CreateAuthCode", mock.Anything, mock.Anything)
@@ -3986,7 +3986,7 @@ func TestHandleIssueGet_RedirectURIRecheck(t *testing.T) {
 				Return(&models.UserSession{Id: 55, SessionIdentifier: liveSessionIdentifier, UserId: 123}, nil).Maybe()
 			userSessionManager.On("HasValidUserSession", mock.Anything, mock.Anything, mock.Anything).Return(true).Maybe()
 			database.On("GetUserById", mock.Anything, int64(123)).
-				Return(&models.User{Id: 123, Subject: uuid.New(), Enabled: true}, nil).Maybe()
+				Return(&models.User{Id: 123, Subject: fake.UUID(), Enabled: true}, nil).Maybe()
 			permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", mock.Anything, mock.Anything).
 				Return(func(scope string, _ *models.User) string { return scope }, nil).Maybe()
 			authHelper.On("ClearAuthContext", rr, req).Return(nil)
@@ -4067,7 +4067,7 @@ func TestHandleIssueGet_RedirectURIRecheckOutranksTheIdTokenHintRefusal(t *testi
 		ResponseType:   "code",
 		RedirectURI:    "https://example.com/callback",
 		State:          "test-state",
-		IdTokenHintSub: uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").String(),
+		IdTokenHintSub: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 	}
 	authHelper.On("GetAuthContext", req).Return(authContext, nil)
 
@@ -4309,7 +4309,7 @@ func TestHandleIssueGet_ScopeRefilter(t *testing.T) {
 			stubLiveSession(database, 123)
 			userSessionManager.On("HasValidUserSession", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
-			user := &models.User{Id: 123, Subject: uuid.New(), Enabled: true}
+			user := &models.User{Id: 123, Subject: fake.UUID(), Enabled: true}
 			database.On("GetUserById", (*sql.Tx)(nil), int64(123)).Return(user, nil)
 
 			// The field the filter is asked about is the one the issuer will read, and asserting
@@ -4410,7 +4410,7 @@ func TestHandleIssueGet_TheLiveChecksFailClosedOnAStorageError(t *testing.T) {
 				database.On("GetUserSessionBySessionIdentifier", (*sql.Tx)(nil), liveSessionIdentifier).
 					Return(&models.UserSession{Id: 55, SessionIdentifier: liveSessionIdentifier, UserId: 123}, nil)
 				database.On("GetUserById", mock.Anything, int64(123)).
-					Return(&models.User{Id: 123, Subject: uuid.New(), Enabled: true}, nil)
+					Return(&models.User{Id: 123, Subject: fake.UUID(), Enabled: true}, nil)
 				permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", mock.Anything).
 					Return("", errors.New("permission filter sentinel"))
 			},
@@ -4674,7 +4674,7 @@ func TestHandleIssueGet_ScopeRefusalSurvivesItsOwnFailures(t *testing.T) {
 		stubLiveSession(database, 123)
 		userSessionManager.On("HasValidUserSession", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
-		user := &models.User{Id: 123, Subject: uuid.New(), Enabled: true}
+		user := &models.User{Id: 123, Subject: fake.UUID(), Enabled: true}
 		database.On("GetUserById", (*sql.Tx)(nil), int64(123)).Return(user, nil)
 		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "backend:read", user).
 			Return("", nil)

--- a/src/authserver/internal/handlers/handler_authorize.go
+++ b/src/authserver/internal/handlers/handler_authorize.go
@@ -555,7 +555,7 @@ func HandleAuthorizeGet(
 
 			// Check id_token_hint sub matching for SSO session reuse (OIDC Core 3.1.2.1)
 			// If hint identifies a different user, force re-authentication instead of SSO
-			if authContext.IdTokenHintSub != "" && userSession.User.Subject.String() != authContext.IdTokenHintSub {
+			if authContext.IdTokenHintSub != "" && userSession.User.Subject != authContext.IdTokenHintSub {
 				// Treat as no valid session — force re-authentication
 				authContext.AuthState = oauth.AuthStateRequiresLevel1
 				err = authHelper.SaveAuthContext(w, r, &authContext)
@@ -679,7 +679,7 @@ func handlePromptNone(w http.ResponseWriter, r *http.Request, httpHelper HttpHel
 	// 3a. Check id_token_hint sub matching (OIDC Core 3.1.2.1)
 	// "MUST NOT reply with an ID Token for a different user"
 	if authContext.IdTokenHintSub != "" {
-		if userSession.User.Subject.String() != authContext.IdTokenHintSub {
+		if userSession.User.Subject != authContext.IdTokenHintSub {
 			redirectWithError(constants.ErrorLoginRequired,
 				"The current session user does not match the id_token_hint")
 			return

--- a/src/authserver/internal/handlers/handler_authorize.go
+++ b/src/authserver/internal/handlers/handler_authorize.go
@@ -96,14 +96,6 @@ func HandleAuthorizeGet(
 		// checks it, so a page left open in another tab cannot act on the authorization
 		// request that replaced it (#79).
 		ceremonyId := stringutil.GenerateSecurityRandomString(ceremonyIdLength)
-		if ceremonyId == "" {
-			// GenerateSecurityRandomString answers "" when the system CSPRNG is unavailable.
-			// Saving that would put an empty id in the context, which every bound POST refuses,
-			// so the ceremony would render its forms and then reject each one. Failing here is
-			// the same outcome with a stack trace attached, as SaveLinkMarker does (#112).
-			httpHelper.InternalServerError(w, r, errors.WithStack(errors.New("unable to generate an auth ceremony id")))
-			return
-		}
 
 		authContext := oauth.AuthContext{
 			AuthState:                     oauth.AuthStateInitial,

--- a/src/authserver/internal/handlers/handler_authorize_test.go
+++ b/src/authserver/internal/handlers/handler_authorize_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/customerrors"
@@ -19,6 +18,7 @@ import (
 	"github.com/leodip/goiabada/core/mocks"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/leodip/goiabada/core/validators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -2720,7 +2720,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		userSubject := uuid.New()
+		userSubject := fake.UUID()
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&id_token_hint=expired-jwt-token", nil)
 		assert.NoError(t, err)
 
@@ -2757,13 +2757,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "expired-jwt-token",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": userSubject.String(),
+				"sub": userSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "expired-jwt-token", mock.Anything, false).Return(expiredToken, nil)
 
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
-			return ac.IdTokenHintSub == userSubject.String()
+			return ac.IdTokenHintSub == userSubject
 		})).Return(nil)
 
 		userSession := &models.UserSession{
@@ -2812,7 +2812,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		userSubject := uuid.New()
+		userSubject := fake.UUID()
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&id_token_hint=valid-jwt-token", nil)
 		assert.NoError(t, err)
 
@@ -2849,13 +2849,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "valid-jwt-token",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": userSubject.String(),
+				"sub": userSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "valid-jwt-token", mock.Anything, false).Return(validToken, nil)
 
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
-			return ac.IdTokenHintSub == userSubject.String()
+			return ac.IdTokenHintSub == userSubject
 		})).Return(nil)
 
 		userSession := &models.UserSession{
@@ -2904,8 +2904,8 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		hintSubject := uuid.New()
-		sessionSubject := uuid.New()
+		hintSubject := fake.UUID()
+		sessionSubject := fake.UUID()
 
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&id_token_hint=different-user-jwt", nil)
 		assert.NoError(t, err)
@@ -2943,13 +2943,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "different-user-jwt",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": hintSubject.String(),
+				"sub": hintSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
 
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
-			return ac.IdTokenHintSub == hintSubject.String()
+			return ac.IdTokenHintSub == hintSubject
 		})).Return(nil)
 
 		userSession := &models.UserSession{
@@ -2997,7 +2997,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		userSubject := uuid.New()
+		userSubject := fake.UUID()
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&prompt=none&id_token_hint=valid-jwt-token", nil)
 		assert.NoError(t, err)
 
@@ -3034,13 +3034,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "valid-jwt-token",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": userSubject.String(),
+				"sub": userSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "valid-jwt-token", mock.Anything, false).Return(validToken, nil)
 
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
-			return ac.IdTokenHintSub == userSubject.String() && ac.Prompt == "none"
+			return ac.IdTokenHintSub == userSubject && ac.Prompt == "none"
 		})).Return(nil)
 		// The silent-issue path sets the AuthContext again just before code issuance; this
 		// is the assertion that it inherits the session's generation and not the user's.
@@ -3111,8 +3111,8 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		hintSubject := uuid.New()
-		sessionSubject := uuid.New()
+		hintSubject := fake.UUID()
+		sessionSubject := fake.UUID()
 
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
 		assert.NoError(t, err)
@@ -3150,13 +3150,13 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "different-user-jwt",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": hintSubject.String(),
+				"sub": hintSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
 
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
-			return ac.IdTokenHintSub == hintSubject.String() && ac.Prompt == "none"
+			return ac.IdTokenHintSub == hintSubject && ac.Prompt == "none"
 		})).Return(nil)
 
 		userSession := &models.UserSession{
@@ -3213,8 +3213,8 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, nil, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		hintSubject := uuid.New()
-		sessionSubject := uuid.New()
+		hintSubject := fake.UUID()
+		sessionSubject := fake.UUID()
 
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
 		assert.NoError(t, err)
@@ -3250,7 +3250,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "different-user-jwt",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": hintSubject.String(),
+				"sub": hintSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
@@ -3315,8 +3315,8 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 		}
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		hintSubject := uuid.New()
-		sessionSubject := uuid.New()
+		hintSubject := fake.UUID()
+		sessionSubject := fake.UUID()
 
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
 		assert.NoError(t, err)
@@ -3352,7 +3352,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "different-user-jwt",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": hintSubject.String(),
+				"sub": hintSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)
@@ -3409,8 +3409,8 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 		}
 		handler := HandleAuthorizeGet(httpHelper, authHelper, userSessionManager, database, templateFS, authorizeValidator, auditLogger, permissionChecker, tokenParser)
 
-		hintSubject := uuid.New()
-		sessionSubject := uuid.New()
+		hintSubject := fake.UUID()
+		sessionSubject := fake.UUID()
 
 		req, err := http.NewRequest("GET", "/authorize?client_id=test-client&redirect_uri=https://example.com&response_type=code&response_mode=form_post&scope=openid&prompt=none&id_token_hint=different-user-jwt", nil)
 		assert.NoError(t, err)
@@ -3446,7 +3446,7 @@ func TestHandleAuthorizeGet_IdTokenHint(t *testing.T) {
 			TokenBase64: "different-user-jwt",
 			Claims: jwt.MapClaims{
 				"iss": "https://test-issuer.com",
-				"sub": hintSubject.String(),
+				"sub": hintSubject,
 			},
 		}
 		tokenParser.On("DecodeAndValidateTokenString", "different-user-jwt", mock.Anything, false).Return(differentUserToken, nil)

--- a/src/authserver/internal/handlers/handler_dynamic_client_registration.go
+++ b/src/authserver/internal/handlers/handler_dynamic_client_registration.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
@@ -18,6 +17,7 @@ import (
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
 	"github.com/leodip/goiabada/core/urlutil"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/leodip/goiabada/core/validators"
 )
 
@@ -375,7 +375,7 @@ func validateRedirectURI(uri string, isPublic bool) error {
 // trustworthy, since it never was; it keeps the prefix and the column from drifting apart for
 // the human reading them, which is the only thing the prefix is for (#108, decision 16).
 func generateDCRClientIdentifier() string {
-	return "dcr_" + uuid.NewString()
+	return "dcr_" + uuidutil.New()
 }
 
 // containsGrantType checks if grant type is in the list

--- a/src/authserver/internal/handlers/handler_dynamic_client_registration_test.go
+++ b/src/authserver/internal/handlers/handler_dynamic_client_registration_test.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestValidateRedirectURI is the source of truth for what the DCR endpoint accepts as a
@@ -180,4 +183,22 @@ func TestValidateRedirectURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGenerateDCRClientIdentifier_IsThePrefixAndAUUID pins the identifier a self-registering
+// client is issued: the cosmetic dcr_ prefix the doc comment describes, then a canonical v4 from
+// the generator. The identifier is what the client authenticates as from then on and what the
+// clients.client_identifier unique index is taken against, so a value that is short, uppercase
+// or not fresh is a collision or a lookup miss (#278).
+func TestGenerateDCRClientIdentifier_IsThePrefixAndAUUID(t *testing.T) {
+	first := generateDCRClientIdentifier()
+
+	rest, found := strings.CutPrefix(first, "dcr_")
+	require.True(t, found, "identifier %q must carry the dcr_ prefix", first)
+
+	parsed, err := uuidutil.Parse(rest)
+	require.NoError(t, err)
+	assert.Equal(t, rest, parsed, "the generator must emit the canonical lowercase form")
+
+	assert.NotEqual(t, first, generateDCRClientIdentifier(), "each call must draw a fresh value")
 }

--- a/src/authserver/internal/handlers/handler_token_test.go
+++ b/src/authserver/internal/handlers/handler_token_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/handlerhelpers"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/require"
 
 	mocks_audit "github.com/leodip/goiabada/authserver/internal/audit/mocks"
@@ -1671,7 +1671,7 @@ func TestHandleTokenPost_ROPC_IgnoresBrowserSession(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	client := &models.Client{Id: 1, ClientIdentifier: "test_client"}
-	user := &models.User{Id: 42, Subject: uuid.New(), AuthStateGeneration: 7}
+	user := &models.User{Id: 42, Subject: fake.UUID(), AuthStateGeneration: 7}
 
 	tokenValidator.On("ValidateTokenRequest", mock.Anything,
 		mock.AnythingOfType("*validators.ValidateTokenRequestInput")).
@@ -1770,7 +1770,7 @@ func TestHandleTokenPost_ROPC_SpendsTheLimiterBudgetOnInvalidGrantOnly(t *testin
 			httpHelper.On("JsonError", mock.Anything, mock.Anything, mock.Anything).Return()
 		} else {
 			client := &models.Client{Id: 1, ClientIdentifier: "app"}
-			user := &models.User{Id: 42, Subject: uuid.New()}
+			user := &models.User{Id: 42, Subject: fake.UUID()}
 			tokenValidator.On("ValidateTokenRequest", mock.Anything, mock.Anything).
 				Return(&validators.ValidateTokenRequestResult{Client: client, User: user, Scope: "openid"}, nil)
 			tokenIssuer.On("GenerateTokenResponseForROPC", mock.Anything, mock.Anything).

--- a/src/authserver/internal/handlers/handler_userinfo.go
+++ b/src/authserver/internal/handlers/handler_userinfo.go
@@ -103,7 +103,7 @@ func HandleUserInfoGetPost(
 			// Add picture claim if user has a profile picture
 			hasPicture, pictureErr := database.UserHasProfilePicture(nil, user.Id)
 			if pictureErr == nil && hasPicture {
-				claims["picture"] = fmt.Sprintf("%v/userinfo/picture/%v", config.GetAuthServer().BaseURL, user.Subject.String())
+				claims["picture"] = fmt.Sprintf("%v/userinfo/picture/%v", config.GetAuthServer().BaseURL, user.Subject)
 			}
 		}
 

--- a/src/authserver/internal/handlers/handler_userinfo_test.go
+++ b/src/authserver/internal/handlers/handler_userinfo_test.go
@@ -12,11 +12,11 @@ import (
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	mocks_handlerhelpers "github.com/leodip/goiabada/core/handlerhelpers/mocks"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/customerrors"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -132,12 +132,12 @@ func TestHandleUserInfoGetPost(t *testing.T) {
 
 		handler := HandleUserInfoGetPost(httpHelper, database, auditLogger)
 
-		sub := uuid.New()
+		sub := fake.UUID()
 
 		req, _ := http.NewRequest("GET", "/userinfo", nil)
 		jwtToken := oauth.JwtToken{
 			Claims: map[string]interface{}{
-				"sub":   sub.String(),
+				"sub":   sub,
 				"scope": constants.AuthServerResourceIdentifier + ":" + constants.UserinfoPermissionIdentifier,
 			},
 		}
@@ -146,7 +146,7 @@ func TestHandleUserInfoGetPost(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		user := &models.User{Id: 1, Subject: sub, Enabled: false}
-		database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+		database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 
 		auditLogger.On("Log", constants.AuditUserDisabled, mock.MatchedBy(func(details map[string]interface{}) bool {
 			return details["userId"] == user.Id
@@ -171,11 +171,11 @@ func TestHandleUserInfoGetPost(t *testing.T) {
 
 		handler := HandleUserInfoGetPost(httpHelper, database, auditLogger)
 
-		sub := uuid.New()
+		sub := fake.UUID()
 		req, _ := http.NewRequest("GET", "/userinfo", nil)
 		jwtToken := oauth.JwtToken{
 			Claims: map[string]interface{}{
-				"sub":   sub.String(),
+				"sub":   sub,
 				"scope": constants.AuthServerResourceIdentifier + ":" + constants.UserinfoPermissionIdentifier + " profile email address phone groups attributes",
 			},
 		}
@@ -223,7 +223,7 @@ func TestHandleUserInfoGetPost(t *testing.T) {
 			Attributes:          []models.UserAttribute{userAttr},
 		}
 
-		database.On("GetUserBySubject", (*sql.Tx)(nil), sub.String()).Return(user, nil)
+		database.On("GetUserBySubject", (*sql.Tx)(nil), sub).Return(user, nil)
 		database.On("UserLoadGroups", (*sql.Tx)(nil), user).Return(nil)
 		database.On("GroupsLoadAttributes", (*sql.Tx)(nil), user.Groups).Return(nil)
 		database.On("UserLoadAttributes", (*sql.Tx)(nil), user).Return(nil)

--- a/src/authserver/internal/handlers/link_marker.go
+++ b/src/authserver/internal/handlers/link_marker.go
@@ -157,12 +157,6 @@ func SaveLinkMarker(httpSession sessionstore.Store, w http.ResponseWriter, r *ht
 	}
 	if continuationId == "" {
 		continuationId = stringutil.GenerateSecurityRandomString(continuationIdLength)
-		// GenerateSecurityRandomString answers "" when the system CSPRNG is unavailable.
-		// Writing that would put an empty id in the marker, which the POST refuses
-		// outright, so failing here is the same outcome with a stack trace attached.
-		if continuationId == "" {
-			return "", errors.WithStack(errors.New("unable to generate a link marker continuation id"))
-		}
 	}
 
 	jsonData, err := json.Marshal(&LinkMarker{

--- a/src/authserver/internal/server/openapi_contract_lint_test.go
+++ b/src/authserver/internal/server/openapi_contract_lint_test.go
@@ -824,10 +824,11 @@ func TestOpenAPI_EveryRefResolves(t *testing.T) {
 // of the contract a caller has already generated against, and an internal Go name is not.
 //
 // The check covers presence, not type. A named type that marshals to a scalar cannot be typed
-// from the Go source lexically: api.UserResponse.Subject is a uuid.UUID, so a type check would
-// call the spec's correct "string" a mismatch against an "object" it inferred from the
-// selector. Carrying a type map for the handful of such types buys less than the one live
-// case costs to explain, so type agreement stays a question for the census.
+// from the Go source lexically: the declared type is a selector, so a type check would infer
+// "object" and call the spec's correct "string" a mismatch. No field in api/ is such a type
+// today -- the last one, UserResponse.Subject, became a plain string in #278 -- but carrying a
+// type map against the next one buys less than it costs, so type agreement stays a question
+// for the census rather than a check here.
 //
 // A schema that no operation reaches is not this test's subject: TestOpenAPI_EveryRefResolves
 // owns reachability, and this one owns content.

--- a/src/authserver/internal/server/routes_ratelimiter_test.go
+++ b/src/authserver/internal/server/routes_ratelimiter_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/authserver/web"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -134,15 +133,12 @@ func newRoutesTestServer(t *testing.T) *Server {
 	passwordHash, err := hashutil.HashPassword("the account's real password")
 	assert.NoError(t, err)
 
-	subject, err := uuid.Parse(routesTestSubject)
-	assert.NoError(t, err)
-
 	database := mocks_data.NewDatabase(t)
 	database.On("GetSettingsById", mock.Anything, int64(1)).Return(routesTestSettings(), nil).Maybe()
 	database.On("GetUserBySubject", mock.Anything, routesTestSubject).Return(&models.User{
 		Id:           1,
 		Enabled:      true,
-		Subject:      subject,
+		Subject:      routesTestSubject,
 		Email:        "victim@example.com",
 		PasswordHash: passwordHash,
 		// EmailVerified false with no stored code: the verification comparison is reached

--- a/src/authserver/tests/data/browser_session_test.go
+++ b/src/authserver/tests/data/browser_session_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data/mssqldb"
 	"github.com/leodip/goiabada/core/data/mysqldb"
 	"github.com/leodip/goiabada/core/data/postgresdb"
 	"github.com/leodip/goiabada/core/data/sqlitedb"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,12 +69,12 @@ func rawSQLHandle(t *testing.T) *sql.DB {
 // timestamps so nothing here depends on the wall clock: every case below states its own
 // times and the engine compares against the value it was handed.
 func newBrowserSession(owner string, now time.Time, ttl time.Duration) *models.BrowserSession {
-	id := uuid.New().String() + uuid.New().String()
+	id := fake.UUID() + fake.UUID()
 	return &models.BrowserSession{
 		Owner:         owner,
 		SessionId:     id,
 		SessionIdHash: sha256Hex(id),
-		Data:          "ciphertext-" + uuid.New().String(),
+		Data:          "ciphertext-" + fake.UUID(),
 		LastAccessed:  now,
 		ExpiresAt:     now.Add(ttl),
 	}
@@ -161,7 +161,7 @@ func TestBrowserSession_ColumnHoldsTheHashAndNeverTheIdentifier(t *testing.T) {
 func TestBrowserSession_TwoOwnersMayHoldTheSameHash(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
-	shared := uuid.New().String() + uuid.New().String()
+	shared := fake.UUID() + fake.UUID()
 	hash := sha256Hex(shared)
 
 	authServer := &models.BrowserSession{

--- a/src/authserver/tests/data/email_backfill_test.go
+++ b/src/authserver/tests/data/email_backfill_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data/migrator"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,7 +108,7 @@ func TestBackfillLowercaseEmails(t *testing.T) {
 	for i, c := range cases {
 		user := &models.User{
 			Enabled:  true,
-			Subject:  uuid.New(),
+			Subject:  fake.UUID(),
 			Username: fmt.Sprintf("emailbackfill%d", i),
 			Email:    c.seed,
 		}
@@ -208,9 +208,9 @@ func TestBackfillLowercaseEmails_DisablingALoserRevokesItsAuthState(t *testing.T
 	// The loser is seeded first, so it holds the lower id and the survivor rule has to reach
 	// past id order to pick the lowercase row. Both rows exist on every engine only because
 	// migration 000040 made idx_email case-sensitive.
-	loser := &models.User{Enabled: true, Subject: uuid.New(), Username: "revokeloser", Email: "Revoke@x.com"}
+	loser := &models.User{Enabled: true, Subject: fake.UUID(), Username: "revokeloser", Email: "Revoke@x.com"}
 	require.NoError(t, h.DB.CreateUser(nil, loser), "seed the mixed-case loser")
-	survivor := &models.User{Enabled: true, Subject: uuid.New(), Username: "revokesurvivor", Email: "revoke@x.com"}
+	survivor := &models.User{Enabled: true, Subject: fake.UUID(), Username: "revokesurvivor", Email: "revoke@x.com"}
 	require.NoError(t, h.DB.CreateUser(nil, survivor), "seed the lowercase survivor")
 
 	clientId := seedClient000035(t, h, "revoke-backfill-client")
@@ -317,7 +317,7 @@ func seedSessionForBackfill(t *testing.T, h *isolatedDB, userId int64) *models.U
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	session := &models.UserSession{
-		SessionIdentifier: uuid.NewString(),
+		SessionIdentifier: fake.UUID(),
 		Started:           now,
 		LastAccessed:      now,
 		AuthMethods:       "pwd",
@@ -339,7 +339,7 @@ func seedSessionForBackfill(t *testing.T, h *isolatedDB, userId int64) *models.U
 func seedCodeForBackfill(t *testing.T, h *isolatedDB, clientId, userId int64) *models.Code {
 	t.Helper()
 
-	suffix := uuid.NewString()
+	suffix := fake.UUID()
 	code := &models.Code{
 		ClientId:            clientId,
 		UserId:              userId,
@@ -355,7 +355,7 @@ func seedCodeForBackfill(t *testing.T, h *isolatedDB, clientId, userId int64) *m
 		UserAgent:           "backfill-fixture",
 		ResponseMode:        "query",
 		AuthenticatedAt:     time.Now().UTC().Truncate(time.Microsecond),
-		SessionIdentifier:   uuid.NewString(),
+		SessionIdentifier:   fake.UUID(),
 		AcrLevel:            enums.AcrLevel1.String(),
 		AuthMethods:         "pwd",
 	}
@@ -374,7 +374,7 @@ func seedRefreshTokenForBackfill(t *testing.T, h *isolatedDB, clientId, userId, 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	token := &models.RefreshToken{
 		ClientId:         sql.NullInt64{Int64: clientId, Valid: true},
-		RefreshTokenJti:  uuid.NewString(),
+		RefreshTokenJti:  fake.UUID(),
 		RefreshTokenType: "Bearer",
 		Scope:            "openid profile offline_access",
 		IssuedAt:         sql.NullTime{Time: now, Valid: true},
@@ -451,9 +451,9 @@ func TestBackfillLowercaseEmails_DisablingALoserIsAudited(t *testing.T) {
 		require.Equalf(t, int64(1), settings.Id,
 			"the pass reads settings id 1, so a fixture whose row landed at %d would prove nothing", settings.Id)
 
-		loser := &models.User{Enabled: true, Subject: uuid.New(), Username: "auditloser", Email: "Audited@x.com"}
+		loser := &models.User{Enabled: true, Subject: fake.UUID(), Username: "auditloser", Email: "Audited@x.com"}
 		require.NoError(t, h.DB.CreateUser(nil, loser), "seed the mixed-case loser")
-		survivor := &models.User{Enabled: true, Subject: uuid.New(), Username: "auditsurvivor", Email: "audited@x.com"}
+		survivor := &models.User{Enabled: true, Subject: fake.UUID(), Username: "auditsurvivor", Email: "audited@x.com"}
 		require.NoError(t, h.DB.CreateUser(nil, survivor), "seed the lowercase survivor")
 
 		clientId := seedClient000035(t, h, "audit-backfill-client")

--- a/src/authserver/tests/data/load_helpers_test.go
+++ b/src/authserver/tests/data/load_helpers_test.go
@@ -3,7 +3,6 @@ package datatests
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/testutil/fake"
 )
@@ -20,7 +19,7 @@ func createUserWithGivenName(t *testing.T, givenName string) *models.User {
 	t.Helper()
 	user := &models.User{
 		Enabled:   true,
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Username:  "u" + fake.LetterN(12),
 		GivenName: givenName,
 		Email:     fake.LetterN(12) + "@example.com",

--- a/src/authserver/tests/data/migration_000021_countries_test.go
+++ b/src/authserver/tests/data/migration_000021_countries_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -241,10 +241,10 @@ func migration000021Fixtures() []migFixture {
 func seedMigrationFixture(t *testing.T, h *isolatedDB, f migFixture) int64 {
 	t.Helper()
 	u := &models.User{
-		Subject: uuid.New(),
+		Subject: fake.UUID(),
 		// username is varchar(32); the fixture label is unique and short.
 		Username:                      f.label,
-		Email:                         uuid.NewString() + "@example.com",
+		Email:                         fake.UUID() + "@example.com",
 		PasswordHash:                  "x",
 		PhoneNumberCountryUniqueId:    f.uid,
 		PhoneNumberCountryCallingCode: f.cc,

--- a/src/authserver/tests/data/migration_000024_auth_state_generation_test.go
+++ b/src/authserver/tests/data/migration_000024_auth_state_generation_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,7 +95,7 @@ func seedPreMigration000024User(t *testing.T, h *isolatedDB) int64 {
 		falseLit = "false"
 	}
 
-	subject := uuid.NewString()
+	subject := fake.UUID()
 	username := "premig24"
 	q := fmt.Sprintf(`INSERT INTO users
 		(enabled, subject, username, email_verified, phone_number_verified,

--- a/src/authserver/tests/data/migration_000026_code_revoked_test.go
+++ b/src/authserver/tests/data/migration_000026_code_revoked_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
@@ -94,7 +93,7 @@ func seedCode000026(t *testing.T, h *isolatedDB) int64 {
 
 	user := &models.User{
 		Enabled:  true,
-		Subject:  uuid.New(),
+		Subject:  fake.UUID(),
 		Username: "mig26_" + random,
 	}
 	require.NoError(t, h.DB.CreateUser(nil, user), "seed user")

--- a/src/authserver/tests/data/migration_000027_last_otp_step_test.go
+++ b/src/authserver/tests/data/migration_000027_last_otp_step_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -87,7 +87,7 @@ func seedPreMigration000027User(t *testing.T, h *isolatedDB) int64 {
 		falseLit, trueLit = "false", "true"
 	}
 
-	subject := uuid.NewString()
+	subject := fake.UUID()
 	q := fmt.Sprintf(`INSERT INTO users
 		(enabled, subject, username, email_verified, phone_number_verified,
 		 password_hash, otp_enabled)

--- a/src/authserver/tests/data/migration_000028_code_hash_test.go
+++ b/src/authserver/tests/data/migration_000028_code_hash_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +141,7 @@ func seedPreMigration000028User(t *testing.T, h *isolatedDB) int64 {
 		falseLit, trueLit = "false", "true"
 	}
 
-	subject := uuid.NewString()
+	subject := fake.UUID()
 	q := fmt.Sprintf(`INSERT INTO users
 		(enabled, subject, username, email_verified, phone_number_verified,
 		 password_hash, otp_enabled)
@@ -161,7 +161,7 @@ func seedPreMigration000028User(t *testing.T, h *isolatedDB) int64 {
 func seedPreMigration000028PreRegistration(t *testing.T, h *isolatedDB) int64 {
 	t.Helper()
 
-	email := uuid.NewString() + "@example.com"
+	email := fake.UUID() + "@example.com"
 	q := fmt.Sprintf(`INSERT INTO pre_registrations (email, password_hash) VALUES ('%s', 'x')`, email)
 	_, err := h.SQL.Exec(q)
 	require.NoError(t, err, "seed pre-registration")

--- a/src/authserver/tests/data/migration_000030_key_pairs_state_unique_test.go
+++ b/src/authserver/tests/data/migration_000030_key_pairs_state_unique_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,7 +136,7 @@ func assertKeyPairsStateIndex000030(t *testing.T, h *isolatedDB, phase string) {
 func insertKeyPair000030SQL(state string) string {
 	return fmt.Sprintf(
 		`INSERT INTO key_pairs (state, key_identifier, type, algorithm)
-		 VALUES ('%s', '%s', 'RSA', 'RS256')`, state, uuid.NewString())
+		 VALUES ('%s', '%s', 'RSA', 'RS256')`, state, fake.UUID())
 }
 
 // seedKeyPair000030 inserts one key_pairs row in state and returns its id. Callers

--- a/src/authserver/tests/data/migration_000031_otp_config_generation_test.go
+++ b/src/authserver/tests/data/migration_000031_otp_config_generation_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -161,7 +161,7 @@ func seedPreMigration000031User(t *testing.T, h *isolatedDB, otpEnabled bool) in
 	// here can do because they seed one user. SQL Server's unique indexes treat two NULLs as
 	// equal, so a second NULL-email row is a duplicate key there and nowhere else, and this
 	// test needs two users: one with an authenticator and one without.
-	subject := uuid.NewString()
+	subject := fake.UUID()
 	q := fmt.Sprintf(`INSERT INTO users
 		(enabled, subject, username, email, email_verified, phone_number_verified,
 		 password_hash, otp_enabled)
@@ -194,7 +194,7 @@ func seedPreMigration000031Session(t *testing.T, h *isolatedDB, userId int64, fl
 	}
 
 	const ts = "'2026-01-01 00:00:00'"
-	identifier := uuid.NewString()
+	identifier := fake.UUID()
 	q := fmt.Sprintf(`INSERT INTO user_sessions
 		(session_identifier, started, last_accessed, auth_methods, acr_level, auth_time,
 		 ip_address, device_name, device_type, device_os, level2_auth_config_has_changed, user_id)

--- a/src/authserver/tests/data/migration_000032_otp_enrollment_test.go
+++ b/src/authserver/tests/data/migration_000032_otp_enrollment_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +78,7 @@ func seedPreMigration000032User(t *testing.T, h *isolatedDB) int64 {
 
 	falseLit, trueLit := boolLiterals000031()
 
-	subject := uuid.NewString()
+	subject := fake.UUID()
 	q := fmt.Sprintf(`INSERT INTO users
 		(enabled, subject, username, email, email_verified, phone_number_verified,
 		 password_hash, otp_enabled)

--- a/src/authserver/tests/data/migration_000039_pkce_nullable_fk_swap_test.go
+++ b/src/authserver/tests/data/migration_000039_pkce_nullable_fk_swap_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -360,7 +360,7 @@ func TestMigration000039_RopcTokenBlocksUserDelete(t *testing.T) {
 func seedClient000039(t *testing.T, h *isolatedDB) *models.Client {
 	t.Helper()
 	client := &models.Client{
-		ClientIdentifier:         "c-" + uuid.NewString()[:8],
+		ClientIdentifier:         "c-" + fake.UUID()[:8],
 		Description:              "seeded by migration 000039's test",
 		Enabled:                  true,
 		AuthorizationCodeEnabled: true,
@@ -373,10 +373,10 @@ func seedClient000039(t *testing.T, h *isolatedDB) *models.Client {
 func seedUser000039(t *testing.T, h *isolatedDB) *models.User {
 	t.Helper()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
-		Email:        uuid.NewString() + "@example.com",
-		Username:     "u-" + uuid.NewString()[:8],
+		Email:        fake.UUID() + "@example.com",
+		Username:     "u-" + fake.UUID()[:8],
 		PasswordHash: "x",
 	}
 	require.NoError(t, h.DB.CreateUser(nil, user), "seed user")
@@ -391,7 +391,7 @@ func seedCode000039(t *testing.T, h *isolatedDB, client *models.Client, user *mo
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	code := &models.Code{
-		CodeHash:            "hash-" + uuid.NewString(),
+		CodeHash:            "hash-" + fake.UUID(),
 		ClientId:            client.Id,
 		UserId:              user.Id,
 		CodeChallenge:       challenge,
@@ -422,7 +422,7 @@ func seedRefreshToken000039(t *testing.T, h *isolatedDB, shape models.RefreshTok
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	token := shape
-	token.RefreshTokenJti = "jti-" + uuid.NewString()
+	token.RefreshTokenJti = "jti-" + fake.UUID()
 	token.PreviousRefreshTokenJti = "previous-jti-value"
 	token.FirstRefreshTokenJti = "first-jti-value"
 	token.SessionIdentifier = "session-identifier-value"
@@ -447,7 +447,7 @@ func createChallengelessCode000039(t *testing.T, h *isolatedDB, client *models.C
 	t.Helper()
 
 	code := &models.Code{
-		CodeHash:            "hash-" + uuid.NewString(),
+		CodeHash:            "hash-" + fake.UUID(),
 		ClientId:            client.Id,
 		UserId:              user.Id,
 		CodeChallenge:       sql.NullString{},
@@ -456,7 +456,7 @@ func createChallengelessCode000039(t *testing.T, h *isolatedDB, client *models.C
 		RedirectURI:         "https://example.com/cb",
 		ResponseMode:        "query",
 		AuthenticatedAt:     time.Now().UTC().Truncate(time.Microsecond),
-		SessionIdentifier:   uuid.NewString(),
+		SessionIdentifier:   fake.UUID(),
 		AcrLevel:            "urn:goiabada:level1",
 		AuthMethods:         "pwd",
 	}

--- a/src/authserver/tests/data/otp_backfill_test.go
+++ b/src/authserver/tests/data/otp_backfill_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/data/sqlitedb"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // TestBackfillEncryptedOTPSecrets exercises the one-time migration of legacy
@@ -34,9 +34,9 @@ func TestBackfillEncryptedOTPSecrets(t *testing.T) {
 	key := config.GetAESEncryptionKey()
 
 	create := func(u *models.User) *models.User {
-		u.Subject = uuid.New()
-		u.Username = uuid.NewString()
-		u.Email = uuid.NewString() + "@example.com"
+		u.Subject = fake.UUID()
+		u.Username = fake.UUID()
+		u.Email = fake.UUID() + "@example.com"
 		u.PasswordHash = "x"
 		if err := db.CreateUser(nil, u); err != nil {
 			t.Fatalf("CreateUser: %v", err)

--- a/src/authserver/tests/data/reencrypt_test.go
+++ b/src/authserver/tests/data/reencrypt_test.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data/sqlitedb"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // TestReencryptDataToNewKey verifies the startup re-encryption migration (issue
@@ -60,7 +60,7 @@ func TestReencryptDataToNewKey(t *testing.T) {
 	}
 
 	client := &models.Client{
-		ClientIdentifier:      "reencrypt-client-" + uuid.NewString(),
+		ClientIdentifier:      "reencrypt-client-" + fake.UUID(),
 		ClientSecretEncrypted: encOld(clientSec),
 	}
 	if err := db.CreateClient(nil, client); err != nil {
@@ -68,9 +68,9 @@ func TestReencryptDataToNewKey(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:                        uuid.New(),
-		Username:                       uuid.NewString(),
-		Email:                          uuid.NewString() + "@example.com",
+		Subject:                        fake.UUID(),
+		Username:                       fake.UUID(),
+		Email:                          fake.UUID() + "@example.com",
 		PasswordHash:                   "x",
 		OTPSecretEncrypted:             encOld(otpSeed),
 		EmailVerificationCodeEncrypted: encOld(emailCode),
@@ -81,7 +81,7 @@ func TestReencryptDataToNewKey(t *testing.T) {
 	}
 
 	preReg := &models.PreRegistration{
-		Email:                     uuid.NewString() + "@example.com",
+		Email:                     fake.UUID() + "@example.com",
 		PasswordHash:              "x",
 		VerificationCodeEncrypted: encOld(preRegCode),
 	}
@@ -92,7 +92,7 @@ func TestReencryptDataToNewKey(t *testing.T) {
 	// RSA key pair stored as PLAINTEXT PEM (the pre-#83 state).
 	keyPair := &models.KeyPair{
 		State:         "current",
-		KeyIdentifier: uuid.NewString(),
+		KeyIdentifier: fake.UUID(),
 		Type:          "RSA",
 		Algorithm:     "RS256",
 		PrivateKeyPEM: []byte(pemPlain),

--- a/src/authserver/tests/data/rotate_test.go
+++ b/src/authserver/tests/data/rotate_test.go
@@ -4,10 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data/sqlitedb"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 )
 
 // TestRotateEncryptionKeyIfNeeded exercises env-to-env key rotation (issue #83):
@@ -48,22 +48,22 @@ func TestRotateEncryptionKeyIfNeeded(t *testing.T) {
 	const otpEnrolment = "otpauth://totp/Goiabada:u@example.com?secret=JBSWY3DPEHPK3PXP"
 
 	if err := db.CreateKeyPair(nil, &models.KeyPair{
-		State: "current", KeyIdentifier: uuid.NewString(), Type: "RSA", Algorithm: "RS256",
+		State: "current", KeyIdentifier: fake.UUID(), Type: "RSA", Algorithm: "RS256",
 		PrivateKeyPEM: encA(pem), // canary, encrypted under keyA
 	}); err != nil {
 		t.Fatalf("CreateKeyPair: %v", err)
 	}
 	client := &models.Client{
-		ClientIdentifier:      "c-" + uuid.NewString(),
+		ClientIdentifier:      "c-" + fake.UUID(),
 		ClientSecretEncrypted: encA(clientSec),
 	}
 	if err := db.CreateClient(nil, client); err != nil {
 		t.Fatalf("CreateClient: %v", err)
 	}
 	user := &models.User{
-		Subject:                      uuid.New(),
-		Username:                     uuid.NewString(),
-		Email:                        uuid.NewString() + "@example.com",
+		Subject:                      fake.UUID(),
+		Username:                     fake.UUID(),
+		Email:                        fake.UUID() + "@example.com",
 		PasswordHash:                 "x",
 		OtpEnrollmentSecretEncrypted: encA(otpEnrolment),
 	}

--- a/src/authserver/tests/data/unique_constraint_test.go
+++ b/src/authserver/tests/data/unique_constraint_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/testutil/fake"
@@ -84,7 +83,7 @@ func TestUnique_UserEmail(t *testing.T) {
 
 	duplicate := &models.User{
 		Enabled:  true,
-		Subject:  uuid.New(),
+		Subject:  fake.UUID(),
 		Username: fake.Username(),
 		Email:    existing.Email,
 	}

--- a/src/authserver/tests/data/unknown_id_test.go
+++ b/src/authserver/tests/data/unknown_id_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,7 +149,7 @@ type byValueReader struct {
 }
 
 func byValueReaders() []byValueReader {
-	randomUUID := func() string { return uuid.New().String() }
+	randomUUID := func() string { return fake.UUID() }
 	randomWord := func() string { return "missing_" + fake.LetterN(16) }
 
 	return []byValueReader{

--- a/src/authserver/tests/data/user_session_test.go
+++ b/src/authserver/tests/data/user_session_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
@@ -432,7 +431,7 @@ func TestDeleteIdleSessions(t *testing.T) {
 		Email:         fake.Email(),
 		EmailVerified: true,
 		PasswordHash:  fake.Password(32),
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		GivenName:     fake.FirstName(),
 		FamilyName:    fake.LastName(),
@@ -630,7 +629,7 @@ func TestDeleteExpiredSessions(t *testing.T) {
 		Email:         fake.Email(),
 		EmailVerified: true,
 		PasswordHash:  fake.Password(32),
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		GivenName:     fake.FirstName(),
 		FamilyName:    fake.LastName(),

--- a/src/authserver/tests/data/user_test.go
+++ b/src/authserver/tests/data/user_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -44,7 +43,7 @@ func TestUpdateUser(t *testing.T) {
 
 	// Update all fields
 	user.Enabled = !user.Enabled
-	user.Subject = uuid.New()
+	user.Subject = fake.UUID()
 	user.Username = "updated_" + fake.Username()
 	user.GivenName = "Updated" + fake.FirstName()
 	user.MiddleName = "Updated" + fake.MiddleName()
@@ -138,14 +137,14 @@ func TestGetUserByUsername(t *testing.T) {
 func TestGetUserBySubject(t *testing.T) {
 	user := createTestUser(t)
 
-	retrievedUser, err := database.GetUserBySubject(nil, user.Subject.String())
+	retrievedUser, err := database.GetUserBySubject(nil, user.Subject)
 	if err != nil {
 		t.Fatalf("Failed to get user by subject: %v", err)
 	}
 
 	compareUsers(t, user, retrievedUser)
 
-	nonExistentUser, err := database.GetUserBySubject(nil, uuid.New().String())
+	nonExistentUser, err := database.GetUserBySubject(nil, fake.UUID())
 	if err != nil {
 		t.Errorf("Expected no error for non-existent user, got: %v", err)
 	}
@@ -315,7 +314,7 @@ func createSearchUser(t *testing.T, givenName string, username string) *models.U
 	t.Helper()
 	user := &models.User{
 		Enabled:   true,
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Username:  username,
 		GivenName: givenName,
 		Email:     fake.LetterN(12) + "@example.com",
@@ -440,7 +439,7 @@ func createTestUser(t *testing.T) *models.User {
 func createTestUserOn(t *testing.T, db data.Database) *models.User {
 	user := &models.User{
 		Enabled:                              fake.Bool(),
-		Subject:                              uuid.New(),
+		Subject:                              fake.UUID(),
 		Username:                             fake.Username(),
 		GivenName:                            fake.FirstName(),
 		MiddleName:                           fake.MiddleName(),
@@ -608,7 +607,7 @@ func TestUpdateUser_DoesNotClobberAuthStateGeneration(t *testing.T) {
 	// Re-created rather than updated: writing it is exactly what UpdateUser must
 	// not do, so the nonzero value has to arrive through an insert.
 	user.Id = 0
-	user.Subject = uuid.New()
+	user.Subject = fake.UUID()
 	user.Username = "gen_" + fake.LetterN(8)
 	user.Email = fake.LetterN(8) + "@example.com"
 	if err := database.CreateUser(nil, user); err != nil {
@@ -1280,7 +1279,7 @@ func codeHashOf(t *testing.T, code string) string {
 func createUserWithResetCode(t *testing.T) (*models.User, string) {
 	t.Helper()
 	user := createTestUser(t)
-	hash := codeHashOf(t, uuid.NewString())
+	hash := codeHashOf(t, fake.UUID())
 	user.ForgotPasswordCodeEncrypted = []byte("PENDINGRESETCODE")
 	user.ForgotPasswordCodeIssuedAt = sql.NullTime{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true}
 	user.ForgotPasswordCodeHash = hash
@@ -1318,7 +1317,7 @@ func TestGetUserByForgotPasswordCodeHash(t *testing.T) {
 	// 2. A hash no row carries is a miss, not an error. The handler renders the same
 	// indistinguishable page for a miss as for a wrong code, so a spurious error here
 	// would surface as a 500 and tell an attacker the difference.
-	missing, err := database.GetUserByForgotPasswordCodeHash(nil, codeHashOf(t, uuid.NewString()))
+	missing, err := database.GetUserByForgotPasswordCodeHash(nil, codeHashOf(t, fake.UUID()))
 	if err != nil {
 		t.Errorf("a hash no row carries must not be an error, got: %v", err)
 	}
@@ -1423,7 +1422,7 @@ func TestSetUserPasswordHash_ClearsCodeHash(t *testing.T) {
 // snapshot, so it would block. transaction_test.go documents both. The outside read here
 // happens only after the transaction is finished, which needs no second connection.
 func TestGetUserByForgotPasswordCodeHash_Transaction(t *testing.T) {
-	hash := codeHashOf(t, uuid.NewString())
+	hash := codeHashOf(t, fake.UUID())
 
 	// The user is created BEFORE the transaction opens. sqlite runs with
 	// SetMaxOpenConns(1), so a pooled write while a transaction holds that one connection
@@ -1533,7 +1532,7 @@ func TestTryConsumeForgotPasswordCode(t *testing.T) {
 
 	// 18. A real hash the row does not carry changes nothing either.
 	other, otherHash := createUserWithResetCode(t)
-	wrong, err := database.TryConsumeForgotPasswordCode(nil, other.Id, codeHashOf(t, uuid.NewString()), "wrongpassword")
+	wrong, err := database.TryConsumeForgotPasswordCode(nil, other.Id, codeHashOf(t, fake.UUID()), "wrongpassword")
 	if err != nil {
 		t.Fatalf("a claim with a non-matching hash errored: %v", err)
 	}
@@ -1791,7 +1790,7 @@ func TestGetUserByEmailIsCaseSensitive(t *testing.T) {
 // commondb.engineFoldedTheMatch.
 func TestGetUserBySubjectIsCaseSensitive(t *testing.T) {
 	user := createTestUser(t)
-	subject := user.Subject.String()
+	subject := user.Subject
 
 	for _, tc := range []struct {
 		name   string
@@ -1828,7 +1827,7 @@ func createUserWithEmail(t *testing.T, email string) *models.User {
 
 	user := &models.User{
 		Enabled:      true,
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Username:     "case_" + fake.LetterN(10),
 		Email:        email,
 		PasswordHash: fake.Password(60),

--- a/src/authserver/tests/integration/account_register_test.go
+++ b/src/authserver/tests/integration/account_register_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -426,7 +425,7 @@ func TestSelfRegister_Post_DuplicateEmail(t *testing.T) {
 	setRegSettings(t, true, false, false)
 
 	existing := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: "irrelevant",

--- a/src/authserver/tests/integration/api_account_consents_test.go
+++ b/src/authserver/tests/integration/api_account_consents_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ func TestAPIAccountConsentsGet_Success(t *testing.T) {
 
 	// Create a client and a consent for this user
 	client := &models.Client{
-		ClientIdentifier: "acct-consents-client-" + uuid.New().String()[:8],
+		ClientIdentifier: "acct-consents-client-" + fake.UUID()[:8],
 		Description:      "Account Consents Test Client",
 		Enabled:          true,
 		IsPublic:         true,
@@ -108,7 +108,7 @@ func TestAPIAccountConsentDelete_Success(t *testing.T) {
 
 	// Create a client and consent for this user
 	client := &models.Client{
-		ClientIdentifier: "acct-consents-del-client-" + uuid.New().String()[:8],
+		ClientIdentifier: "acct-consents-del-client-" + fake.UUID()[:8],
 		Description:      "Account Consents Delete Client",
 		Enabled:          true,
 		IsPublic:         true,
@@ -150,7 +150,7 @@ func TestAPIAccountConsentDelete_ForbiddenOnOtherUser(t *testing.T) {
 
 	// Create another user (user2)
 	user2 := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "otheruser@consents.test",
 		GivenName:  "Other",
@@ -162,7 +162,7 @@ func TestAPIAccountConsentDelete_ForbiddenOnOtherUser(t *testing.T) {
 
 	// Create client and consent for user2
 	client := &models.Client{
-		ClientIdentifier: "acct-consents-oth-client-" + uuid.New().String()[:8],
+		ClientIdentifier: "acct-consents-oth-client-" + fake.UUID()[:8],
 		Description:      "Other User Client",
 		Enabled:          true,
 		IsPublic:         true,

--- a/src/authserver/tests/integration/api_account_email_test.go
+++ b/src/authserver/tests/integration/api_account_email_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -91,7 +90,7 @@ func TestAPIAccountEmailPut_EmailAlreadyExists(t *testing.T) {
 
 	// Create another user with a known email
 	otherEmail := "existing_" + strings.ToLower(fake.LetterN(6)) + "@example.com"
-	otherUser := &models.User{Email: otherEmail, Enabled: true, Subject: uuid.New()}
+	otherUser := &models.User{Email: otherEmail, Enabled: true, Subject: fake.UUID()}
 	err := database.CreateUser(nil, otherUser)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteUser(nil, otherUser.Id) }()

--- a/src/authserver/tests/integration/api_account_otp_test.go
+++ b/src/authserver/tests/integration/api_account_otp_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -17,6 +16,7 @@ import (
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/otp"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -464,7 +464,7 @@ func seedExtraSessionForOTPTest(t *testing.T, userId int64) *models.UserSession 
 
 	now := time.Now().UTC()
 	session := &models.UserSession{
-		SessionIdentifier:   uuid.New().String(),
+		SessionIdentifier:   fake.UUID(),
 		Started:             now,
 		LastAccessed:        now,
 		AuthMethods:         "pwd otp",

--- a/src/authserver/tests/integration/api_account_sessions_test.go
+++ b/src/authserver/tests/integration/api_account_sessions_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +23,7 @@ func TestAPIAccountSessionsGet_Success_IncludesIsCurrent(t *testing.T) {
 
 	// Create an extra client and a couple of sessions linked to it for richer output
 	testClient := &models.Client{
-		ClientIdentifier:         "acct-sess-client-" + uuid.New().String()[:8],
+		ClientIdentifier:         "acct-sess-client-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Account Sessions Client",
 		Enabled:                  true,
@@ -36,8 +36,8 @@ func TestAPIAccountSessionsGet_Success_IncludesIsCurrent(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteClient(nil, testClient.Id) }()
 
-	s1 := createTestUserSession(t, user.Id, uuid.New().String())
-	s2 := createTestUserSession(t, user.Id, uuid.New().String())
+	s1 := createTestUserSession(t, user.Id, fake.UUID())
+	s2 := createTestUserSession(t, user.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, s1.Id)
 		_ = database.DeleteUserSession(nil, s2.Id)
@@ -81,7 +81,7 @@ func TestAPIAccountSessionsGet_OnlyValidSessions(t *testing.T) {
 	accessToken, user := getUserAccessTokenWithAccountScope(t)
 
 	valid := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-30 * time.Minute),
 		LastAccessed:      time.Now().UTC().Add(-5 * time.Minute),
 		AuthMethods:       "pwd",
@@ -98,7 +98,7 @@ func TestAPIAccountSessionsGet_OnlyValidSessions(t *testing.T) {
 	defer func() { _ = database.DeleteUserSession(nil, valid.Id) }()
 
 	expired := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-25 * time.Hour),
 		LastAccessed:      time.Now().UTC().Add(-24 * time.Hour),
 		AuthMethods:       "pwd",
@@ -133,7 +133,7 @@ func TestAPIAccountSessionsGet_OnlyValidSessions(t *testing.T) {
 func TestAPIAccountSessionDelete_Success(t *testing.T) {
 	accessToken, user := getUserAccessTokenWithAccountScope(t)
 
-	session := createTestUserSession(t, user.Id, uuid.New().String())
+	session := createTestUserSession(t, user.Id, fake.UUID())
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/account/sessions/" + strconv.FormatInt(session.Id, 10)
 	resp := makeAPIRequest(t, "DELETE", url, accessToken, nil)
@@ -157,12 +157,12 @@ func TestAPIAccountSessionDelete_ForbiddenOnOtherUsersSession(t *testing.T) {
 	accessToken, _ := getUserAccessTokenWithAccountScope(t)
 
 	// Create another user and a session for them
-	other := &models.User{Subject: uuid.New(), Enabled: true, Email: "other-" + uuid.New().String()[:8] + "@acctsess.test"}
+	other := &models.User{Subject: fake.UUID(), Enabled: true, Email: "other-" + fake.UUID()[:8] + "@acctsess.test"}
 	err := database.CreateUser(nil, other)
 	assert.NoError(t, err)
 	defer func() { _ = database.DeleteUser(nil, other.Id) }()
 
-	otherSession := createTestUserSession(t, other.Id, uuid.New().String())
+	otherSession := createTestUserSession(t, other.Id, fake.UUID())
 	defer func() { _ = database.DeleteUserSession(nil, otherSession.Id) }()
 
 	url := config.GetAuthServer().BaseURL + "/api/v1/account/sessions/" + strconv.FormatInt(otherSession.Id, 10)

--- a/src/authserver/tests/integration/api_clients_delete_test.go
+++ b/src/authserver/tests/integration/api_clients_delete_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -243,7 +242,7 @@ func TestAPIClientDelete_CascadesLinkedData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create user and consent to the client
-	user := &models.User{Subject: uuid.New(), Enabled: true, Email: fake.Email()}
+	user := &models.User{Subject: fake.UUID(), Enabled: true, Email: fake.Email()}
 	err = database.CreateUser(nil, user)
 	assert.NoError(t, err)
 	consent := &models.UserConsent{ClientId: client.Id, UserId: user.Id, Scope: "openid"}

--- a/src/authserver/tests/integration/api_clients_flip_revocation_test.go
+++ b/src/authserver/tests/integration/api_clients_flip_revocation_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -192,7 +191,7 @@ func TestAPIClientAuthenticationPut_FlipToPublic_LeavesTheUsersOtherClientAlone(
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/api_clients_sessions_test.go
+++ b/src/authserver/tests/integration/api_clients_sessions_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIClientSessionsGet_Success(t *testing.T) {
 
 	// Create a client
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-sessions-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-sessions-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Test Client for Sessions",
 		Enabled:                  true,
@@ -35,7 +35,7 @@ func TestAPIClientSessionsGet_Success(t *testing.T) {
 
 	// Create a user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@client-sessions-success.test",
 		GivenName:     "Test",
@@ -47,8 +47,8 @@ func TestAPIClientSessionsGet_Success(t *testing.T) {
 	defer func() { _ = database.DeleteUser(nil, testUser.Id) }()
 
 	// Create sessions
-	s1 := createTestUserSession(t, testUser.Id, uuid.New().String())
-	s2 := createTestUserSession(t, testUser.Id, uuid.New().String())
+	s1 := createTestUserSession(t, testUser.Id, fake.UUID())
+	s2 := createTestUserSession(t, testUser.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, s1.Id)
 		_ = database.DeleteUserSession(nil, s2.Id)
@@ -98,7 +98,7 @@ func TestAPIClientSessionsGet_EmptySessions(t *testing.T) {
 
 	// Create a client without linked sessions
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-empty-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-empty-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Empty Client",
 		Enabled:                  true,
@@ -165,7 +165,7 @@ func TestAPIClientSessionsGet_InvalidId(t *testing.T) {
 func TestAPIClientSessionsGet_Unauthorized(t *testing.T) {
 	// Create a client
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-unauth-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-unauth-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Client",
 		Enabled:                  true,
@@ -193,7 +193,7 @@ func TestAPIClientSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Client
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-valid-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-valid-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Client",
 		Enabled:                  true,
@@ -208,7 +208,7 @@ func TestAPIClientSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// User
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@client-valid-sessions.test",
 		GivenName:     "Test",
@@ -221,7 +221,7 @@ func TestAPIClientSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Valid session
 	valid := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-30 * time.Minute),
 		LastAccessed:      time.Now().UTC().Add(-5 * time.Minute),
 		AuthMethods:       "pwd",
@@ -239,7 +239,7 @@ func TestAPIClientSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Expired session
 	expired := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-25 * time.Hour),
 		LastAccessed:      time.Now().UTC().Add(-24 * time.Hour),
 		AuthMethods:       "pwd",
@@ -282,7 +282,7 @@ func TestAPIClientSessionsGet_PaginationDefaultAndCap(t *testing.T) {
 
 	// Client
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-page-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-page-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Client",
 		Enabled:                  true,
@@ -297,7 +297,7 @@ func TestAPIClientSessionsGet_PaginationDefaultAndCap(t *testing.T) {
 
 	// User
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@client-page.test",
 		GivenName:     "Test",
@@ -314,7 +314,7 @@ func TestAPIClientSessionsGet_PaginationDefaultAndCap(t *testing.T) {
 	now := time.Now().UTC()
 	for i := 0; i < total; i++ {
 		s := &models.UserSession{
-			SessionIdentifier: uuid.New().String(),
+			SessionIdentifier: fake.UUID(),
 			Started:           now.Add(-time.Hour),
 			LastAccessed:      now.Add(-time.Minute * 5),
 			AuthMethods:       "pwd",

--- a/src/authserver/tests/integration/api_granular_scopes_test.go
+++ b/src/authserver/tests/integration/api_granular_scopes_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
@@ -87,7 +86,7 @@ func TestGranularScopes_AdminReadCanOnlyReadUserEndpoints(t *testing.T) {
 
 	// Create a test user for the tests
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",
@@ -234,7 +233,7 @@ func TestGranularScopes_ManageUsersCanAccessUserEndpointsOnly(t *testing.T) {
 
 	// Create a test user for the tests
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",
@@ -293,7 +292,7 @@ func TestGranularScopes_ManageClientsCanAccessClientEndpointsOnly(t *testing.T) 
 
 	// Create a test user
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",
@@ -352,7 +351,7 @@ func TestGranularScopes_ManageSettingsCanAccessSettingsEndpointsOnly(t *testing.
 
 	// Create a test user
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",
@@ -397,7 +396,7 @@ func TestGranularScopes_ManageCanAccessAllEndpoints(t *testing.T) {
 
 	// Create a test user
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",
@@ -606,7 +605,7 @@ func TestGranularScopes_ResourcesRequireSettingsScope(t *testing.T) {
 func TestGranularScopes_UserPermissionsRequireUsersScope(t *testing.T) {
 	// Create a test user
 	testUser := &models.User{
-		Subject:   uuid.New(),
+		Subject:   fake.UUID(),
 		Enabled:   true,
 		Email:     fake.Email(),
 		GivenName: "TestUser",

--- a/src/authserver/tests/integration/api_group_members_test.go
+++ b/src/authserver/tests/integration/api_group_members_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +33,7 @@ func TestAPIGroupMembersGet_Success(t *testing.T) {
 
 	// Setup: Create test users and add to group
 	testUser1 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "member1@group.test",
 		GivenName:     "Member",
@@ -47,7 +47,7 @@ func TestAPIGroupMembersGet_Success(t *testing.T) {
 	}()
 
 	testUser2 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "member2@group.test",
 		GivenName:     "Member",
@@ -160,7 +160,7 @@ func TestAPIGroupMembersGet_Pagination(t *testing.T) {
 
 	for i := 1; i <= 3; i++ {
 		user := &models.User{
-			Subject:    uuid.New(),
+			Subject:    fake.UUID(),
 			Enabled:    true,
 			Email:      "paguser" + strconv.Itoa(i) + "@group.test",
 			GivenName:  "Page",
@@ -259,7 +259,7 @@ func TestAPIGroupMemberAdd_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "newmember@group.test",
 		GivenName:  "New",
@@ -317,7 +317,7 @@ func TestAPIGroupMemberAdd_UserAlreadyInGroup(t *testing.T) {
 
 	// Setup: Create test user and add to group
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "duplicate@group.test",
 		GivenName:  "Duplicate",
@@ -440,7 +440,7 @@ func TestAPIGroupMemberRemove_Success(t *testing.T) {
 
 	// Setup: Create test user and add to group
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "removeme@group.test",
 		GivenName:  "Remove",
@@ -494,7 +494,7 @@ func TestAPIGroupMemberRemove_UserNotInGroup(t *testing.T) {
 
 	// Setup: Create test user (not in group)
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "notingroup@group.test",
 		GivenName:  "Not",

--- a/src/authserver/tests/integration/api_groups_delete_test.go
+++ b/src/authserver/tests/integration/api_groups_delete_test.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +45,7 @@ func TestAPIGroupDelete_SuccessWithMembers(t *testing.T) {
 
 	// Setup: Create test user and add to group
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@groupdelete.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_groups_get_test.go
+++ b/src/authserver/tests/integration/api_groups_get_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -302,7 +302,7 @@ func TestAPIGroupsGet_MemberCountAccuracy(t *testing.T) {
 
 	// Setup: Create test users
 	testUser1 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser1@membercount.test",
 		GivenName:     "Test",
@@ -316,7 +316,7 @@ func TestAPIGroupsGet_MemberCountAccuracy(t *testing.T) {
 	}()
 
 	testUser2 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser2@membercount.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_groups_single_test.go
+++ b/src/authserver/tests/integration/api_groups_single_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -120,7 +120,7 @@ func TestAPIGroupGet_MemberCountAccuracy(t *testing.T) {
 
 	// Setup: Create test users
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@singlegroupmembercount.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_groups_update_test.go
+++ b/src/authserver/tests/integration/api_groups_update_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
@@ -387,7 +386,7 @@ func TestAPIGroupUpdatePut_MemberCountInResponse(t *testing.T) {
 
 	// Setup: Create test user and add to group
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@updatemembercount.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_permission_users_test.go
+++ b/src/authserver/tests/integration/api_permission_users_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -24,9 +23,9 @@ func TestAPIPermissionUsersGet_Success(t *testing.T) {
 
 	// Create three users; assign permission to two
 	randSuffix := fake.LetterN(6)
-	u1 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser1-" + randSuffix, Email: "permuser1-" + randSuffix + "@test.com", GivenName: "U1", FamilyName: "T"}
-	u2 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser2-" + randSuffix, Email: "permuser2-" + randSuffix + "@test.com", GivenName: "U2", FamilyName: "T"}
-	u3 := &models.User{Subject: uuid.New(), Enabled: true, Username: "permuser3-" + randSuffix, Email: "permuser3-" + randSuffix + "@test.com", GivenName: "U3", FamilyName: "T"}
+	u1 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "permuser1-" + randSuffix, Email: "permuser1-" + randSuffix + "@test.com", GivenName: "U1", FamilyName: "T"}
+	u2 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "permuser2-" + randSuffix, Email: "permuser2-" + randSuffix + "@test.com", GivenName: "U2", FamilyName: "T"}
+	u3 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "permuser3-" + randSuffix, Email: "permuser3-" + randSuffix + "@test.com", GivenName: "U3", FamilyName: "T"}
 	assert.NoError(t, database.CreateUser(nil, u1))
 	assert.NoError(t, database.CreateUser(nil, u2))
 	assert.NoError(t, database.CreateUser(nil, u3))

--- a/src/authserver/tests/integration/api_profile_picture_test.go
+++ b/src/authserver/tests/integration/api_profile_picture_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -68,7 +67,7 @@ func createTestUserForProfilePicture(t *testing.T) *models.User {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -136,7 +135,7 @@ func TestAPIAccountProfilePicturePost_Success(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&response)
 	assert.NoError(t, err)
 	assert.True(t, response["success"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), user.Subject.String())
+	assert.Contains(t, response["pictureUrl"].(string), user.Subject)
 
 	// Verify the picture was saved
 	getResp := makeAPIRequest(t, "GET", url, accessToken, nil)
@@ -323,7 +322,7 @@ func TestAPIUserProfilePicturePost_Success(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&response)
 	assert.NoError(t, err)
 	assert.True(t, response["success"].(bool))
-	assert.Contains(t, response["pictureUrl"].(string), user.Subject.String())
+	assert.Contains(t, response["pictureUrl"].(string), user.Subject)
 
 	// Verify the picture was saved
 	getResp := makeAPIRequest(t, "GET", url, accessToken, nil)
@@ -418,7 +417,7 @@ func TestUserinfoPicture_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, uploadResp.StatusCode)
 
 	// Now fetch the picture via the userinfo/picture endpoint (no auth required)
-	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject.String())
+	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject)
 	httpClient := createHttpClient(t)
 	req, err := http.NewRequest("GET", pictureUrl, nil)
 	assert.NoError(t, err)
@@ -441,7 +440,7 @@ func TestUserinfoPicture_Success(t *testing.T) {
 
 func TestUserinfoPicture_NotFound(t *testing.T) {
 	// Use a random UUID that doesn't exist
-	randomUUID := uuid.New().String()
+	randomUUID := fake.UUID()
 	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, randomUUID)
 
 	httpClient := createHttpClient(t)
@@ -474,7 +473,7 @@ func TestUserinfoPicture_UserHasNoPicture(t *testing.T) {
 	// Create a user without a profile picture
 	user := createTestUserForProfilePicture(t)
 
-	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject.String())
+	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject)
 
 	httpClient := createHttpClient(t)
 	req, err := http.NewRequest("GET", pictureUrl, nil)
@@ -498,7 +497,7 @@ func TestUserinfoPicture_CacheHeaders(t *testing.T) {
 	assert.Equal(t, http.StatusOK, uploadResp.StatusCode)
 
 	// Fetch the picture and check cache headers
-	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject.String())
+	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject)
 	httpClient := createHttpClient(t)
 	req, err := http.NewRequest("GET", pictureUrl, nil)
 	assert.NoError(t, err)
@@ -546,7 +545,7 @@ func TestProfilePicture_FullWorkflow(t *testing.T) {
 	assert.True(t, getResponse2["hasPicture"].(bool))
 
 	// 5. Fetch the actual picture via public endpoint
-	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject.String())
+	pictureUrl := fmt.Sprintf("%s/userinfo/picture/%s", config.GetAuthServer().BaseURL, user.Subject)
 	httpClient := createHttpClient(t)
 	pictureResp, err := httpClient.Get(pictureUrl)
 	assert.NoError(t, err)

--- a/src/authserver/tests/integration/api_resource_permissions_test.go
+++ b/src/authserver/tests/integration/api_resource_permissions_test.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIResourcePermissionsGet_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Setup: Create test resource
-	resource := createTestResource(t, "test-resource-perms-"+uuid.New().String()[:8], "Test Resource for Permissions")
+	resource := createTestResource(t, "test-resource-perms-"+fake.UUID()[:8], "Test Resource for Permissions")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()
@@ -85,7 +85,7 @@ func TestAPIResourcePermissionsGet_NoPermissions(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Setup: Create test resource without permissions
-	resource := createTestResource(t, "test-resource-no-perms-"+uuid.New().String()[:8], "Test Resource without Permissions")
+	resource := createTestResource(t, "test-resource-no-perms-"+fake.UUID()[:8], "Test Resource without Permissions")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()
@@ -242,7 +242,7 @@ func TestAPIResourcePermissionsGet_NonAuthServerResourceIncludesAllPermissions(t
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Setup: Create test resource (non-AuthServer)
-	resource := createTestResource(t, "test-non-authserver-"+uuid.New().String()[:8], "Test Non-AuthServer Resource")
+	resource := createTestResource(t, "test-non-authserver-"+fake.UUID()[:8], "Test Non-AuthServer Resource")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()
@@ -288,7 +288,7 @@ func TestAPIResourcePermissionsGet_NonAuthServerResourceIncludesAllPermissions(t
 
 func TestAPIResourcePermissionsGet_Unauthorized(t *testing.T) {
 	// Setup: Create test resource
-	resource := createTestResource(t, "test-resource-unauth-"+uuid.New().String()[:8], "Test Resource for Unauthorized Test")
+	resource := createTestResource(t, "test-resource-unauth-"+fake.UUID()[:8], "Test Resource for Unauthorized Test")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()
@@ -309,7 +309,7 @@ func TestAPIResourcePermissionsGet_Unauthorized(t *testing.T) {
 
 func TestAPIResourcePermissionsGet_InvalidAccessToken(t *testing.T) {
 	// Setup: Create test resource
-	resource := createTestResource(t, "test-resource-invalid-token-"+uuid.New().String()[:8], "Test Resource for Invalid Token Test")
+	resource := createTestResource(t, "test-resource-invalid-token-"+fake.UUID()[:8], "Test Resource for Invalid Token Test")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()
@@ -328,7 +328,7 @@ func TestAPIResourcePermissionsGet_LargeNumberOfPermissions(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Setup: Create test resource
-	resource := createTestResource(t, "test-resource-many-perms-"+uuid.New().String()[:8], "Test Resource with Many Permissions")
+	resource := createTestResource(t, "test-resource-many-perms-"+fake.UUID()[:8], "Test Resource with Many Permissions")
 	defer func() {
 		_ = database.DeleteResource(nil, resource.Id)
 	}()

--- a/src/authserver/tests/integration/api_resources_test.go
+++ b/src/authserver/tests/integration/api_resources_test.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -160,7 +160,7 @@ func createClientCredentialsTokenWithScope(t *testing.T, resourceIdentifier, per
 	assert.NoError(t, err)
 
 	client := &models.Client{
-		ClientIdentifier:         "nonadmin-test-client-" + uuid.New().String()[:8],
+		ClientIdentifier:         "nonadmin-test-client-" + fake.UUID()[:8],
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,

--- a/src/authserver/tests/integration/api_user_email_verification_code_test.go
+++ b/src/authserver/tests/integration/api_user_email_verification_code_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func TestAPIUserEmailVerificationCodePost_Success(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	user := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "email-code-user@example.test",
 		GivenName:     "Email",
@@ -65,7 +65,7 @@ func TestAPIUserEmailVerificationCodePost_VerifiedUser(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	user := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "verified-email-code@example.test",
 		GivenName:     "Verified",
@@ -173,7 +173,7 @@ func TestAPIUserEmailVerificationCodePost_RegeneratesCode(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	user := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "regen-email-code@example.test",
 		GivenName:     "Regen",

--- a/src/authserver/tests/integration/api_user_groups_get_test.go
+++ b/src/authserver/tests/integration/api_user_groups_get_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUserGroupsGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@user-groups.test",
 		GivenName:     "Test",
@@ -100,7 +100,7 @@ func TestAPIUserGroupsGet_NoGroups(t *testing.T) {
 
 	// Setup: Create test user without groups
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@no-groups.test",
 		GivenName:  "Test",
@@ -171,7 +171,7 @@ func TestAPIUserGroupsGet_InvalidId(t *testing.T) {
 func TestAPIUserGroupsGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-groups.test",
 		GivenName:  "Test",

--- a/src/authserver/tests/integration/api_user_groups_update_test.go
+++ b/src/authserver/tests/integration/api_user_groups_update_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUserGroupsPut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@groups-update.test",
 		GivenName:     "Test",
@@ -114,7 +114,7 @@ func TestAPIUserGroupsPut_EmptyGroups(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@empty-groups.test",
 		GivenName:  "Test",
@@ -179,7 +179,7 @@ func TestAPIUserGroupsPut_NonExistentGroup(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid-group.test",
 		GivenName:  "Test",
@@ -256,7 +256,7 @@ func TestAPIUserGroupsPut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid-body.test",
 		GivenName:  "Test",
@@ -287,7 +287,7 @@ func TestAPIUserGroupsPut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserGroupsPut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-update.test",
 		GivenName:  "Test",

--- a/src/authserver/tests/integration/api_users_attributes_test.go
+++ b/src/authserver/tests/integration/api_users_attributes_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUserAttributesGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@attributes.test",
 		GivenName:     "Test",
@@ -83,7 +83,7 @@ func TestAPIUserAttributesGet_EmptyAttributes(t *testing.T) {
 
 	// Setup: Create test user without attributes
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@empty-attrs.test",
 		GivenName:  "Test",
@@ -153,7 +153,7 @@ func TestAPIUserAttributesGet_InvalidId(t *testing.T) {
 func TestAPIUserAttributesGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-attrs.test",
 		GivenName:  "Test",
@@ -186,7 +186,7 @@ func TestAPIUserAttributeGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-get.test",
 		GivenName:  "Test",
@@ -268,7 +268,7 @@ func TestAPIUserAttributeGet_InvalidId(t *testing.T) {
 func TestAPIUserAttributeGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user and attribute
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-attr.test",
 		GivenName:  "Test",
@@ -306,7 +306,7 @@ func TestAPIUserAttributeCreatePost_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-create.test",
 		GivenName:  "Test",
@@ -369,7 +369,7 @@ func TestAPIUserAttributeCreatePost_ValidationErrors(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-validation.test",
 		GivenName:  "Test",
@@ -485,7 +485,7 @@ func TestAPIUserAttributeUpdatePut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-update.test",
 		GivenName:  "Test",
@@ -565,7 +565,7 @@ func TestAPIUserAttributeUpdatePut_ValidationErrors(t *testing.T) {
 
 	// Setup: Create test user and attribute
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-update-validation.test",
 		GivenName:  "Test",
@@ -667,7 +667,7 @@ func TestAPIUserAttributeUpdatePut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user and attribute
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-invalid-body.test",
 		GivenName:  "Test",
@@ -703,7 +703,7 @@ func TestAPIUserAttributeUpdatePut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserAttributeUpdatePut_Unauthorized(t *testing.T) {
 	// Setup: Create test user and attribute
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-unauth-update.test",
 		GivenName:  "Test",
@@ -741,7 +741,7 @@ func TestAPIUserAttributeDelete_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-delete.test",
 		GivenName:  "Test",
@@ -820,7 +820,7 @@ func TestAPIUserAttributeDelete_InvalidId(t *testing.T) {
 func TestAPIUserAttributeDelete_Unauthorized(t *testing.T) {
 	// Setup: Create test user and attribute
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-delete-unauth.test",
 		GivenName:  "Test",
@@ -876,7 +876,7 @@ func TestAPIUserAttribute_AngleBracketsRejected(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-angle.test",
 		GivenName:  "Test",
@@ -929,7 +929,7 @@ func TestAPIUserAttribute_AmpersandsAndQuotesStoredVerbatim(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@attr-verbatim.test",
 		GivenName:  "Test",

--- a/src/authserver/tests/integration/api_users_auth_test.go
+++ b/src/authserver/tests/integration/api_users_auth_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,7 +24,7 @@ func TestAPIUserPasswordPut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@password.test",
 		GivenName:     "Test",
@@ -73,7 +73,7 @@ func TestAPIUserPasswordPut_ValidationError(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@password-validation.test",
 		GivenName:     "Test",
@@ -155,7 +155,7 @@ func TestAPIUserOTPPut_DisableSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	testUser := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              "testuser@otp.test",
 		GivenName:          "Test",
@@ -262,7 +262,7 @@ func TestAPIUserOTPPut_EnableNotSupported(t *testing.T) {
 
 	// Setup: Create test user without OTP
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@otp-enable.test",
 		GivenName:     "Test",
@@ -310,7 +310,7 @@ func TestAPIUserOTPPut_OTPNotEnabled(t *testing.T) {
 
 	// Setup: Create test user without OTP enabled
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@otp-not-enabled.test",
 		GivenName:     "Test",
@@ -343,7 +343,7 @@ func TestAPIUserSessionGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@session.test",
 		GivenName:     "Test",
@@ -358,7 +358,7 @@ func TestAPIUserSessionGet_Success(t *testing.T) {
 
 	// Setup: Create test session
 	testSession := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC(),
 		LastAccessed:      time.Now().UTC(),
 		AuthMethods:       "pwd",
@@ -421,7 +421,7 @@ func TestAPIUserSessionPut_MethodNotAllowed(t *testing.T) {
 	accessToken, _ := createAdminClientWithToken(t)
 
 	// Test: PUT the session path, which no longer registers that method
-	url := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + uuid.New().String()
+	url := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + fake.UUID()
 	resp := makeAPIRequest(t, "PUT", url, accessToken, map[string]interface{}{"level2AuthConfigHasChanged": true})
 	defer func() { _ = resp.Body.Close() }()
 

--- a/src/authserver/tests/integration/api_users_consents_test.go
+++ b/src/authserver/tests/integration/api_users_consents_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +23,7 @@ func TestAPIUserConsentsGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@consents.test",
 		GivenName:     "Test",
@@ -99,7 +99,7 @@ func TestAPIUserConsentsGet_EmptyConsents(t *testing.T) {
 
 	// Setup: Create test user without consents
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@empty-consents.test",
 		GivenName:  "Test",
@@ -169,7 +169,7 @@ func TestAPIUserConsentsGet_InvalidId(t *testing.T) {
 func TestAPIUserConsentsGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-consents.test",
 		GivenName:  "Test",
@@ -202,7 +202,7 @@ func TestAPIUserConsentDelete_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@consent-delete.test",
 		GivenName:     "Test",
@@ -288,7 +288,7 @@ func TestAPIUserConsentDelete_InvalidId(t *testing.T) {
 func TestAPIUserConsentDelete_Unauthorized(t *testing.T) {
 	// Setup: Create test user and consent
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-consent-delete.test",
 		GivenName:  "Test",
@@ -337,7 +337,7 @@ func TestAPIUserConsentDelete_WithClientDetails(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@consent-client-details.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_users_crud_test.go
+++ b/src/authserver/tests/integration/api_users_crud_test.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ func TestAPIUserGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@get.test",
 		GivenName:     "Test",
@@ -99,7 +99,7 @@ func TestAPIUserGet_InvalidId(t *testing.T) {
 func TestAPIUserGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@unauth.test",
 		GivenName:     "Test",
@@ -190,7 +190,7 @@ func TestAPIUserCreatePost_DuplicateEmail(t *testing.T) {
 
 	// Setup: Create existing user
 	existingUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "duplicate@create.test",
 		GivenName:     "Existing",
@@ -339,7 +339,7 @@ func TestAPIUserEnabledPut_Success(t *testing.T) {
 
 	// Setup: Create test user (enabled by default)
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@enabled.test",
 		GivenName:     "Test",
@@ -386,7 +386,7 @@ func TestAPIUserEnabledPut_EnableUser(t *testing.T) {
 
 	// Setup: Create disabled test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       false,
 		Email:         "disabled@enabled.test",
 		GivenName:     "Disabled",
@@ -461,7 +461,7 @@ func TestAPIUserEnabledPut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@invalid.test",
 		GivenName:     "Test",
@@ -497,7 +497,7 @@ func TestAPIUserDelete_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@delete.test",
 		GivenName:     "Test",
@@ -571,7 +571,7 @@ func TestAPIUserDelete_InvalidId(t *testing.T) {
 func TestAPIUserDelete_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@delete-unauth.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_users_email_test.go
+++ b/src/authserver/tests/integration/api_users_email_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ func TestAPIUserEmailPut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@email.test",
 		GivenName:     "Test",
@@ -75,7 +75,7 @@ func TestAPIUserEmailPut_EmailNormalization(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@normalize.test",
 		GivenName:  "Test",
@@ -120,7 +120,7 @@ func TestAPIUserEmailPut_DuplicateEmail(t *testing.T) {
 
 	// Setup: Create first user with existing email
 	existingUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "existing@duplicate.test",
 		GivenName:  "Existing",
@@ -134,7 +134,7 @@ func TestAPIUserEmailPut_DuplicateEmail(t *testing.T) {
 
 	// Setup: Create second user to test duplicate email
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@duplicate.test",
 		GivenName:  "Test",
@@ -171,7 +171,7 @@ func TestAPIUserEmailPut_InvalidEmail(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid.test",
 		GivenName:  "Test",
@@ -219,7 +219,7 @@ func TestAPIUserEmailPut_SetEmailVerified(t *testing.T) {
 
 	// Setup: Create test user with unverified email and verification code
 	testUser := &models.User{
-		Subject:                        uuid.New(),
+		Subject:                        fake.UUID(),
 		Enabled:                        true,
 		Email:                          "testuser@verified.test",
 		GivenName:                      "Test",
@@ -269,7 +269,7 @@ func TestAPIUserEmailPut_UnsetEmailVerified(t *testing.T) {
 
 	// Setup: Create test user with verified email
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@unverified.test",
 		GivenName:     "Test",
@@ -363,7 +363,7 @@ func TestAPIUserEmailPut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid-body.test",
 		GivenName:  "Test",
@@ -394,7 +394,7 @@ func TestAPIUserEmailPut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserEmailPut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-email.test",
 		GivenName:  "Test",
@@ -426,7 +426,7 @@ func TestAPIUserEmailPut_PartialUpdate(t *testing.T) {
 
 	// Setup: Create test user with existing data
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "original@partial.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_users_permissions_test.go
+++ b/src/authserver/tests/integration/api_users_permissions_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUserPermissionsGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@permissions.test",
 		GivenName:     "Test",
@@ -128,7 +128,7 @@ func TestAPIUserPermissionsGet_NoPermissions(t *testing.T) {
 
 	// Setup: Create test user without permissions
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@no-permissions.test",
 		GivenName:  "Test",
@@ -161,7 +161,7 @@ func TestAPIUserPermissionsGet_NoPermissions(t *testing.T) {
 func TestAPIUserPermissionsGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-permissions.test",
 		GivenName:  "Test",
@@ -194,7 +194,7 @@ func TestAPIUserPermissionsPut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@permissions-put.test",
 		GivenName:     "Test",
@@ -270,7 +270,7 @@ func TestAPIUserPermissionsPut_RemoveAllPermissions(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@remove-all-permissions.test",
 		GivenName:  "Test",
@@ -348,7 +348,7 @@ func TestAPIUserPermissionsPut_PermissionNotFound(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@perm-not-found.test",
 		GivenName:  "Test",
@@ -379,7 +379,7 @@ func TestAPIUserPermissionsPut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid-body.test",
 		GivenName:  "Test",
@@ -410,7 +410,7 @@ func TestAPIUserPermissionsPut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserPermissionsPut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-put.test",
 		GivenName:  "Test",

--- a/src/authserver/tests/integration/api_users_phone_test.go
+++ b/src/authserver/tests/integration/api_users_phone_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,7 +96,7 @@ func TestAPIUserPhonePut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@phone.test",
 		GivenName:     "Test",
@@ -153,7 +153,7 @@ func TestAPIUserPhonePut_ClearPhoneNumber(t *testing.T) {
 
 	// Setup: Create test user with existing phone number
 	testUser := &models.User{
-		Subject:                       uuid.New(),
+		Subject:                       fake.UUID(),
 		Enabled:                       true,
 		Email:                         "testuser@phone-clear.test",
 		GivenName:                     "Test",
@@ -210,7 +210,7 @@ func TestAPIUserPhonePut_ValidationErrors(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@phone-validation.test",
 		GivenName:     "Test",
@@ -351,7 +351,7 @@ func TestAPIUserPhonePut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@phone-invalid-body.test",
 		GivenName:     "Test",
@@ -383,7 +383,7 @@ func TestAPIUserPhonePut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserPhonePut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@phone-unauth.test",
 		GivenName:     "Test",
@@ -416,7 +416,7 @@ func TestAPIUserPhonePut_PhoneNumberVerifiedAutoCleared(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@phone-verified.test",
 		GivenName:     "Test",

--- a/src/authserver/tests/integration/api_users_profile_test.go
+++ b/src/authserver/tests/integration/api_users_profile_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestAPIUserProfilePut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@profile.test",
 		GivenName:     "Test",
@@ -89,7 +89,7 @@ func TestAPIUserProfilePut_PartialUpdate(t *testing.T) {
 
 	// Setup: Create test user with existing data
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@partial.test",
 		GivenName:  "Original",
@@ -136,7 +136,7 @@ func TestAPIUserProfilePut_InvalidGender(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@gender.test",
 		GivenName:  "Test",
@@ -169,7 +169,7 @@ func TestAPIUserProfilePut_ValidGender(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@valid-gender.test",
 		GivenName:  "Test",
@@ -223,7 +223,7 @@ func TestAPIUserProfilePut_InvalidDateOfBirth(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@dob.test",
 		GivenName:  "Test",
@@ -304,7 +304,7 @@ func TestAPIUserProfilePut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid.test",
 		GivenName:  "Test",
@@ -335,7 +335,7 @@ func TestAPIUserProfilePut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserProfilePut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth.test",
 		GivenName:  "Test",
@@ -368,7 +368,7 @@ func TestAPIUserAddressPut_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@address.test",
 		GivenName:     "Test",
@@ -430,7 +430,7 @@ func TestAPIUserAddressPut_PartialAddress(t *testing.T) {
 
 	// Setup: Create test user with existing address
 	testUser := &models.User{
-		Subject:           uuid.New(),
+		Subject:           fake.UUID(),
 		Enabled:           true,
 		Email:             "testuser@partial-addr.test",
 		GivenName:         "Test",
@@ -480,7 +480,7 @@ func TestAPIUserAddressPut_ClearAllFields(t *testing.T) {
 
 	// Setup: Create test user with existing address data
 	testUser := &models.User{
-		Subject:           uuid.New(),
+		Subject:           fake.UUID(),
 		Enabled:           true,
 		Email:             "testuser@clear-addr.test",
 		GivenName:         "Test",
@@ -529,7 +529,7 @@ func TestAPIUserAddressPut_AngleBracketsRefused(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@angle-brackets.test",
 		GivenName:     "Test",
@@ -572,7 +572,7 @@ func TestAPIUserAddressPut_AmpersandAndQuotesStoredVerbatim(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@verbatim-address.test",
 		GivenName:     "Test",
@@ -658,7 +658,7 @@ func TestAPIUserAddressPut_InvalidRequestBody(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@invalid-addr.test",
 		GivenName:  "Test",
@@ -689,7 +689,7 @@ func TestAPIUserAddressPut_InvalidRequestBody(t *testing.T) {
 func TestAPIUserAddressPut_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-addr.test",
 		GivenName:  "Test",

--- a/src/authserver/tests/integration/api_users_search_annotate_permission_test.go
+++ b/src/authserver/tests/integration/api_users_search_annotate_permission_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -24,9 +23,9 @@ func TestAPIUsersSearch_AnnotatePermission_Success(t *testing.T) {
 
 	// Create three users; grant permission to two
 	randSuffix := fake.LetterN(6)
-	u1 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm1-" + randSuffix, Email: "annperm1-" + randSuffix + "@test.com", GivenName: "A1", FamilyName: "T"}
-	u2 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm2-" + randSuffix, Email: "annperm2-" + randSuffix + "@test.com", GivenName: "A2", FamilyName: "T"}
-	u3 := &models.User{Subject: uuid.New(), Enabled: true, Username: "annperm3-" + randSuffix, Email: "annperm3-" + randSuffix + "@test.com", GivenName: "A3", FamilyName: "T"}
+	u1 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "annperm1-" + randSuffix, Email: "annperm1-" + randSuffix + "@test.com", GivenName: "A1", FamilyName: "T"}
+	u2 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "annperm2-" + randSuffix, Email: "annperm2-" + randSuffix + "@test.com", GivenName: "A2", FamilyName: "T"}
+	u3 := &models.User{Subject: fake.UUID(), Enabled: true, Username: "annperm3-" + randSuffix, Email: "annperm3-" + randSuffix + "@test.com", GivenName: "A3", FamilyName: "T"}
 	assert.NoError(t, database.CreateUser(nil, u1))
 	assert.NoError(t, database.CreateUser(nil, u2))
 	assert.NoError(t, database.CreateUser(nil, u3))

--- a/src/authserver/tests/integration/api_users_search_test.go
+++ b/src/authserver/tests/integration/api_users_search_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
@@ -84,7 +83,7 @@ func TestAPIUsersSearch_WithQuery(t *testing.T) {
 	// Setup: Create test users with more unique identifiers to avoid conflicts
 	uniqueSuffix := fake.LetterN(8)
 	user1 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "uniquejohn" + uniqueSuffix + "@searchtest.com",
 		GivenName:     "UniqueJohn",
@@ -379,7 +378,7 @@ func TestAPIUsersSearch_MultiplePages(t *testing.T) {
 	var testUsers []*models.User
 	for i := 1; i <= 8; i++ {
 		user := &models.User{
-			Subject:       uuid.New(),
+			Subject:       fake.UUID(),
 			Enabled:       true,
 			Email:         "testuser" + string(rune('0'+i)) + "@pagination.test",
 			GivenName:     "Test",
@@ -453,7 +452,7 @@ func createTestUsers(t *testing.T) []*models.User {
 
 	// Create user 1
 	user1 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "john.doe@test.com",
 		GivenName:     "AAA John",
@@ -466,7 +465,7 @@ func createTestUsers(t *testing.T) []*models.User {
 
 	// Create user 2
 	user2 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "jane.smith@test.com",
 		GivenName:     "AAA Jane",
@@ -479,7 +478,7 @@ func createTestUsers(t *testing.T) []*models.User {
 
 	// Create user 3
 	user3 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       false, // Disabled user
 		Email:         "disabled@test.com",
 		GivenName:     "AAA Disabled",
@@ -501,7 +500,7 @@ func createTestUsersWithSuffix(t *testing.T, suffix string) []*models.User {
 
 	// Create user 1 - enabled user
 	user1 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "john.doe." + suffix + "@test.com",
 		GivenName:     "John" + suffix,
@@ -514,7 +513,7 @@ func createTestUsersWithSuffix(t *testing.T, suffix string) []*models.User {
 
 	// Create user 2 - enabled user
 	user2 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "jane.smith." + suffix + "@test.com",
 		GivenName:     "Jane" + suffix,
@@ -527,7 +526,7 @@ func createTestUsersWithSuffix(t *testing.T, suffix string) []*models.User {
 
 	// Create user 3 - disabled user
 	user3 := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       false,
 		Email:         "disabled." + suffix + "@test.com",
 		GivenName:     "Disabled" + suffix,

--- a/src/authserver/tests/integration/api_users_sessions_test.go
+++ b/src/authserver/tests/integration/api_users_sessions_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +22,7 @@ func TestAPIUserSessionsGet_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@sessions.test",
 		GivenName:     "Test",
@@ -37,7 +37,7 @@ func TestAPIUserSessionsGet_Success(t *testing.T) {
 
 	// Setup: Create test client (inline createTestClientForSessions)
 	testClient := &models.Client{
-		ClientIdentifier:         "test-client-sessions-" + uuid.New().String()[:8],
+		ClientIdentifier:         "test-client-sessions-" + fake.UUID()[:8],
 		ClientSecretEncrypted:    []byte("encrypted-secret"),
 		Description:              "Test Client for Sessions",
 		Enabled:                  true,
@@ -53,8 +53,8 @@ func TestAPIUserSessionsGet_Success(t *testing.T) {
 	}()
 
 	// Setup: Create test sessions
-	session1 := createTestUserSession(t, testUser.Id, uuid.New().String())
-	session2 := createTestUserSession(t, testUser.Id, uuid.New().String())
+	session1 := createTestUserSession(t, testUser.Id, fake.UUID())
+	session2 := createTestUserSession(t, testUser.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, session1.Id)
 		_ = database.DeleteUserSession(nil, session2.Id)
@@ -120,7 +120,7 @@ func TestAPIUserSessionsGet_EmptySessions(t *testing.T) {
 
 	// Setup: Create test user without sessions
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@empty-sessions.test",
 		GivenName:     "Test",
@@ -191,7 +191,7 @@ func TestAPIUserSessionsGet_InvalidId(t *testing.T) {
 func TestAPIUserSessionsGet_Unauthorized(t *testing.T) {
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@unauth-sessions.test",
 		GivenName:  "Test",
@@ -223,7 +223,7 @@ func TestAPIUserSessionsGet_SessionsWithNoClients(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@no-clients.test",
 		GivenName:     "Test",
@@ -237,7 +237,7 @@ func TestAPIUserSessionsGet_SessionsWithNoClients(t *testing.T) {
 	}()
 
 	// Setup: Create test session without client relationship
-	session := createTestUserSession(t, testUser.Id, uuid.New().String())
+	session := createTestUserSession(t, testUser.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, session.Id)
 	}()
@@ -267,7 +267,7 @@ func TestAPIUserSessionDelete_Success(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@session-delete.test",
 		GivenName:     "Test",
@@ -281,7 +281,7 @@ func TestAPIUserSessionDelete_Success(t *testing.T) {
 	}()
 
 	// Setup: Create test session
-	session := createTestUserSession(t, testUser.Id, uuid.New().String())
+	session := createTestUserSession(t, testUser.Id, fake.UUID())
 
 	// Test: Delete user session
 	url := config.GetAuthServer().BaseURL + "/api/v1/admin/user-sessions/" + strconv.FormatInt(session.Id, 10)
@@ -398,7 +398,7 @@ func TestAPIUserSessionDelete_InvalidId(t *testing.T) {
 func TestAPIUserSessionDelete_Unauthorized(t *testing.T) {
 	// Setup: Create test user and session
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@session-delete-unauth.test",
 		GivenName:  "Test",
@@ -410,7 +410,7 @@ func TestAPIUserSessionDelete_Unauthorized(t *testing.T) {
 		_ = database.DeleteUser(nil, testUser.Id)
 	}()
 
-	session := createTestUserSession(t, testUser.Id, uuid.New().String())
+	session := createTestUserSession(t, testUser.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, session.Id)
 	}()
@@ -437,7 +437,7 @@ func TestAPIUserSessionDelete_Unauthorized(t *testing.T) {
 func TestAPIUserSessionDelete_InvalidToken(t *testing.T) {
 	// Setup: Create test user and session
 	testUser := &models.User{
-		Subject:    uuid.New(),
+		Subject:    fake.UUID(),
 		Enabled:    true,
 		Email:      "testuser@session-delete-invalid-token.test",
 		GivenName:  "Test",
@@ -449,7 +449,7 @@ func TestAPIUserSessionDelete_InvalidToken(t *testing.T) {
 		_ = database.DeleteUser(nil, testUser.Id)
 	}()
 
-	session := createTestUserSession(t, testUser.Id, uuid.New().String())
+	session := createTestUserSession(t, testUser.Id, fake.UUID())
 	defer func() {
 		_ = database.DeleteUserSession(nil, session.Id)
 	}()
@@ -475,7 +475,7 @@ func TestAPIUserSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Setup: Create test user
 	testUser := &models.User{
-		Subject:       uuid.New(),
+		Subject:       fake.UUID(),
 		Enabled:       true,
 		Email:         "testuser@valid-sessions.test",
 		GivenName:     "Test",
@@ -490,7 +490,7 @@ func TestAPIUserSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Setup: Create a valid session (recently accessed)
 	validSession := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-time.Minute * 30), // Started 30 minutes ago
 		LastAccessed:      time.Now().UTC().Add(-time.Minute * 5),  // Last accessed 5 minutes ago
 		AuthMethods:       "pwd",
@@ -510,7 +510,7 @@ func TestAPIUserSessionsGet_OnlyValidSessions(t *testing.T) {
 
 	// Setup: Create an expired session (very old last access)
 	expiredSession := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: fake.UUID(),
 		Started:           time.Now().UTC().Add(-time.Hour * 25), // Started 25 hours ago
 		LastAccessed:      time.Now().UTC().Add(-time.Hour * 24), // Last accessed 24 hours ago (expired)
 		AuthMethods:       "pwd",

--- a/src/authserver/tests/integration/auth_otp_client_display_test.go
+++ b/src/authserver/tests/integration/auth_otp_client_display_test.go
@@ -3,7 +3,6 @@ package integrationtests
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
@@ -45,7 +44,7 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -107,7 +106,7 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -170,7 +169,7 @@ func TestAuthOtp_ClientDisplay_AllDisabled_Enabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -222,7 +221,7 @@ func TestAuthOtp_ClientDisplay_ShowDisplayName_Enrollment(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -275,7 +274,7 @@ func TestAuthOtp_ClientDisplay_AllEnabled_Enrollment(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -329,7 +328,7 @@ func TestAuthOtp_ClientDisplay_AllDisabled_Enrollment(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/auth_otp_replay_test.go
+++ b/src/authserver/tests/integration/auth_otp_replay_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
@@ -73,7 +72,7 @@ func createLevel2MandatoryUser(t *testing.T, otpEnabled bool) (*models.Client, *
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_acr_snapshot_test.go
+++ b/src/authserver/tests/integration/authorize_acr_snapshot_test.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -63,7 +62,7 @@ func TestAcrSnapshot_ClientRaisedMidCeremonyDoesNotElevateTheAcr(t *testing.T) {
 	// No OTP: this user has no second factor to present, so an acr naming one can only have come
 	// from the client row rather than from anything the ceremony did.
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_ceremony_binding_test.go
+++ b/src/authserver/tests/integration/authorize_ceremony_binding_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -55,7 +54,7 @@ func createCeremonyUser(t *testing.T) (*models.User, string) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
+++ b/src/authserver/tests/integration/authorize_completed_refusal_replay_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -62,7 +61,7 @@ func TestAuthCompleted_DisabledUserRefusal_CannotBeReplayed(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -175,7 +174,7 @@ func TestAuthCompleted_NoAuthorizedScopesRefusal_CannotBeReplayed(t *testing.T) 
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_cross_user_session_test.go
+++ b/src/authserver/tests/integration/authorize_cross_user_session_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -75,7 +74,7 @@ func createCrossUserUser(t *testing.T, withOtp bool) (*models.User, string) {
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -330,7 +329,7 @@ func assertCeremonyBoundToUserB(t *testing.T, b *crossUserBrowser, codeVal strin
 	idToken, ok := tokenData["id_token"].(string)
 	require.True(t, ok, "expected an id_token, got %v", tokenData)
 	idClaims := decodeJWTPayload(t, idToken)
-	assert.Equal(t, b.userB.Subject.String(), idClaims["sub"])
+	assert.Equal(t, b.userB.Subject, idClaims["sub"])
 	assert.Equal(t, code.SessionIdentifier, idClaims["sid"],
 		"the id_token's sid must name the session this ceremony bound to")
 

--- a/src/authserver/tests/integration/authorize_deferred_error_test.go
+++ b/src/authserver/tests/integration/authorize_deferred_error_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -377,7 +376,7 @@ func newDeferralClient(t *testing.T) (*models.Client, *models.User, string) {
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_id_token_hint_test.go
+++ b/src/authserver/tests/integration/authorize_id_token_hint_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -34,7 +33,7 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	assert.NoError(t, err)
 
 	userA := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashedA,
@@ -47,7 +46,7 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	assert.NoError(t, err)
 
 	userB := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashedB,
@@ -155,7 +154,7 @@ func TestIdTokenHint_PromptLogin_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 
 	// Verify User A's ID token contains correct subject
 	idClaimsA := decodeJWTPayload(t, idTokenUserA)
-	assert.Equal(t, userA.Subject.String(), idClaimsA["sub"], "ID token should have User A's subject")
+	assert.Equal(t, userA.Subject, idClaimsA["sub"], "ID token should have User A's subject")
 
 	// =========================================================================
 	// Step 4: Start NEW auth request with id_token_hint and prompt=login
@@ -256,7 +255,7 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -357,7 +356,7 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 
 	// Verify ID token
 	idClaims := decodeJWTPayload(t, idToken)
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 
 	// =========================================================================
 	// Step 4: Start NEW auth with same user using id_token_hint + prompt=login
@@ -434,7 +433,7 @@ func TestIdTokenHint_PromptLogin_MatchingUser_Success(t *testing.T) {
 	// Verify new ID token still has same subject
 	newIdToken := tokenData2["id_token"].(string)
 	newIdClaims := decodeJWTPayload(t, newIdToken)
-	assert.Equal(t, user.Subject.String(), newIdClaims["sub"])
+	assert.Equal(t, user.Subject, newIdClaims["sub"])
 }
 
 // TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance verifies that
@@ -446,7 +445,7 @@ func TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	assert.NoError(t, err)
 
 	userA := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashedA,
@@ -459,7 +458,7 @@ func TestIdTokenHint_NoPrompt_MismatchedUser_BlocksAtIssuance(t *testing.T) {
 	assert.NoError(t, err)
 
 	userB := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashedB,

--- a/src/authserver/tests/integration/authorize_no_session_consent_test.go
+++ b/src/authserver/tests/integration/authorize_no_session_consent_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -50,7 +49,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsFu
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -185,7 +184,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsPa
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -323,7 +322,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -463,7 +462,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -616,7 +615,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -778,7 +777,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -936,7 +935,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	userEmail := fake.Email()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        userEmail,
 		PasswordHash: passwordHashed,
@@ -1089,7 +1088,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	userEmail := fake.Email()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        userEmail,
 		PasswordHash: passwordHashed,
@@ -1254,7 +1253,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -1416,7 +1415,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -1573,7 +1572,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ConsentIsCa
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1703,7 +1702,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1830,7 +1829,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsR
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -1962,7 +1961,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	userEmail := fake.Email()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        userEmail,
 		PasswordHash: passwordHashed,
@@ -2101,7 +2100,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -2237,7 +2236,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsRequired_ElevenScope
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_no_session_no_consent_test.go
+++ b/src/authserver/tests/integration/authorize_no_session_no_consent_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -49,7 +48,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired(t *testi
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -156,7 +155,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpDisabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -277,7 +276,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Optional_Pwd_OtpEnabled_ConsentIsN
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -403,7 +402,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	userEmail := fake.Email()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        userEmail,
 		PasswordHash: passwordHashed,
@@ -536,7 +535,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,
@@ -661,7 +660,7 @@ func TestAuthorize_NoExistingSession_AcrLevel1_Pwd_ConsentIsNotRequired_Password
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -753,7 +752,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpDisabled_ConsentI
 
 	userEmail := fake.Email()
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        userEmail,
 		PasswordHash: passwordHashed,
@@ -871,7 +870,7 @@ func TestAuthorize_NoExistingSession_AcrLevel2Mandatory_Pwd_OtpEnabled_ConsentIs
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              userEmail,
 		PasswordHash:       passwordHashed,

--- a/src/authserver/tests/integration/authorize_prompt_helpers_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -99,7 +98,7 @@ func createSessionWithAcrLevel1AndPassword(t *testing.T) (*http.Client, *models.
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_prompt_login_consent_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_login_consent_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -54,7 +53,7 @@ func TestPromptConsent_ForcesConsentEvenWhenAlreadyConsented(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -448,7 +447,7 @@ func TestPromptConsent_UserDeclines(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -657,7 +656,7 @@ func TestPromptLogin_NewAuthTime(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_prompt_none_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_none_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -203,7 +202,7 @@ func TestPromptNone_ConsentRequired_ReturnsConsentRequired(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -324,7 +323,7 @@ func walkDCRClientToConsentScreen(t *testing.T, clientName string) (*http.Client
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -921,7 +920,7 @@ func TestPromptNone_FullConsentCoverage(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1065,7 +1064,7 @@ func TestPromptNone_PartialConsentCoverage(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1188,7 +1187,7 @@ func TestPromptNone_OfflineAccessNotInConsent(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1320,7 +1319,7 @@ func TestPromptNone_OfflineAccessInConsent(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1464,7 +1463,7 @@ func TestPromptNone_RequestSubsetOfConsent(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1599,7 +1598,7 @@ func TestPromptNone_EffectiveScopesEmpty_ReturnsAccessDenied(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_prompt_none_token_test.go
+++ b/src/authserver/tests/integration/authorize_prompt_none_token_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -313,7 +312,7 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -424,7 +423,7 @@ func TestPromptNone_CodeExchange(t *testing.T) {
 	assert.Equal(t, requestNonce2, idClaims["nonce"])
 
 	// Verify sub matches user
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 }
 
 func TestPromptNone_SubClaimConsistent(t *testing.T) {
@@ -466,7 +465,7 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -582,7 +581,7 @@ func TestPromptNone_SubClaimConsistent(t *testing.T) {
 	sub2 := claims2["sub"].(string)
 
 	assert.Equal(t, sub1, sub2, "sub claim should be consistent across tokens")
-	assert.Equal(t, user.Subject.String(), sub1, "sub should match user's subject")
+	assert.Equal(t, user.Subject, sub1, "sub should match user's subject")
 }
 
 func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
@@ -624,7 +623,7 @@ func TestPromptNone_AuthTimePreservedInToken(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -783,7 +782,7 @@ func TestPromptNone_PKCEWrongVerifier(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -933,7 +932,7 @@ func TestPromptNone_RefreshWithOfflineAccess(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1123,7 +1122,7 @@ func TestPromptNone_NoncePreserved(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -1270,7 +1269,7 @@ func TestPromptNone_PKCESupported(t *testing.T) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_public_client_pkce_test.go
+++ b/src/authserver/tests/integration/authorize_public_client_pkce_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -67,7 +66,7 @@ func newPublicPKCEClient(t *testing.T, pkceRequired *bool) (*models.Client, stri
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_registered_query_state_test.go
+++ b/src/authserver/tests/integration/authorize_registered_query_state_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -170,7 +169,7 @@ func newRegisteredQueryClient(t *testing.T) (*models.Client, *models.User, strin
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/authorize_revalidate_at_issuance_test.go
+++ b/src/authserver/tests/integration/authorize_revalidate_at_issuance_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -83,7 +82,7 @@ func parkOnConsentScreen(t *testing.T, requestScope string, clientSecret string,
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/browser_session_test.go
+++ b/src/authserver/tests/integration/browser_session_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/enums"
@@ -381,7 +380,7 @@ func newLevel1Actors(t *testing.T) (*models.Client, *models.RedirectURI, *models
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/consent_client_display_test.go
+++ b/src/authserver/tests/integration/consent_client_display_test.go
@@ -3,7 +3,6 @@ package integrationtests
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
@@ -37,7 +36,7 @@ func TestConsent_ClientDisplay_ShowDisplayName(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -86,7 +85,7 @@ func TestConsent_ClientDisplay_ShowLogo_WithLogo(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -135,7 +134,7 @@ func TestConsent_ClientDisplay_ShowDescription(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -187,7 +186,7 @@ func TestConsent_ClientDisplay_AllEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -240,7 +239,7 @@ func TestConsent_ClientDisplay_AllDisabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/credential_change_revocation_test.go
+++ b/src/authserver/tests/integration/credential_change_revocation_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/authserver/internal/handlers"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
@@ -345,7 +344,7 @@ func createOfflineGrant(t *testing.T) *offlineGrant {
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        strings.ToLower(fake.LetterN(12)) + "@example.com",
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/implicit_flow_test.go
+++ b/src/authserver/tests/integration/implicit_flow_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -95,7 +94,7 @@ func createTestUserForImplicit(t *testing.T) (*models.User, string) {
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -268,7 +267,7 @@ func TestImplicitFlow_IdTokenResponseType(t *testing.T) {
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	assert.NoError(t, err)
 	assert.Contains(t, string(payload), requestNonce, "id_token should contain the nonce")
-	assert.Contains(t, string(payload), user.Subject.String(), "id_token should contain user subject")
+	assert.Contains(t, string(payload), user.Subject, "id_token should contain user subject")
 }
 
 // TestImplicitFlow_IdTokenTokenResponseType tests implicit flow with response_type=id_token token
@@ -708,7 +707,7 @@ func TestImplicitFlow_ValidateAccessToken(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify claims
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	// Note: aud in access token is the resource server ("authserver"), not the client
 	assert.NotEmpty(t, claims["aud"])
 	assert.NotEmpty(t, claims["iat"])

--- a/src/authserver/tests/integration/reset_password_flow_test.go
+++ b/src/authserver/tests/integration/reset_password_flow_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +78,7 @@ func createResetTestUser(t *testing.T, email string) (*models.User, string) {
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        email,
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/ropc_flow_test.go
+++ b/src/authserver/tests/integration/ropc_flow_test.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
@@ -59,7 +58,7 @@ func createROPCUser(t *testing.T, password string) *models.User {
 	assert.Nil(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -404,7 +403,7 @@ func TestROPC_DisabledUser(t *testing.T) {
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.Nil(t, err)
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      false, // Disabled
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -572,7 +571,7 @@ func TestROPC_UserWith2FAEnabled(t *testing.T) {
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.Nil(t, err)
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              fake.Email(),
 		PasswordHash:       passwordHashed,

--- a/src/authserver/tests/integration/session_deletion_test.go
+++ b/src/authserver/tests/integration/session_deletion_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/hashutil"
@@ -56,7 +55,7 @@ func TestSessionDeletedDuringAuthFlow_LoginSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -234,7 +233,7 @@ func TestSessionEndedOnConsentScreen_NoCodeIsIssued(t *testing.T) {
 	assert.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/token_authcode_loopback_port_test.go
+++ b/src/authserver/tests/integration/token_authcode_loopback_port_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -61,7 +60,7 @@ func TestToken_AuthCode_LoopbackEphemeralPort(t *testing.T) {
 	require.NoError(t, err)
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/token_oidc_claims_test.go
+++ b/src/authserver/tests/integration/token_oidc_claims_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -336,7 +335,7 @@ func createAuthCodeWithUserProfile(t *testing.T, clientSecret string, scope stri
 	// below asserts on either value, only that the claim carries what was
 	// stored (#272).
 	user := &models.User{
-		Subject:             uuid.New(),
+		Subject:             fake.UUID(),
 		Enabled:             true,
 		Email:               fake.Email(),
 		EmailVerified:       true,

--- a/src/authserver/tests/integration/token_refresh_test.go
+++ b/src/authserver/tests/integration/token_refresh_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -284,7 +283,7 @@ func TestToken_Refresh_TokenExpired(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	jti := uuid.New().String()
+	jti := fake.UUID()
 	exp := now.AddDate(-5, 0, 0)
 	claims["iss"] = settings.Issuer
 	claims["iat"] = now.Unix()
@@ -293,7 +292,7 @@ func TestToken_Refresh_TokenExpired(t *testing.T) {
 	claims["aud"] = settings.Issuer
 	claims["typ"] = "Refresh"
 	claims["exp"] = exp.Unix()
-	claims["sub"] = uuid.New().String()
+	claims["sub"] = fake.UUID()
 
 	keyPair, err := database.GetCurrentSigningKey(nil)
 	if err != nil {
@@ -462,7 +461,7 @@ func TestToken_Refresh_ConsentRemoved(t *testing.T) {
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -594,7 +593,7 @@ func TestToken_Refresh_ConsentDoesNotIncludeScope(t *testing.T) {
 	passwordHashed, err := hashutil.HashPassword(password)
 	assert.NoError(t, err)
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,

--- a/src/authserver/tests/integration/user_bound_token_test.go
+++ b/src/authserver/tests/integration/user_bound_token_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/api"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -40,22 +39,22 @@ import (
 // maximum. A 36 character UUID satisfies all of it whenever its first hex digit is a-f,
 // which is 6 of 16 values, so 3 in 8 UUIDs qualify and a handful of draws suffices.
 // Generated rather than hardcoded so the test does not silently depend on one literal.
-func newUserSubjectValidAsClientIdentifier(t *testing.T) uuid.UUID {
+func newUserSubjectValidAsClientIdentifier(t *testing.T) string {
 	t.Helper()
 
 	for i := 0; i < 200; i++ {
-		candidate := uuid.New()
-		first := candidate.String()[0]
+		candidate := fake.UUID()
+		first := candidate[0]
 		if first >= 'a' && first <= 'f' {
 			return candidate
 		}
 	}
 	t.Fatal("could not generate a UUID whose first character is a-f")
-	return uuid.UUID{}
+	return ""
 }
 
 // createUserWithSubject creates an enabled user with a caller-chosen subject.
-func createUserWithSubject(t *testing.T, subject uuid.UUID) (*models.User, string) {
+func createUserWithSubject(t *testing.T, subject string) (*models.User, string) {
 	t.Helper()
 
 	password := fake.Password(12)
@@ -79,7 +78,7 @@ func createUserWithSubject(t *testing.T, subject uuid.UUID) (*models.User, strin
 // createImpersonatingClientCredentialsToken mints a real client credentials token for a
 // client whose identifier EQUALS the given user's subject, carrying the given built-in
 // authserver permission. This is the attacker's token in the original vulnerability.
-func createImpersonatingClientCredentialsToken(t *testing.T, subject uuid.UUID, permissionIdentifier string) string {
+func createImpersonatingClientCredentialsToken(t *testing.T, subject string, permissionIdentifier string) string {
 	t.Helper()
 
 	clientSecret := fake.Password(32)
@@ -88,7 +87,7 @@ func createImpersonatingClientCredentialsToken(t *testing.T, subject uuid.UUID, 
 
 	client := &models.Client{
 		// The whole point: the client identifier is the user's subject.
-		ClientIdentifier:         subject.String(),
+		ClientIdentifier:         subject,
 		Enabled:                  true,
 		ClientCredentialsEnabled: true,
 		IsPublic:                 false,
@@ -343,7 +342,7 @@ func userAccessTokenViaROPC(t *testing.T) (string, *models.User, string) {
 	client := createROPCClient(t, clientSecret, false)
 
 	password := fake.Password(12)
-	user, _ := createUserWithSubject(t, uuid.New())
+	user, _ := createUserWithSubject(t, fake.UUID())
 	passwordHashed, err := hashutil.HashPassword(password)
 	require.NoError(t, err)
 	user.PasswordHash = passwordHashed

--- a/src/authserver/tests/integration/utils_test.go
+++ b/src/authserver/tests/integration/utils_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
@@ -376,7 +375,7 @@ func createSessionWithAcrLevel1(t *testing.T) (*http.Client, *models.Client, *mo
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -485,7 +484,7 @@ func createSessionWithAcrLevel2Optional(t *testing.T) (*http.Client, *models.Cli
 	}
 
 	user := &models.User{
-		Subject:      uuid.New(),
+		Subject:      fake.UUID(),
 		Enabled:      true,
 		Email:        fake.Email(),
 		PasswordHash: passwordHashed,
@@ -607,7 +606,7 @@ func createSessionWithAcrLevel2Mandatory(t *testing.T) (*http.Client, *models.Cl
 	}
 
 	user := &models.User{
-		Subject:            uuid.New(),
+		Subject:            fake.UUID(),
 		Enabled:            true,
 		Email:              fake.Email(),
 		PasswordHash:       passwordHashed,
@@ -790,7 +789,7 @@ func createAuthCode(t *testing.T, clientSecret string, scope string, opts ...aut
 		}
 
 		user = &models.User{
-			Subject:      uuid.New(),
+			Subject:      fake.UUID(),
 			Enabled:      true,
 			Email:        fake.Email(),
 			PasswordHash: passwordHashed,
@@ -901,7 +900,7 @@ func createAuthCodeEnsuringUserScope(t *testing.T, clientSecret string, scope st
 		t.Fatal(err)
 	}
 
-	user := &models.User{Subject: uuid.New(), Enabled: true, Email: fake.Email(), PasswordHash: passwordHashed}
+	user := &models.User{Subject: fake.UUID(), Enabled: true, Email: fake.Email(), PasswordHash: passwordHashed}
 	err = database.CreateUser(nil, user)
 	if err != nil {
 		t.Fatal(err)
@@ -1209,7 +1208,7 @@ func createTestResource(t *testing.T, identifier, description string) *models.Re
 // Helper function to create a test group
 func createTestGroup(t *testing.T) *models.Group {
 	group := &models.Group{
-		GroupIdentifier:      "test-group-" + uuid.New().String()[:8],
+		GroupIdentifier:      "test-group-" + fake.UUID()[:8],
 		Description:          "Test Group",
 		IncludeInIdToken:     true,
 		IncludeInAccessToken: false,

--- a/src/core/api/responses.go
+++ b/src/core/api/responses.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
 )
 
@@ -13,7 +12,7 @@ type UserResponse struct {
 	CreatedAt                     *time.Time              `json:"createdAt"`
 	UpdatedAt                     *time.Time              `json:"updatedAt"`
 	Enabled                       bool                    `json:"enabled"`
-	Subject                       uuid.UUID               `json:"subject"`
+	Subject                       string                  `json:"subject"`
 	Username                      string                  `json:"username"`
 	GivenName                     string                  `json:"givenName"`
 	MiddleName                    string                  `json:"middleName"`

--- a/src/core/api/responses_test.go
+++ b/src/core/api/responses_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -176,7 +176,7 @@ func TestToUserResponse_MapsAllFields(t *testing.T) {
 	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	updatedAt := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
 	birthDate := time.Date(1990, 5, 15, 0, 0, 0, 0, time.UTC)
-	subject := uuid.New()
+	subject := fake.UUID()
 
 	user := &models.User{
 		Id:                            7,
@@ -287,6 +287,28 @@ func TestUserResponse_ToUser_RoundTripsTimes(t *testing.T) {
 	assert.False(t, roundTripped.UpdatedAt.Valid, "an absent time must stay invalid")
 	assert.Len(t, roundTripped.Attributes, 1)
 	assert.Equal(t, "k", roundTripped.Attributes[0].Key)
+}
+
+// UserResponse.Subject was a 16-byte named type until #278, reaching JSON through that
+// type's MarshalText and coming back through UnmarshalText. It is a plain string now, and the
+// claim that made the swap safe is that no byte on the wire moved: the field is still the
+// bare canonical 36-character spelling, unquoted-array-free and unwrapped, and openapi.yaml
+// still describes it truthfully as type string, format uuid. A JSON encoder given the wrong
+// type would have produced a 16-element array instead, which is what this pins.
+func TestUserResponse_SubjectIsABareCanonicalString(t *testing.T) {
+	const subject = "3f2a1c4e-5b6d-4e8f-9a0b-1c2d3e4f5a6b"
+
+	encoded, err := json.Marshal(&UserResponse{Id: 9, Subject: subject})
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(encoded), `"subject":"`+subject+`"`,
+		"subject must marshal as the bare 36-character string a client already parses")
+
+	var decoded UserResponse
+	assert.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, subject, decoded.Subject, "the wire form must round-trip unchanged")
+	assert.Equal(t, subject, decoded.ToUser().Subject,
+		"and reach a model unchanged, which is the adminconsole's path back")
 }
 
 func TestToUserResponses_MapsEachUserDistinctly(t *testing.T) {

--- a/src/core/data/commondb/user.go
+++ b/src/core/data/commondb/user.go
@@ -339,11 +339,11 @@ func (d *CommonDatabase) GetUserBySubject(tx *sql.Tx, subject string) (*models.U
 	// The engine may have folded a value this lookup did not ask for; see
 	// engineFoldedTheMatch. OpenID Connect Core section 2 makes sub case sensitive.
 	//
-	// Subject.String() is the stored spelling rather than a normalisation of it: the column
-	// is only ever written from a uuid.UUID, whose Value() is String(), so every row holds
-	// the canonical lowercase hyphenated form. Comparing the parsed value would otherwise
-	// be exactly the re-normalisation this guard must not do.
-	if user != nil && engineFoldedTheMatch(user.Subject.String(), subject) {
+	// user.Subject is the stored spelling rather than a normalisation of it: the column is
+	// only ever written from uuidutil.New, which emits the canonical lowercase hyphenated
+	// form, so every row holds that form already. Parsing and re-emitting the value here
+	// would be exactly the re-normalisation this guard must not do (#278).
+	if user != nil && engineFoldedTheMatch(user.Subject, subject) {
 		return nil, nil
 	}
 

--- a/src/core/data/database_seeder.go
+++ b/src/core/data/database_seeder.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
@@ -394,7 +393,7 @@ func (ds *DatabaseSeeder) Seed() error {
 		},
 	)
 
-	kid := uuid.New().String()
+	kid := uuidutil.New()
 	publicKeyJWK, err := rsautil.MarshalRSAPublicKeyToJWK(&privateKey.PublicKey, kid)
 	if err != nil {
 		return err
@@ -439,7 +438,7 @@ func (ds *DatabaseSeeder) Seed() error {
 		},
 	)
 
-	kid = uuid.New().String()
+	kid = uuidutil.New()
 	publicKeyJWK, err = rsautil.MarshalRSAPublicKeyToJWK(&privateKey.PublicKey, kid)
 	if err != nil {
 		return err

--- a/src/core/data/database_seeder.go
+++ b/src/core/data/database_seeder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/rsautil"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 )
 
@@ -226,7 +227,7 @@ func (ds *DatabaseSeeder) Seed() error {
 	passwordHash, _ := hashutil.HashPassword(adminPassword)
 
 	user := &models.User{
-		Subject: uuid.New(),
+		Subject: uuidutil.New(),
 		// Lowercased at the write, exactly as every other path that stores an email does.
 		// Without it GOIABADA_ADMIN_EMAIL reaches the column verbatim, and an operator who
 		// sets Admin@Example.com gets an admin who cannot sign in at all on SQLite or

--- a/src/core/go.mod
+++ b/src/core/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/huandu/go-sqlbuilder v1.43.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/microsoft/go-mssqldb v1.10.0
@@ -29,6 +28,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/src/core/models/user.go
+++ b/src/core/models/user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/encryption"
 )
 
@@ -14,7 +13,7 @@ type User struct {
 	CreatedAt                            sql.NullTime `db:"created_at" fieldtag:"dont-update"`
 	UpdatedAt                            sql.NullTime `db:"updated_at"`
 	Enabled                              bool         `db:"enabled"`
-	Subject                              uuid.UUID    `db:"subject"`
+	Subject                              string       `db:"subject"`
 	Username                             string       `db:"username"`
 	GivenName                            string       `db:"given_name"`
 	MiddleName                           string       `db:"middle_name"`

--- a/src/core/oauth/code_issuer.go
+++ b/src/core/oauth/code_issuer.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/hashutil"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 )
 
@@ -72,7 +72,7 @@ func (ci *CodeIssuer) CreateAuthCode(tx *sql.Tx, input *CreateCodeInput) (*model
 	}
 	scope = strings.TrimSpace(scope)
 
-	authCode := strings.ReplaceAll(uuid.New().String(), "-", "") + stringutil.GenerateSecurityRandomString(96)
+	authCode := strings.ReplaceAll(uuidutil.New(), "-", "") + stringutil.GenerateSecurityRandomString(96)
 	authCodeHash, err := hashutil.HashString(authCode)
 	if err != nil {
 		return nil, err

--- a/src/core/oauth/code_issuer_test.go
+++ b/src/core/oauth/code_issuer_test.go
@@ -9,10 +9,34 @@ import (
 	"github.com/leodip/goiabada/core/enums"
 
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// assertAuthCodeShape pins what CreateAuthCode emits: a canonical v4 with its hyphens stripped,
+// followed by 96 characters of the security alphabet, 128 in all. The prefix is 32 hex digits
+// because a UUID is what produces it, so re-inserting the hyphens has to give something the
+// generator's own parser accepts. Nothing about the code's format may change while its consumers
+// hash a fixed-width secret (#278): the library swap kept the bytes, and this says so.
+func assertAuthCodeShape(t *testing.T, authCode string) {
+	t.Helper()
+
+	require.Len(t, authCode, 128)
+
+	hyphenated := authCode[0:8] + "-" + authCode[8:12] + "-" + authCode[12:16] + "-" +
+		authCode[16:20] + "-" + authCode[20:32]
+	parsed, err := uuidutil.Parse(hyphenated)
+	require.NoError(t, err, "the first 32 characters must be a canonical UUID with its hyphens removed")
+	assert.Equal(t, hyphenated, parsed, "the generator must emit lowercase")
+
+	const securityAlphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_."
+	for i, r := range authCode[32:] {
+		assert.Contains(t, securityAlphabet, string(r),
+			"character %d of the random suffix is outside the security alphabet", i)
+	}
+}
 
 func TestCreateAuthCode(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
@@ -65,7 +89,7 @@ func TestCreateAuthCode(t *testing.T) {
 	assert.Equal(t, input.AuthMethods, code.AuthMethods)
 	assert.Equal(t, input.SessionIdentifier, code.SessionIdentifier)
 	assert.False(t, code.Used)
-	assert.NotEmpty(t, code.Code)
+	assertAuthCodeShape(t, code.Code)
 	assert.NotEmpty(t, code.CodeHash)
 	assert.WithinDuration(t, time.Now(), code.AuthenticatedAt, time.Second)
 

--- a/src/core/oauth/signing_key_rotator.go
+++ b/src/core/oauth/signing_key_rotator.go
@@ -5,12 +5,12 @@ import (
 	"database/sql"
 	"encoding/pem"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/encryption"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/rsautil"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 )
 
@@ -161,7 +161,7 @@ func (r *SigningKeyRotator) generateNextKey() (*models.KeyPair, error) {
 	}
 	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: publicKeyASN1DER})
 
-	kid := uuid.New().String()
+	kid := uuidutil.New()
 	publicKeyJWK, err := rsautil.MarshalRSAPublicKeyToJWK(&privateKey.PublicKey, kid)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to marshal JWK")

--- a/src/core/oauth/signing_key_rotator_test.go
+++ b/src/core/oauth/signing_key_rotator_test.go
@@ -8,6 +8,7 @@ import (
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -128,7 +129,12 @@ func TestSigningKeyRotator_Rotate_Success(t *testing.T) {
 	assert.Equal(t, enums.KeyStateNext.String(), created.State)
 	assert.Equal(t, "RSA", created.Type)
 	assert.Equal(t, "RS256", created.Algorithm)
-	assert.NotEmpty(t, created.KeyIdentifier)
+	// The kid is a canonical v4 the generator produced, not merely a non-empty string: it is
+	// published in the JWKS and every token header names it, so a malformed or duplicated one
+	// would make a signed token unverifiable (#278).
+	parsedKid, err := uuidutil.Parse(created.KeyIdentifier)
+	require.NoError(t, err)
+	assert.Equal(t, created.KeyIdentifier, parsedKid)
 	assert.NotEmpty(t, created.PrivateKeyPEM)
 	assert.NotEmpty(t, created.PublicKeyPEM)
 	assert.NotEmpty(t, created.PublicKeyASN1_DER)

--- a/src/core/oauth/token_issuer.go
+++ b/src/core/oauth/token_issuer.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/oidc"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 
 	"slices"
@@ -222,7 +222,7 @@ func (t *TokenIssuer) generateRefreshToken(settings *models.Settings, code *mode
 
 	claims := make(jwt.MapClaims)
 
-	jti := uuid.New().String()
+	jti := uuidutil.New()
 	claims["iss"] = settings.Issuer
 	claims["iat"] = now.Unix()
 	claims["nbf"] = now.Unix()
@@ -406,7 +406,7 @@ func (t *TokenIssuer) GenerateTokenResponseForClientCred(ctx context.Context, cl
 	claims["sub"] = client.ClientIdentifier
 	claims["iat"] = now.Unix()
 	claims["nbf"] = now.Unix()
-	claims["jti"] = uuid.New().String()
+	claims["jti"] = uuidutil.New()
 
 	audCollection := []string{}
 	for _, scope := range scopes {
@@ -701,7 +701,7 @@ func (t *TokenIssuer) generateAccessTokenCore(settings *models.Settings, input *
 	claims["iat"] = now.Unix()
 	claims["nbf"] = now.Unix()
 	claims["auth_time"] = input.AuthenticatedAt.Unix()
-	claims["jti"] = uuid.New().String()
+	claims["jti"] = uuidutil.New()
 	claims["acr"] = input.AcrLevel
 	// Omit amr rather than signing an empty array. OIDC Core 1.0 section 2 makes amr OPTIONAL, so
 	// absent says nothing about how the user authenticated, where "amr": [] positively asserts that
@@ -843,7 +843,7 @@ func (t *TokenIssuer) generateIdTokenCore(settings *models.Settings, input *Toke
 	claims["iat"] = now.Unix()
 	claims["nbf"] = now.Unix()
 	claims["auth_time"] = input.AuthenticatedAt.Unix()
-	claims["jti"] = uuid.New().String()
+	claims["jti"] = uuidutil.New()
 	claims["acr"] = input.AcrLevel
 	// Omitted when no method was recorded, for the reason given in generateAccessTokenCore (#240).
 	if len(input.AuthMethods) > 0 {
@@ -1278,7 +1278,7 @@ func (t *TokenIssuer) generateRefreshTokenForROPC(settings *models.Settings, inp
 
 	claims := make(jwt.MapClaims)
 
-	jti := uuid.New().String()
+	jti := uuidutil.New()
 	claims["iss"] = settings.Issuer
 	claims["iat"] = now.Unix()
 	claims["nbf"] = now.Unix()

--- a/src/core/oauth/token_issuer.go
+++ b/src/core/oauth/token_issuer.go
@@ -669,7 +669,7 @@ func (t *TokenIssuer) addOpenIdConnectClaimsFromUser(claims jwt.MapClaims, user 
 		// Add picture claim if user has a profile picture
 		hasPicture, err := t.database.UserHasProfilePicture(nil, user.Id)
 		if err == nil && hasPicture {
-			claims["picture"] = fmt.Sprintf("%v/userinfo/picture/%v", t.baseURL, user.Subject.String())
+			claims["picture"] = fmt.Sprintf("%v/userinfo/picture/%v", t.baseURL, user.Subject)
 		}
 	}
 

--- a/src/core/oauth/token_issuer_auth_state_generation_test.go
+++ b/src/core/oauth/token_issuer_auth_state_generation_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -54,7 +54,7 @@ func generationTestCode(scope string, sessionIdentifier string, codeGeneration i
 		},
 		User: models.User{
 			Id:                  1,
-			Subject:             uuid.New(),
+			Subject:             fake.UUID(),
 			Username:            "testuser",
 			Email:               "test@example.com",
 			AuthStateGeneration: userGeneration,
@@ -216,7 +216,7 @@ func TestAccessToken_GenerationProvenance(t *testing.T) {
 		// handler-to-issuer seam is pinned separately in handler_token's ROPC test.
 		input := &ROPCGrantInput{
 			Client: &models.Client{Id: 1, ClientIdentifier: "test-client", TokenExpirationInSeconds: 900},
-			User:   &models.User{Id: 1, Subject: uuid.New(), Username: "testuser", AuthStateGeneration: 7},
+			User:   &models.User{Id: 1, Subject: fake.UUID(), Username: "testuser", AuthStateGeneration: 7},
 			Scope:  "openid",
 		}
 		tokenStr, _, err := issuer.generateROPCAccessToken(settings, input, input.Scope, now, privKey, "test-kid", nil)
@@ -234,7 +234,7 @@ func TestAccessToken_GenerationProvenance(t *testing.T) {
 		// with the current 9 and launders it forward.
 		input := &ROPCGrantInput{
 			Client: &models.Client{Id: 1, ClientIdentifier: "test-client", TokenExpirationInSeconds: 900},
-			User:   &models.User{Id: 1, Subject: uuid.New(), Username: "testuser", AuthStateGeneration: 9},
+			User:   &models.User{Id: 1, Subject: fake.UUID(), Username: "testuser", AuthStateGeneration: 9},
 			Scope:  "openid",
 		}
 		parent := &models.RefreshToken{RefreshTokenType: offlineRefreshTokenType, AuthStateGeneration: 7}
@@ -246,7 +246,7 @@ func TestAccessToken_GenerationProvenance(t *testing.T) {
 	t.Run("implicit takes the AuthContext's generation", func(t *testing.T) {
 		input := &ImplicitGrantInput{
 			Client:              &models.Client{Id: 1, ClientIdentifier: "test-client", TokenExpirationInSeconds: 900},
-			User:                &models.User{Id: 1, Subject: uuid.New(), Username: "testuser", AuthStateGeneration: 9},
+			User:                &models.User{Id: 1, Subject: fake.UUID(), Username: "testuser", AuthStateGeneration: 9},
 			Scope:               "openid",
 			AcrLevel:            "urn:goiabada:level1",
 			AuthMethods:         "pwd",
@@ -368,7 +368,7 @@ func TestPersistedGeneration_Stamping(t *testing.T) {
 
 		input := &ROPCGrantInput{
 			Client: &models.Client{Id: 1, ClientIdentifier: "test-client"},
-			User:   &models.User{Id: 1, Subject: uuid.New(), AuthStateGeneration: 7},
+			User:   &models.User{Id: 1, Subject: fake.UUID(), AuthStateGeneration: 7},
 			Scope:  "openid",
 		}
 
@@ -391,7 +391,7 @@ func TestPersistedGeneration_Stamping(t *testing.T) {
 		// while the grant was authenticated at 7.
 		input := &ROPCGrantInput{
 			Client: &models.Client{Id: 1, ClientIdentifier: "test-client"},
-			User:   &models.User{Id: 1, Subject: uuid.New(), AuthStateGeneration: 9},
+			User:   &models.User{Id: 1, Subject: fake.UUID(), AuthStateGeneration: 9},
 			Scope:  "openid",
 		}
 		parent := &models.RefreshToken{

--- a/src/core/oauth/token_issuer_include_oidc_claims_in_id_token_test.go
+++ b/src/core/oauth/token_issuer_include_oidc_claims_in_id_token_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -33,7 +33,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_GlobalEnabled(t *te
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -92,7 +92,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_GlobalEnabled(t *te
 
 	// Standard claims
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 	assert.Equal(t, input.Client.ClientIdentifier, claims["aud"])
 	assert.Equal(t, input.Nonce, claims["nonce"])
 
@@ -139,7 +139,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_GlobalDisabled(t *t
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-456"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -187,7 +187,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_GlobalDisabled(t *t
 
 	// Standard claims should still be present
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 	assert.Equal(t, input.Client.ClientIdentifier, claims["aud"])
 	assert.Equal(t, input.Nonce, claims["nonce"])
 
@@ -224,7 +224,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_ClientOverrideOn(t 
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-789"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -266,7 +266,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_ClientOverrideOn(t 
 	claims := verifyAndDecodeToken(t, idToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// OIDC profile scope claims should be present
 	assert.Equal(t, input.User.GivenName, claims["given_name"])
@@ -289,7 +289,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_ClientOverrideOff(t
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-321"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -331,7 +331,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_ClientOverrideOff(t
 	claims := verifyAndDecodeToken(t, idToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// OIDC scope claims should NOT be present
 	assert.NotContains(t, claims, "given_name")
@@ -352,7 +352,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_GroupsAndAttributes
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-groups"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -431,7 +431,7 @@ func TestGenerateTokenResponseForAuthCode_IncludeOpenIDConnectClaimsInIdToken_Fu
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-full-flow"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -499,7 +499,7 @@ func TestGenerateTokenResponseForAuthCode_IncludeOpenIDConnectClaimsInIdToken_Fu
 	// Verify ID token does NOT have OIDC claims
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, code.Nonce, idClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, idClaims["acr"])
@@ -540,7 +540,7 @@ func TestGenerateTokenResponseForAuthCode_IncludeOpenIDConnectClaimsInIdToken_Cl
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-override-flow"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -630,7 +630,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_MinimalScope_NotAff
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
@@ -667,7 +667,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_MinimalScope_NotAff
 
 	// Standard claims present
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// No OIDC scope claims (because scope doesn't include them)
 	assert.NotContains(t, claims, "email")
@@ -690,7 +690,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_MinimalScope_Global
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
@@ -727,7 +727,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_MinimalScope_Global
 
 	// Standard claims present
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// No OIDC scope claims (because scope doesn't include them)
 	assert.NotContains(t, claims, "email")
@@ -748,7 +748,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_PartialScope_EmailO
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
@@ -791,7 +791,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_PartialScope_EmailO
 
 	// Standard claims
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// Email scope claims SHOULD be present
 	assert.Equal(t, input.User.Email, claims["email"])
@@ -824,7 +824,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_WithProfilePicture(
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	userId := int64(999)
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -867,7 +867,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_WithProfilePicture(
 
 	// Standard claims
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// Profile claims should be present
 	assert.Equal(t, input.User.GivenName, claims["given_name"])
@@ -875,7 +875,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_WithProfilePicture(
 
 	// Picture claim SHOULD be present (user has profile picture)
 	// URL format: {baseURL}/userinfo/picture/{userSubject}
-	expectedPictureURL := fmt.Sprintf("http://localhost:8081/userinfo/picture/%s", sub.String())
+	expectedPictureURL := fmt.Sprintf("http://localhost:8081/userinfo/picture/%s", sub)
 	assert.Equal(t, expectedPictureURL, claims["picture"])
 }
 
@@ -892,7 +892,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_EmptyUserFields(t *
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
@@ -941,7 +941,7 @@ func TestGenerateIdToken_IncludeOpenIDConnectClaimsInIdToken_EmptyUserFields(t *
 
 	// Standard claims
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, sub.String(), claims["sub"])
+	assert.Equal(t, sub, claims["sub"])
 
 	// Email claims SHOULD be present (non-empty)
 	assert.Equal(t, input.User.Email, claims["email"])

--- a/src/core/oauth/token_issuer_test.go
+++ b/src/core/oauth/token_issuer_test.go
@@ -14,9 +14,10 @@ import (
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/encryption"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -156,7 +157,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, code.Nonce, idClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, idClaims["acr"])
@@ -174,7 +175,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 	authTime := time.Unix(int64(authTimeUnix), 0)
 	assert.Equal(t, now.Add(-300*time.Second).Unix(), authTime.Unix(), fmt.Sprintf("auth_time should be 300 seconds ago: %s", authTime))
 
-	_, err = uuid.Parse(idClaims["jti"].(string))
+	_, err = uuidutil.Parse(idClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), idClaims["name"])
@@ -217,7 +218,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, "authserver", accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -236,7 +237,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 	assertTimeClaimWithinRange(t, accessClaims, "updated_at", -60*time.Second, "updated_at should be 60 seconds ago")
 	assertTimeClaimWithinRange(t, accessClaims, "auth_time", -300*time.Second, "auth_time should be 300 seconds ago")
 
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), accessClaims["name"])
@@ -279,7 +280,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 	// validate Refresh token --------------------------------------------
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, "https://test-issuer.com", refreshClaims["aud"])
 	assert.Equal(t, "https://test-issuer.com", refreshClaims["iss"])
 	assert.Equal(t, "Offline", refreshClaims["typ"])
@@ -290,7 +291,7 @@ func TestGenerateTokenResponseForAuthCode_FullOpenIDConnect(t *testing.T) {
 	assertTimeClaimWithinRange(t, refreshClaims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, refreshClaims, "offline_access_max_lifetime", 7200*time.Second, "offline_access_max_lifetime should be 7200 seconds from now")
 
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -314,7 +315,7 @@ func TestGenerateTokenResponseForAuthCode_MinimalScope(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -376,7 +377,7 @@ func TestGenerateTokenResponseForAuthCode_MinimalScope(t *testing.T) {
 
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, "https://test-issuer.com", idClaims["iss"])
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, code.Nonce, idClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, idClaims["acr"])
@@ -388,14 +389,14 @@ func TestGenerateTokenResponseForAuthCode_MinimalScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, idClaims, "iat", 0, "iat should be now")
 	assertTimeClaimWithinRange(t, idClaims, "nbf", 0, "nbf should be now")
 
-	_, err = uuid.Parse(idClaims["jti"].(string))
+	_, err = uuidutil.Parse(idClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	// validate Access token --------------------------------------------
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, "https://test-issuer.com", accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
 	assert.ElementsMatch(t, strings.Fields(code.AuthMethods), accessClaims["amr"])
@@ -408,13 +409,13 @@ func TestGenerateTokenResponseForAuthCode_MinimalScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, accessClaims, "iat", 0, "iat should be now")
 	assertTimeClaimWithinRange(t, accessClaims, "nbf", 0, "nbf should be now")
 
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	// validate Refresh token --------------------------------------------
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, "https://test-issuer.com", refreshClaims["aud"])
 	assert.Equal(t, "Refresh", refreshClaims["typ"])
 	assert.Equal(t, sessionIdentifier, refreshClaims["sid"])
@@ -424,7 +425,7 @@ func TestGenerateTokenResponseForAuthCode_MinimalScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, refreshClaims, "iat", 0, "iat should be now")
 	assertTimeClaimWithinRange(t, refreshClaims, "nbf", 0, "nbf should be now")
 
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -447,7 +448,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -528,7 +529,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, code.Nonce, idClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, idClaims["acr"])
@@ -541,7 +542,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 	assertTimeClaimWithinRange(t, idClaims, "auth_time", -60*time.Second, "auth_time should be 60 seconds ago")
 	assertTimeClaimWithinRange(t, idClaims, "updated_at", -24*time.Hour, "updated_at should be 24 hours ago")
 
-	_, err = uuid.Parse(idClaims["jti"].(string))
+	_, err = uuidutil.Parse(idClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.Email, idClaims["email"])
@@ -559,7 +560,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, []interface{}{"authserver", "resource1", "resource2"}, accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -573,7 +574,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 	assertTimeClaimWithinRange(t, accessClaims, "auth_time", -60*time.Second, "auth_time should be 60 seconds ago")
 	assertTimeClaimWithinRange(t, accessClaims, "updated_at", -24*time.Hour, "updated_at should be 24 hours ago")
 
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.Email, accessClaims["email"])
@@ -591,7 +592,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 	// validate Refresh token --------------------------------------------
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, settings.Issuer, refreshClaims["aud"])
 	assert.Equal(t, settings.Issuer, refreshClaims["iss"])
 	assert.Equal(t, "Refresh", refreshClaims["typ"])
@@ -602,7 +603,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndMixedScopes(t *testin
 	assertTimeClaimWithinRange(t, refreshClaims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, refreshClaims, "exp", 600*time.Second, "exp should be 600 seconds from now")
 
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -625,7 +626,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndCustomScope(t *testin
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -683,7 +684,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndCustomScope(t *testin
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, []interface{}{"resource1", "resource2"}, accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -701,7 +702,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndCustomScope(t *testin
 	assertTimeClaimWithinRange(t, accessClaims, "exp", 1200*time.Second, "exp should be 1200 seconds from now")
 	assertTimeClaimWithinRange(t, accessClaims, "auth_time", -30*time.Second, "auth_time should be 30 seconds ago")
 
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "resource1:read resource2:write offline_access", accessClaims["scope"])
@@ -709,7 +710,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndCustomScope(t *testin
 	assert.NotContains(t, accessClaims, "name")
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, settings.Issuer, refreshClaims["aud"])
 	assert.Equal(t, settings.Issuer, refreshClaims["iss"])
 	assert.Equal(t, "Offline", refreshClaims["typ"])
@@ -720,7 +721,7 @@ func TestGenerateTokenResponseForAuthCode_ClientOverrideAndCustomScope(t *testin
 	assertTimeClaimWithinRange(t, refreshClaims, "exp", 3000*time.Second, "exp should be 3000 seconds from now")
 	assertTimeClaimWithinRange(t, refreshClaims, "offline_access_max_lifetime", 6000*time.Second, "offline_access_max_lifetime should be 6000 seconds from now")
 
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -743,7 +744,7 @@ func TestGenerateTokenResponseForAuthCode_CustomScope(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -803,7 +804,7 @@ func TestGenerateTokenResponseForAuthCode_CustomScope(t *testing.T) {
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, "resource1", accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -816,7 +817,7 @@ func TestGenerateTokenResponseForAuthCode_CustomScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, accessClaims, "exp", 600*time.Second, "exp should be 600 seconds from now")
 	assertTimeClaimWithinRange(t, accessClaims, "auth_time", -30*time.Second, "auth_time should be 30 seconds ago")
 
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "resource1:read", accessClaims["scope"])
@@ -824,7 +825,7 @@ func TestGenerateTokenResponseForAuthCode_CustomScope(t *testing.T) {
 	assert.NotContains(t, accessClaims, "name")
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, settings.Issuer, refreshClaims["aud"])
 	assert.Equal(t, settings.Issuer, refreshClaims["iss"])
 	assert.Equal(t, "Refresh", refreshClaims["typ"])
@@ -834,7 +835,7 @@ func TestGenerateTokenResponseForAuthCode_CustomScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, refreshClaims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, refreshClaims, "exp", 600*time.Second, "exp should be 600 seconds from now")
 
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -851,7 +852,7 @@ func TestGenerateAccessToken(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -901,7 +902,7 @@ func TestGenerateAccessToken(t *testing.T) {
 	claims := verifyAndDecodeToken(t, accessToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, constants.AuthServerResourceIdentifier, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -914,7 +915,7 @@ func TestGenerateAccessToken(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 900*time.Second, "exp should be 900 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -300*time.Second, "auth_time should be 300 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), claims["name"])
@@ -940,7 +941,7 @@ func TestGenerateAccessToken_CustomScope(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-456"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -980,7 +981,7 @@ func TestGenerateAccessToken_CustomScope(t *testing.T) {
 	claims := verifyAndDecodeToken(t, accessToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, []interface{}{"resource1", "resource2"}, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -993,7 +994,7 @@ func TestGenerateAccessToken_CustomScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 600*time.Second, "exp should be 600 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -600*time.Second, "auth_time should be 600 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "resource1:read resource2:write", claims["scope"])
@@ -1015,7 +1016,7 @@ func TestGenerateAccessToken_WithGroupsAndAttributes(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-789"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1075,7 +1076,7 @@ func TestGenerateAccessToken_WithGroupsAndAttributes(t *testing.T) {
 	claims := verifyAndDecodeToken(t, accessToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, constants.AuthServerResourceIdentifier, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -1088,7 +1089,7 @@ func TestGenerateAccessToken_WithGroupsAndAttributes(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 1200*time.Second, "exp should be 1200 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -900*time.Second, "auth_time should be 900 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), claims["name"])
@@ -1127,7 +1128,7 @@ func TestGenerateAccessToken_InvalidScope(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-invalid"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1174,7 +1175,7 @@ func TestGenerateIdToken_FullScope(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1245,7 +1246,7 @@ func TestGenerateIdToken_FullScope(t *testing.T) {
 	claims := verifyAndDecodeToken(t, idToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, client.ClientIdentifier, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -1257,7 +1258,7 @@ func TestGenerateIdToken_FullScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 600*time.Second, "exp should be 600 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -300*time.Second, "auth_time should be 300 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), claims["name"])
@@ -1305,7 +1306,7 @@ func TestGenerateIdToken_MinimalScope(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-456"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1344,7 +1345,7 @@ func TestGenerateIdToken_MinimalScope(t *testing.T) {
 	claims := verifyAndDecodeToken(t, idToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, client.ClientIdentifier, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -1356,7 +1357,7 @@ func TestGenerateIdToken_MinimalScope(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 300*time.Second, "exp should be 300 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -60*time.Second, "auth_time should be 60 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.NotContains(t, claims, "name")
@@ -1378,7 +1379,7 @@ func TestGenerateIdToken_ClientOverride(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-789"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1426,7 +1427,7 @@ func TestGenerateIdToken_ClientOverride(t *testing.T) {
 	claims := verifyAndDecodeToken(t, idToken, publicKeyBytes)
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, client.ClientIdentifier, claims["aud"])
 	assert.Equal(t, code.Nonce, claims["nonce"])
 	assert.Equal(t, code.AcrLevel, claims["acr"])
@@ -1438,7 +1439,7 @@ func TestGenerateIdToken_ClientOverride(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 1200*time.Second, "exp should be 1200 seconds from now (client override)")
 	assertTimeClaimWithinRange(t, claims, "auth_time", -120*time.Second, "auth_time should be 120 seconds ago")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	assert.Equal(t, user.GetFullName(), claims["name"])
@@ -1463,7 +1464,7 @@ func TestGenerateRefreshToken_Offline(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1507,7 +1508,7 @@ func TestGenerateRefreshToken_Offline(t *testing.T) {
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
 	assert.Equal(t, settings.Issuer, claims["aud"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, "Offline", claims["typ"])
 	assert.Equal(t, code.Scope, claims["scope"])
 
@@ -1516,7 +1517,7 @@ func TestGenerateRefreshToken_Offline(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 7200*time.Second, "exp should be 7200 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "offline_access_max_lifetime", 172800*time.Second, "offline_access_max_lifetime should be 172800 seconds from now")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -1533,7 +1534,7 @@ func TestGenerateRefreshToken_Refresh(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-456"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1581,7 +1582,7 @@ func TestGenerateRefreshToken_Refresh(t *testing.T) {
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
 	assert.Equal(t, settings.Issuer, claims["aud"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, "Refresh", claims["typ"])
 	assert.Equal(t, code.Scope, claims["scope"])
 	assert.Equal(t, sessionIdentifier, claims["sid"])
@@ -1590,7 +1591,7 @@ func TestGenerateRefreshToken_Refresh(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, claims, "exp", 1800*time.Second, "exp should be 1800 seconds from now")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -1607,7 +1608,7 @@ func TestGenerateRefreshToken_WithExistingRefreshToken(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-789"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1656,7 +1657,7 @@ func TestGenerateRefreshToken_WithExistingRefreshToken(t *testing.T) {
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
 	assert.Equal(t, settings.Issuer, claims["aud"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, "Offline", claims["typ"])
 	assert.Equal(t, code.Scope, claims["scope"])
 
@@ -1665,7 +1666,7 @@ func TestGenerateRefreshToken_WithExistingRefreshToken(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", 3600*time.Second, "exp should be 3600 seconds from now")
 	assertTimeClaimWithinRange(t, claims, "offline_access_max_lifetime", 24*time.Hour, "offline_access_max_lifetime should match existing refresh token")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -1687,7 +1688,7 @@ func TestGenerateRefreshToken_OfflineMaxLifetimeLimit(t *testing.T) {
 	}
 
 	initialTime := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-max-lifetime"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -1748,7 +1749,7 @@ func TestGenerateRefreshToken_OfflineMaxLifetimeLimit(t *testing.T) {
 
 	assert.Equal(t, settings.Issuer, claims["iss"])
 	assert.Equal(t, settings.Issuer, claims["aud"])
-	assert.Equal(t, user.Subject.String(), claims["sub"])
+	assert.Equal(t, user.Subject, claims["sub"])
 	assert.Equal(t, "Offline", claims["typ"])
 	assert.Equal(t, code.Scope, claims["scope"])
 
@@ -1757,7 +1758,7 @@ func TestGenerateRefreshToken_OfflineMaxLifetimeLimit(t *testing.T) {
 	assertTimeClaimWithinRange(t, claims, "exp", time.Duration(expectedRemainingTime)*time.Second, "exp should be close to the remaining time in the max lifetime")
 	assertTimeClaimWithinRange(t, claims, "offline_access_max_lifetime", time.Duration(expectedRemainingTime)*time.Second, "offline_access_max_lifetime is not correct")
 
-	_, err = uuid.Parse(claims["jti"].(string))
+	_, err = uuidutil.Parse(claims["jti"].(string))
 	assert.NoError(t, err)
 
 	mockDB.AssertExpectations(t)
@@ -1994,7 +1995,7 @@ func TestGenerateTokenResponseForClientCred(t *testing.T) {
 			assertTimeClaimWithinRange(t, claims, "nbf", 0*time.Second, "nbf should be now")
 			assertTimeClaimWithinRange(t, claims, "exp", 3600*time.Second, "exp should be 3600 seconds from now")
 
-			_, err = uuid.Parse(claims["jti"].(string))
+			_, err = uuidutil.Parse(claims["jti"].(string))
 			assert.NoError(t, err)
 
 			mockDB.AssertExpectations(t)
@@ -2055,7 +2056,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -2104,7 +2105,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 			"iat":    now.Add(-1 * time.Hour).Unix(),
 			"iss":    "https://test-issuer.com",
 			"aud":    "https://test-issuer.com",
-			"sub":    sub.String(),
+			"sub":    sub,
 			"typ":    "Refresh",
 			"sid":    sessionIdentifier,
 			"client": client.ClientIdentifier,
@@ -2160,7 +2161,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, user.Subject.String(), idClaims["sub"])
+	assert.Equal(t, user.Subject, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, code.Nonce, idClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, idClaims["acr"])
@@ -2175,7 +2176,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 	assert.Equal(t, user.GetFullName(), idClaims["name"])
 	assert.Equal(t, user.Username, idClaims["preferred_username"])
 	assert.Equal(t, fmt.Sprintf("%v/account/profile", "http://localhost:8081"), idClaims["profile"])
-	_, err = uuid.Parse(idClaims["jti"].(string))
+	_, err = uuidutil.Parse(idClaims["jti"].(string))
 	assert.NoError(t, err)
 	assertTimeClaimWithinRange(t, idClaims, "updated_at", -1*time.Hour, "updated_at should be 1 hour ago")
 
@@ -2183,7 +2184,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.ElementsMatch(t, []string{constants.AuthServerResourceIdentifier, "resource1"}, accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -2196,7 +2197,7 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 	assert.Equal(t, user.Username, accessClaims["preferred_username"])
 	assert.Equal(t, fmt.Sprintf("%v/account/profile", "http://localhost:8081"), accessClaims["profile"])
 	assert.Equal(t, "openid profile resource1:read authserver:userinfo", accessClaims["scope"])
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err)
 	assertTimeClaimWithinRange(t, accessClaims, "updated_at", -1*time.Hour, "updated_at should be 1 hour ago")
 
@@ -2209,12 +2210,12 @@ func TestGenerateTokenResponseForRefresh(t *testing.T) {
 	// RFC 6749 Section 6: New refresh token scope MUST be identical to original refresh token's scope
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, "https://test-issuer.com", refreshClaims["aud"])
 	assert.Equal(t, "https://test-issuer.com", refreshClaims["iss"])
 	assert.Equal(t, "Refresh", refreshClaims["typ"])
 	assert.Equal(t, "openid profile resource1:read", refreshClaims["scope"])
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err)
 	assert.Equal(t, sessionIdentifier, refreshClaims["sid"])
 
@@ -2258,7 +2259,7 @@ func TestGenerateTokenResponseForRefresh_Offline_NoIdToken(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
 	now := time.Now().UTC()
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-offline"
 
 	privateKeyBytes := getTestPrivateKey(t)
@@ -2317,7 +2318,7 @@ func TestGenerateTokenResponseForRefresh_Offline_NoIdToken(t *testing.T) {
 			"iat":    now.Add(-1 * time.Hour).Unix(),
 			"iss":    "https://test-issuer.com",
 			"aud":    "https://test-issuer.com",
-			"sub":    sub.String(),
+			"sub":    sub,
 			"typ":    "Offline",
 			"client": client.ClientIdentifier,
 		},
@@ -2364,7 +2365,7 @@ func TestGenerateTokenResponseForRefresh_Offline_NoIdToken(t *testing.T) {
 
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, user.Subject.String(), accessClaims["sub"])
+	assert.Equal(t, user.Subject, accessClaims["sub"])
 	assert.Equal(t, "resource1", accessClaims["aud"])
 	assert.Equal(t, code.Nonce, accessClaims["nonce"])
 	assert.Equal(t, code.AcrLevel, accessClaims["acr"])
@@ -2384,14 +2385,14 @@ func TestGenerateTokenResponseForRefresh_Offline_NoIdToken(t *testing.T) {
 	assertTimeClaimWithinRange(t, accessClaims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, accessClaims, "exp", 1200*time.Second, "exp should be 1200 seconds from now")
 	assertTimeClaimWithinRange(t, accessClaims, "auth_time", -600*time.Second, "auth_time should be 600 seconds ago")
-	_, err = uuid.Parse(accessClaims["jti"].(string))
+	_, err = uuidutil.Parse(accessClaims["jti"].(string))
 	assert.NoError(t, err, "Access token jti should be a valid UUID")
 
 	// validate Refresh token --------------------------------------------
 	// RFC 6749 Section 6: New refresh token scope MUST be identical to original refresh token's scope
 
 	refreshClaims := verifyAndDecodeToken(t, response.RefreshToken, publicKeyBytes)
-	assert.Equal(t, user.Subject.String(), refreshClaims["sub"])
+	assert.Equal(t, user.Subject, refreshClaims["sub"])
 	assert.Equal(t, settings.Issuer, refreshClaims["aud"])
 	assert.Equal(t, settings.Issuer, refreshClaims["iss"])
 	assert.Equal(t, "Offline", refreshClaims["typ"])
@@ -2400,7 +2401,7 @@ func TestGenerateTokenResponseForRefresh_Offline_NoIdToken(t *testing.T) {
 	assertTimeClaimWithinRange(t, refreshClaims, "nbf", 0*time.Second, "nbf should be now")
 	assertTimeClaimWithinRange(t, refreshClaims, "exp", 7200*time.Second, "exp should be 7200 seconds from now")
 	assertTimeClaimWithinRange(t, refreshClaims, "offline_access_max_lifetime", 172800*time.Second, "offline_access_max_lifetime should be 172800 seconds from now")
-	_, err = uuid.Parse(refreshClaims["jti"].(string))
+	_, err = uuidutil.Parse(refreshClaims["jti"].(string))
 	assert.NoError(t, err, "Refresh token jti should be a valid UUID")
 
 	// validate Refresh token passed to CreateRefreshToken --------------------------------------------
@@ -2720,7 +2721,7 @@ func TestGenerateTokenResponseForImplicit_AccessTokenOnly(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-implicit"
 	authenticatedAt := time.Now().UTC().Add(-5 * time.Minute)
 
@@ -2776,7 +2777,7 @@ func TestGenerateTokenResponseForImplicit_AccessTokenOnly(t *testing.T) {
 	// Decode and verify access token claims
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, sub.String(), accessClaims["sub"])
+	assert.Equal(t, sub, accessClaims["sub"])
 	assert.Equal(t, input.AcrLevel, accessClaims["acr"])
 	assert.ElementsMatch(t, strings.Fields(input.AuthMethods), accessClaims["amr"])
 	assert.Equal(t, sessionIdentifier, accessClaims["sid"])
@@ -2798,7 +2799,7 @@ func TestGenerateTokenResponseForImplicit_IdTokenOnly(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-idtoken"
 	authenticatedAt := time.Now().UTC().Add(-5 * time.Minute)
 
@@ -2855,7 +2856,7 @@ func TestGenerateTokenResponseForImplicit_IdTokenOnly(t *testing.T) {
 	// Decode and verify id_token claims
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, sub.String(), idClaims["sub"])
+	assert.Equal(t, sub, idClaims["sub"])
 	assert.Equal(t, client.ClientIdentifier, idClaims["aud"])
 	assert.Equal(t, input.AcrLevel, idClaims["acr"])
 	assert.ElementsMatch(t, strings.Fields(input.AuthMethods), idClaims["amr"])
@@ -2887,7 +2888,7 @@ func TestGenerateTokenResponseForImplicit_BothTokens(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-both"
 	authenticatedAt := time.Now().UTC().Add(-5 * time.Minute)
 
@@ -2943,12 +2944,12 @@ func TestGenerateTokenResponseForImplicit_BothTokens(t *testing.T) {
 	// Decode and verify access token
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, accessClaims["iss"])
-	assert.Equal(t, sub.String(), accessClaims["sub"])
+	assert.Equal(t, sub, accessClaims["sub"])
 
 	// Decode and verify id_token
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, settings.Issuer, idClaims["iss"])
-	assert.Equal(t, sub.String(), idClaims["sub"])
+	assert.Equal(t, sub, idClaims["sub"])
 	assert.Equal(t, "nonce-for-both", idClaims["nonce"])
 
 	// Verify at_hash IS present (since access token was also issued)
@@ -2976,7 +2977,7 @@ func TestGenerateTokenResponseForImplicit_NoRefreshToken(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	privateKeyBytes := getTestPrivateKey(t)
 
 	client := &models.Client{
@@ -3032,7 +3033,7 @@ func TestGenerateTokenResponseForImplicit_ClientOverrideExpiration(t *testing.T)
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
@@ -3093,7 +3094,7 @@ func TestGenerateTokenResponseForImplicit_WithGroupsAndAttributes(t *testing.T) 
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
@@ -3256,7 +3257,7 @@ func TestGenerateTokenResponseForROPC_BasicOpenIDScope(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:                                      1,
 		ClientIdentifier:                        "test-client",
@@ -3312,7 +3313,7 @@ func TestGenerateTokenResponseForROPC_BasicOpenIDScope(t *testing.T) {
 	// Verify access token claims
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
 	assert.Equal(t, "https://test-issuer.com", accessClaims["iss"])
-	assert.Equal(t, sub.String(), accessClaims["sub"])
+	assert.Equal(t, sub, accessClaims["sub"])
 	assert.Equal(t, "urn:goiabada:pwd", accessClaims["acr"])
 	assert.ElementsMatch(t, []string{"pwd"}, accessClaims["amr"])
 	// ROPC is sessionless, on BOTH tokens. This replaced an assert.Nil on the same claim:
@@ -3324,7 +3325,7 @@ func TestGenerateTokenResponseForROPC_BasicOpenIDScope(t *testing.T) {
 	// Verify id_token claims
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
 	assert.Equal(t, "https://test-issuer.com", idClaims["iss"])
-	assert.Equal(t, sub.String(), idClaims["sub"])
+	assert.Equal(t, sub, idClaims["sub"])
 	assert.Equal(t, "urn:goiabada:pwd", idClaims["acr"])
 	assert.ElementsMatch(t, []string{"pwd"}, idClaims["amr"])
 	// The ID token is where the browser session used to leak, so this is the assertion that
@@ -3355,7 +3356,7 @@ func TestGenerateTokenResponseForROPC_WithOfflineAccess(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:                                      1,
 		ClientIdentifier:                        "test-client",
@@ -3436,7 +3437,7 @@ func TestGenerateTokenResponseForROPC_WithProfileScope(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3516,7 +3517,7 @@ func TestGenerateTokenResponseForROPC_WithEmailScope(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3590,7 +3591,7 @@ func TestGenerateTokenResponseForROPC_WithResourcePermissions(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3673,7 +3674,7 @@ func TestGenerateTokenResponseForROPC_WithGroups(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3757,7 +3758,7 @@ func TestGenerateTokenResponseForROPC_WithoutOpenID(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3821,7 +3822,7 @@ func TestGenerateTokenResponseForROPC_DatabaseError_GetSigningKey(t *testing.T) 
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3872,7 +3873,7 @@ func TestGenerateTokenResponseForROPC_DatabaseError_CreateRefreshToken(t *testin
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:               1,
 		ClientIdentifier: "test-client",
@@ -3940,7 +3941,7 @@ func TestGenerateTokenResponseForROPC_ClientTokenExpiration(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:                       1,
 		ClientIdentifier:         "test-client",
@@ -4010,7 +4011,7 @@ func TestGenerateTokenResponseForROPC_GlobalTokenExpiration(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	client := &models.Client{
 		Id:                       1,
 		ClientIdentifier:         "test-client",
@@ -4167,7 +4168,7 @@ func TestAMR_IsArrayType_InGeneratedTokens(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-123"
 
 	client := &models.Client{
@@ -4372,7 +4373,7 @@ func TestAMR_OmittedWhenNoAuthMethodRecorded(t *testing.T) {
 	privateKeyBytes := getTestPrivateKey(t)
 	publicKeyBytes := getTestPublicKey(t)
 
-	sub := uuid.New()
+	sub := fake.UUID()
 	sessionIdentifier := "test-session-amr-absent"
 
 	client := &models.Client{
@@ -4570,7 +4571,7 @@ func TestCreateTokenInputFromCode(t *testing.T) {
 	tokenIssuer := NewTokenIssuer(mockDB, "http://localhost:8081")
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	code := &models.Code{
 		Scope:             "openid profile email",
@@ -4607,7 +4608,7 @@ func TestCreateTokenInputFromImplicit(t *testing.T) {
 	tokenIssuer := NewTokenIssuer(mockDB, "http://localhost:8081")
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	implicitInput := &ImplicitGrantInput{
 		Client: &models.Client{
@@ -4643,7 +4644,7 @@ func TestCreateTokenInputFromROPC(t *testing.T) {
 	tokenIssuer := NewTokenIssuer(mockDB, "http://localhost:8081")
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	ropcInput := &ROPCGrantInput{
 		Client: &models.Client{
@@ -4688,7 +4689,7 @@ func TestGenerateAccessTokenCore_InvalidScope(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	t.Run("Invalid scope format - no colon", func(t *testing.T) {
 		input := &TokenGenerationInput{
@@ -4749,7 +4750,7 @@ func TestGenerateAccessTokenCore_MultipleAudiences(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	input := &TokenGenerationInput{
 		User: &models.User{
@@ -4791,7 +4792,7 @@ func TestGenerateAccessTokenCore_OptionalClaims(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	t.Run("With nonce and sid", func(t *testing.T) {
 		input := &TokenGenerationInput{
@@ -4861,7 +4862,7 @@ func TestGenerateIdTokenCore_WithAtHash(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	t.Run("With access token - at_hash included", func(t *testing.T) {
 		input := &TokenGenerationInput{
@@ -4931,7 +4932,7 @@ func TestGenerateIdTokenCore_GroupsAndAttributes(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	user := &models.User{
 		Subject:   userSubject,
@@ -4994,7 +4995,7 @@ func TestGenerateTokenResponseForRefreshROPC(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	user := &models.User{
 		Id:        1,
@@ -5062,7 +5063,7 @@ func TestGenerateTokenResponseForRefreshROPC(t *testing.T) {
 
 	// Verify access token claims
 	accessClaims := verifyAndDecodeToken(t, response.AccessToken, publicKeyBytes)
-	assert.Equal(t, userSubject.String(), accessClaims["sub"])
+	assert.Equal(t, userSubject, accessClaims["sub"])
 	assert.Equal(t, "urn:goiabada:pwd", accessClaims["acr"])
 	assert.ElementsMatch(t, []string{"pwd"}, accessClaims["amr"])
 	// From the parent (7), not the reloaded user (9).
@@ -5072,7 +5073,7 @@ func TestGenerateTokenResponseForRefreshROPC(t *testing.T) {
 
 	// Verify id token claims
 	idClaims := verifyAndDecodeToken(t, response.IdToken, publicKeyBytes)
-	assert.Equal(t, userSubject.String(), idClaims["sub"])
+	assert.Equal(t, userSubject, idClaims["sub"])
 	assert.Equal(t, "ropc-client", idClaims["aud"])
 	assert.NotContains(t, idClaims, "sid", "a ROPC ID token must never carry a session identifier")
 
@@ -5106,7 +5107,7 @@ func TestGenerateTokenResponseForRefreshROPC_ScopeDowngrade(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), constants.ContextKeySettings, settings)
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	user := &models.User{
 		Id:        1,
@@ -5173,7 +5174,7 @@ func TestTokenGenerationInput_AllFieldsCopied(t *testing.T) {
 
 	now := time.Now().UTC()
 	authTime := now.Add(-10 * time.Minute)
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	// Test with Code - ensure all fields transferred
 	code := &models.Code{
@@ -5223,7 +5224,7 @@ func TestGenerateAccessTokenCore_ClientOverrideExpiration(t *testing.T) {
 	}
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	t.Run("Uses client override when set", func(t *testing.T) {
 		input := &TokenGenerationInput{
@@ -5285,7 +5286,7 @@ func TestGenerateAccessTokenCore_OIDCClaimsInAccessToken(t *testing.T) {
 	assert.NoError(t, err)
 
 	now := time.Now().UTC()
-	userSubject := uuid.New()
+	userSubject := fake.UUID()
 
 	mockDB.On("UserHasProfilePicture", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 

--- a/src/core/sessionstore/server_side_store.go
+++ b/src/core/sessionstore/server_side_store.go
@@ -672,10 +672,12 @@ func chunkCookieName(logicalName string, n int) string {
 
 // newSessionId returns 256 bits from the CSPRNG, hex encoded.
 //
-// Deliberately not stringutil.GenerateSecurityRandomString: that helper returns "" when
-// the CSPRNG fails rather than an error (#211), and a session identifier that silently
-// becomes the empty string for every session is the one fail-open this store must not
-// have. A failure here fails the save instead.
+// Deliberately not stringutil.GenerateSecurityRandomString: that helper has no error
+// return at all, because a CSPRNG failure there ends the process (#211, closed by #278).
+// A save does have one, so an entropy failure costs the one save -- no cookie, no backend
+// row -- rather than the server. It also keeps that failure reachable from a test through
+// randReader, which is what pins the behaviour; the helper reads crypto/rand directly and
+// nothing can make it fail in-process.
 func newSessionId() (string, error) {
 	buf := make([]byte, SessionIdBytes)
 	if _, err := io.ReadFull(randReader, buf); err != nil {

--- a/src/core/sessionstore/server_side_store_test.go
+++ b/src/core/sessionstore/server_side_store_test.go
@@ -263,9 +263,10 @@ func TestServerSideStore_CSPRNGFailureFailsTheSave(t *testing.T) {
 
 			err = store.Save(req, w, session)
 
-			// The alternative, which stringutil.GenerateSecurityRandomString takes, is to
-			// return the empty string. Every session would then share one identifier, or
-			// every seal one nonce.
+			// What must never happen is a session saved with an identifier or a nonce that
+			// did not come from the CSPRNG. This store refuses it with an error, because a
+			// save has one to return; stringutil.GenerateSecurityRandomString has no error
+			// return and refuses it by ending the process instead (#211, #278).
 			require.Error(t, err)
 			assert.Empty(t, w.Result().Cookies(), "no cookie may be issued without an identifier")
 			assert.Equal(t, 0, backend.creates)

--- a/src/core/stringutil/stringutil.go
+++ b/src/core/stringutil/stringutil.go
@@ -41,22 +41,47 @@ func randomStringFromReader(r io.Reader, length int, alphabet string) (string, e
 	return string(out), nil
 }
 
+// cryptoRandReader is the system CSPRNG presented as an io.Reader that cannot
+// fail. crypto/rand.Read has not returned an error since Go 1.24: on a failed
+// read it calls the runtime's fatal handler, which no recover can catch, so the
+// process is gone before Read could return one.
+//
+// io.ReadFull(rand.Reader, p) reads the same source and is deliberately not the
+// call here. It hands the error back, and randomStringFromAlphabet has no error
+// return of its own, so it would have to invent a value; the value it used to
+// invent was "", and an empty security token, ceremony id or continuation id is
+// exactly what this contract exists to make impossible (#211).
+type cryptoRandReader struct{}
+
+func (cryptoRandReader) Read(p []byte) (int, error) {
+	_, _ = rand.Read(p) // cannot fail; the process dies first, see above
+	return len(p), nil
+}
+
 // randomStringFromAlphabet is the crypto/rand-backed convenience wrapper around
-// randomStringFromReader. It preserves the package's historical contract of
-// returning "" when the system CSPRNG is unavailable.
+// randomStringFromReader. It cannot fail: cryptoRandReader never returns an
+// error, so the error randomStringFromReader declares is always nil here and a
+// branch on it would be dead code.
 func randomStringFromAlphabet(length int, alphabet string) string {
-	s, err := randomStringFromReader(rand.Reader, length, alphabet)
-	if err != nil {
-		return ""
-	}
+	s, _ := randomStringFromReader(cryptoRandReader{}, length, alphabet)
 	return s
 }
 
+// GenerateSecurityRandomString returns length characters drawn uniformly from
+// [0-9a-zA-Z-_.], the alphabet the ceremony ids, continuation ids and security
+// tokens in this repository are minted over.
+//
+// A CSPRNG failure ends the process rather than this call: it never returns a
+// short, empty or non-random string, so callers need no guard against one
+// (#211).
 func GenerateSecurityRandomString(length int) string {
 	const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_."
 	return randomStringFromAlphabet(length, chars)
 }
 
+// GenerateRandomLetterString returns length characters drawn uniformly from
+// [A-Za-z]. Like GenerateSecurityRandomString, a CSPRNG failure ends the
+// process rather than this call (#211).
 func GenerateRandomLetterString(length int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	return randomStringFromAlphabet(length, letters)
@@ -78,6 +103,9 @@ func ConvertToString(v interface{}) string {
 	}
 }
 
+// GenerateRandomNumberString returns length characters drawn uniformly from
+// [0-9]. Like GenerateSecurityRandomString, a CSPRNG failure ends the process
+// rather than this call (#211).
 func GenerateRandomNumberString(length int) string {
 	const chars = "0123456789"
 	return randomStringFromAlphabet(length, chars)

--- a/src/core/stringutil/stringutil_test.go
+++ b/src/core/stringutil/stringutil_test.go
@@ -2,7 +2,11 @@ package stringutil
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -119,6 +123,77 @@ func TestGenerateRandomLetterString_LettersOnly(t *testing.T) {
 		if !isLetter {
 			t.Fatalf("GenerateRandomLetterString emitted non-letter %q", c)
 		}
+	}
+}
+
+// crashChildEnv marks the re-executed child of
+// TestGenerateSecurityRandomString_CrashesIrrecoverablyOnReaderFailure. Only the
+// child swaps crypto/rand.Reader, so the parent's binary -- and every other case
+// in this package -- keeps the real source.
+const crashChildEnv = "GOIABADA_STRINGUTIL_CRASH_CHILD"
+
+// alwaysFailingReader is a CSPRNG that has stopped answering. errReader above is
+// the same shape but is fed straight to randomStringFromReader; this one is
+// installed as crypto/rand.Reader, which is the only way to reach the exported
+// generators' source.
+type alwaysFailingReader struct{}
+
+func (alwaysFailingReader) Read([]byte) (int, error) {
+	return 0, errors.New("stringutil_test: entropy source is unavailable")
+}
+
+// TestGenerateSecurityRandomString_CrashesIrrecoverablyOnReaderFailure pins the
+// half of the exported generators' contract that no length or alphabet
+// assertion can reach: on a CSPRNG failure the process dies, and no caller gets
+// a string or a chance to invent one.
+//
+// It is the case #211 was missing. The wrapper this package shipped until then
+// answered a failed draw with "", and every other case in this file passes
+// against that version, so the ceremony ids and continuation ids it fed were
+// guarded by hand at two call sites and nowhere else. Reverting
+// randomStringFromAlphabet to io.ReadFull with an `if err != nil { return "" }`
+// branch leaves the whole rest of this file green and fails only here.
+//
+// It runs in a re-executed child because the failure is a runtime fatal that no
+// recover can catch, so it takes its process with it. The child needs no broken
+// OS: crypto/rand.Read reads whatever crypto/rand.Reader holds and calls the
+// fatal handler on any error from it.
+func TestGenerateSecurityRandomString_CrashesIrrecoverablyOnReaderFailure(t *testing.T) {
+	if os.Getenv(crashChildEnv) == "1" {
+		rand.Reader = alwaysFailingReader{}
+		defer func() {
+			// Reached only if the draw failed in a catchable way, which is the
+			// contract being violated. Exit 0 so the parent's assertion fails.
+			if r := recover(); r != nil {
+				fmt.Fprintf(os.Stderr, "GenerateSecurityRandomString panicked recoverably with %v\n", r)
+				os.Exit(0)
+			}
+		}()
+		got := GenerateSecurityRandomString(32)
+		fmt.Fprintf(os.Stderr, "GenerateSecurityRandomString returned %q from a failing reader\n", got)
+		os.Exit(0)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0],
+		"-test.run=^TestGenerateSecurityRandomString_CrashesIrrecoverablyOnReaderFailure$")
+	cmd.Env = append(os.Environ(), crashChildEnv+"=1")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("child exited 0 with a failing CSPRNG, want a fatal crash; output:\n%s", out.String())
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("could not run the child: %v; output:\n%s", err, out.String())
+	}
+	const wantFatal = "crypto/rand: failed to read random data"
+	if !strings.Contains(out.String(), wantFatal) {
+		t.Fatalf("child died without %q, so it died of something other than the CSPRNG; output:\n%s",
+			wantFatal, out.String())
 	}
 }
 

--- a/src/core/testutil/fake/fake.go
+++ b/src/core/testutil/fake/fake.go
@@ -63,12 +63,13 @@ func intn(n int) int {
 }
 
 // mustDraw returns s unless it is short of the n characters that were asked
-// for, which is how the stringutil helpers report a CSPRNG failure: they
-// swallow the error and return "" to preserve a contract their production
-// callers were written against. A fixture that degrades to a constant instead
-// produces tests that pass while every username is the same string, which is
-// exactly the collision #136 describes, so the draw fails closed here rather
-// than propagating an invalid value into a fixture (#272).
+// for, in which case it panics. No caller can reach that panic today: the
+// stringutil helpers draw through crypto/rand.Read, which ends the process on a
+// CSPRNG failure rather than returning a short string (#211). The check is kept
+// as this package's own contract, independent of what stringutil promises: a
+// fixture that quietly degrades to a shorter or constant value produces tests
+// that pass while every username is the same string, which is exactly the
+// collision #136 describes. TestMustDraw_PanicsOnShortResult is what holds it.
 //
 // The alphabets are ASCII, so a byte count is a character count.
 func mustDraw(s string, n uint, who string) string {
@@ -82,8 +83,8 @@ func mustDraw(s string, n uint, who string) string {
 // LetterN returns n characters drawn from [A-Za-z]. n == 0 returns one
 // character, matching what the call sites were written against.
 //
-// It panics on a CSPRNG failure, like intn. Removing the mustDraw guard breaks
-// TestLetterN_PanicsOnEntropyFailure.
+// It panics rather than return a run shorter than n. Removing the mustDraw
+// guard breaks TestMustDraw_PanicsOnShortResult.
 func LetterN(n uint) string {
 	if n == 0 {
 		n = 1
@@ -96,8 +97,8 @@ func LetterN(n uint) string {
 // nothing parses those fields, only the column width constrains them, so a digit
 // run of the right length is the whole requirement (#272).
 //
-// It panics on a CSPRNG failure, like intn. Removing the mustDraw guard breaks
-// TestDigitN_PanicsOnEntropyFailure.
+// It panics rather than return a run shorter than n. Removing the mustDraw
+// guard breaks TestMustDraw_PanicsOnShortResult.
 func DigitN(n uint) string {
 	if n == 0 {
 		n = 1

--- a/src/core/testutil/fake/fake.go
+++ b/src/core/testutil/fake/fake.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/stringutil"
+	"github.com/leodip/goiabada/core/uuidutil"
 )
 
 const (
@@ -154,10 +154,12 @@ func URL() string {
 	return "https://" + strings.ToLower(LetterN(10)) + ".example.com/" + strings.ToLower(LetterN(6))
 }
 
-// UUID returns a random UUID string. Nothing in the fixtures parses one; they
-// are session identifiers, JTIs and key identifiers written straight to a column.
+// UUID returns a random UUID string. It is the fixture-side name for the
+// generator production uses, uuidutil.New, so a fixture and a real subject are
+// drawn the same way and a test cannot pass on a value production could never
+// have written (#278).
 func UUID() string {
-	return uuid.NewString()
+	return uuidutil.New()
 }
 
 // Username returns "user" followed by 12 lowercase letters: 16 characters, well

--- a/src/core/testutil/fake/fake_test.go
+++ b/src/core/testutil/fake/fake_test.go
@@ -1,8 +1,6 @@
 package fake
 
 import (
-	"crypto/rand"
-	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -62,53 +60,29 @@ func TestDigitN(t *testing.T) {
 	}
 }
 
-// brokenReader stands in for a system CSPRNG that has stopped answering. It is
-// the only way to reach the branch stringutil takes when crypto/rand fails,
-// because that helper swallows the error and returns "".
-type brokenReader struct{}
-
-func (brokenReader) Read([]byte) (int, error) {
-	return 0, errors.New("fake_test: entropy source is unavailable")
-}
-
-// withBrokenEntropy runs fn with crypto/rand.Reader replaced, and restores it
-// however fn leaves: these cases expect a panic, and a reader left broken would
-// take every later case in the package down with it. No test in this repository
-// calls t.Parallel(), so swapping the package variable for the length of one
-// case races with nothing.
-func withBrokenEntropy(t *testing.T, fn func()) {
-	t.Helper()
-	saved := rand.Reader
-	rand.Reader = brokenReader{}
-	defer func() { rand.Reader = saved }()
-	fn()
-}
-
-// TestLetterN_PanicsOnEntropyFailure and its DigitN twin pin the fail-closed
-// contract the package documents: a generator either produces its shape or stops
-// the test. stringutil returns "" on a CSPRNG failure, so without the mustDraw
-// guard LetterN hands a fixture an empty username and the suite goes green while
-// every generated value is identical (#272).
-func TestLetterN_PanicsOnEntropyFailure(t *testing.T) {
-	withBrokenEntropy(t, func() {
+// TestMustDraw_PanicsOnShortResult pins the fail-closed contract LetterN and
+// DigitN document, directly on the guard that carries it. It replaces a pair of
+// cases that swapped crypto/rand.Reader for a failing reader and called through
+// stringutil: since #211 that helper draws through crypto/rand.Read, which ends
+// the process on a read error rather than returning "", so those cases would now
+// take this whole test binary down instead of observing a panic.
+//
+// Calling mustDraw directly is what is left, and it is what the guard is for:
+// nothing can produce a short draw today, and the panic is this package's own
+// refusal to put a degraded value in a fixture (#272, #136).
+func TestMustDraw_PanicsOnShortResult(t *testing.T) {
+	func() {
 		defer func() {
 			if recover() == nil {
-				t.Error("LetterN(8) with a broken CSPRNG: want a panic, got none")
+				t.Error(`mustDraw("ab", 3, "x"): want a panic on a short draw, got none`)
 			}
 		}()
-		_ = LetterN(8)
-	})
-}
+		_ = mustDraw("ab", 3, "x")
+	}()
 
-func TestDigitN_PanicsOnEntropyFailure(t *testing.T) {
-	withBrokenEntropy(t, func() {
-		defer func() {
-			if recover() == nil {
-				t.Error("DigitN(8) with a broken CSPRNG: want a panic, got none")
-			}
-		}()
-		_ = DigitN(8)
-	})
+	if got := mustDraw("abc", 3, "x"); got != "abc" {
+		t.Errorf(`mustDraw("abc", 3, "x") = %q, want "abc"`, got)
+	}
 }
 
 // TestPassword_AllClassesPresent is the pin for the guarantee Password documents:

--- a/src/core/testutil/fake/fake_test.go
+++ b/src/core/testutil/fake/fake_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/urlutil"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/leodip/goiabada/core/validators"
 )
 
@@ -192,7 +192,7 @@ func TestURL(t *testing.T) {
 func TestUUID(t *testing.T) {
 	for i := 0; i < draws; i++ {
 		got := UUID()
-		if _, err := uuid.Parse(got); err != nil {
+		if _, err := uuidutil.Parse(got); err != nil {
 			t.Fatalf("UUID(): %q does not parse: %v", got, err)
 		}
 	}

--- a/src/core/user/user_creator.go
+++ b/src/core/user/user_creator.go
@@ -3,10 +3,10 @@ package user
 import (
 	"database/sql"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +32,7 @@ type CreateUserInput struct {
 func (uc *UserCreator) CreateUser(input *CreateUserInput) (*models.User, error) {
 
 	user := &models.User{
-		Subject:       uuid.New(),
+		Subject:       uuidutil.New(),
 		Enabled:       true,
 		Email:         input.Email,
 		EmailVerified: input.EmailVerified,

--- a/src/core/user/usersession_manager.go
+++ b/src/core/user/usersession_manager.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/data"
 	"github.com/leodip/goiabada/core/enums"
@@ -17,6 +16,7 @@ import (
 	"github.com/leodip/goiabada/core/oauth"
 	"github.com/leodip/goiabada/core/sessionstore"
 	"github.com/leodip/goiabada/core/useragent"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 )
 
@@ -78,7 +78,7 @@ func (u *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.
 	}
 
 	userSession := &models.UserSession{
-		SessionIdentifier: uuid.New().String(),
+		SessionIdentifier: uuidutil.New(),
 		Started:           utcNow,
 		LastAccessed:      utcNow,
 		IpAddress:         ipWithoutPort,

--- a/src/core/user/usersession_manager_start_test.go
+++ b/src/core/user/usersession_manager_start_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/leodip/goiabada/core/constants"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/models"
 	"github.com/leodip/goiabada/core/sessionstore"
 	"github.com/leodip/goiabada/core/useragent"
+	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -109,9 +109,11 @@ func TestStartNewUserSession_PopulatesSessionFields(t *testing.T) {
 
 	// The identifier must be a fresh UUID, since it is what the browser cookie
 	// carries and what every later lookup keys on.
-	parsed, parseErr := uuid.Parse(result.SessionIdentifier)
+	parsed, parseErr := uuidutil.Parse(result.SessionIdentifier)
 	assert.NoError(t, parseErr, "the session identifier must be a valid UUID")
-	assert.NotEqual(t, uuid.Nil, parsed)
+	// uuidutil.Parse accepts the nil UUID, so "non-empty" would pass against a hard-coded
+	// one. Compare against the nil spelling itself.
+	assert.NotEqual(t, "00000000-0000-0000-0000-000000000000", parsed)
 
 	// Started, LastAccessed and AuthTime are all stamped with the same UTC now.
 	for name, value := range map[string]time.Time{

--- a/src/core/uuidutil/uuidutil.go
+++ b/src/core/uuidutil/uuidutil.go
@@ -1,0 +1,99 @@
+// Package uuidutil supplies the random identifiers this server hands out --
+// subjects, session identifiers, JTIs, key identifiers -- and validates ones it
+// reads back. It holds two functions, no types, and depends on nothing outside
+// the standard library.
+//
+// The values are RFC 9562 version 4 UUIDs in the canonical 36-character
+// 8-4-4-4-12 lowercase form, which is the shape every column, claim, JSON body
+// and template in this repository already carries. Callers hold them as
+// strings: nothing here takes the bits apart again, and no code path branches
+// on a version or a variant.
+package uuidutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"strings"
+)
+
+// The reasons Parse refuses a string. They are matched with errors.Is, so a
+// test can assert that a case was refused for the reason it was written for
+// rather than merely refused.
+var (
+	errWrongLength = errors.New("uuidutil: wrong length, want 36 characters")
+	errHyphen      = errors.New("uuidutil: hyphen expected at index 8, 13, 18 and 23")
+	errNonHex      = errors.New("uuidutil: non-hex character")
+)
+
+// New returns a fresh RFC 9562 version 4 UUID in the canonical 36-character
+// lowercase form. It draws 16 bytes from the system CSPRNG per call, so two
+// calls colliding has probability around 2^-122.
+//
+// It cannot return a zero, short or partly random identifier. crypto/rand.Read
+// has not returned an error since Go 1.24: on a failed read it calls the
+// runtime's fatal handler, which no recover can catch, so the process is gone
+// before New could return anything at all. That is this package's contract, and
+// it is the point of the package (#278) -- an identifier stands for a user, a
+// session or a key, so it is either drawn from the CSPRNG or not produced.
+//
+// io.ReadFull(rand.Reader, b) reads the same source and is deliberately not the
+// call here. It hands the error back instead, and a caller that has no error
+// return of its own must then invent a value; the empty string is the value
+// that gets invented, and an empty identifier is exactly what this contract
+// exists to make impossible. Changing New to return an error would push that
+// choice out to every one of its call sites.
+func New() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])      // cannot fail; see the contract above
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4, RFC 9562 section 4.2
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10x, RFC 9562 section 4.1
+
+	var out [36]byte
+	hex.Encode(out[0:8], b[0:4])
+	out[8] = '-'
+	hex.Encode(out[9:13], b[4:6])
+	out[13] = '-'
+	hex.Encode(out[14:18], b[6:8])
+	out[18] = '-'
+	hex.Encode(out[19:23], b[8:10])
+	out[23] = '-'
+	hex.Encode(out[24:36], b[10:16])
+	return string(out[:])
+}
+
+// Parse checks that s is a UUID in the canonical 36-character 8-4-4-4-12 form
+// and returns it lowercased. Hex digits of either case are accepted. The
+// version and variant nibbles are not inspected, so the nil UUID and a UUID of
+// any version parse.
+//
+// The braced "{...}", "urn:uuid:..." and unhyphenated 32-hex spellings are
+// legal UUIDs that other parsers accept, and this one refuses them on purpose:
+// nothing in this repository produces or receives them, so accepting them would
+// widen the set of strings that can reach a column or a claim while serving no
+// caller (#278). A value that arrives in one of those forms is a value from
+// somewhere unexpected, which is worth an error rather than a silent
+// normalisation.
+func Parse(s string) (string, error) {
+	if len(s) != 36 {
+		return "", errWrongLength
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return "", errHyphen
+			}
+		default:
+			if !isHexDigit(c) {
+				return "", errNonHex
+			}
+		}
+	}
+	return strings.ToLower(s), nil
+}
+
+func isHexDigit(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}

--- a/src/core/uuidutil/uuidutil_test.go
+++ b/src/core/uuidutil/uuidutil_test.go
@@ -126,6 +126,30 @@ func TestParse(t *testing.T) {
 			in:      "550e8400_e29b_41d4_a716_446655440000",
 			wantErr: errHyphen,
 		},
+		// One row per separator position, because the row above cannot pin any single
+		// one of them: with the check relaxed at index 8 alone, its underscore at 13
+		// still raises errHyphen and the case passes over a parser that now accepts an
+		// arbitrary character in the middle of a subject (#278).
+		{
+			name:    "an underscore at index 8 only",
+			in:      "550e8400_e29b-41d4-a716-446655440000",
+			wantErr: errHyphen,
+		},
+		{
+			name:    "an underscore at index 13 only",
+			in:      "550e8400-e29b_41d4-a716-446655440000",
+			wantErr: errHyphen,
+		},
+		{
+			name:    "an underscore at index 18 only",
+			in:      "550e8400-e29b-41d4_a716-446655440000",
+			wantErr: errHyphen,
+		},
+		{
+			name:    "an underscore at index 23 only",
+			in:      "550e8400-e29b-41d4-a716_446655440000",
+			wantErr: errHyphen,
+		},
 		{
 			name:    "empty",
 			in:      "",

--- a/src/core/uuidutil/uuidutil_test.go
+++ b/src/core/uuidutil/uuidutil_test.go
@@ -1,0 +1,225 @@
+package uuidutil
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// draws is how many identifiers the format properties are checked over. One
+// draw proves almost nothing here: the version nibble is fixed but the variant
+// character is one of four, and a generator that got the masks wrong still
+// produces a plausible-looking string most of the time.
+const draws = 5000
+
+const lowerHex = "0123456789abcdef"
+
+// TestNew_CanonicalV4 owns the format table: everything a reader of New's
+// output is entitled to assume. Removing either mask in New leaves this
+// failing on the first few draws.
+func TestNew_CanonicalV4(t *testing.T) {
+	seen := make(map[string]struct{}, draws)
+	for i := 0; i < draws; i++ {
+		got := New()
+
+		if len(got) != 36 {
+			t.Fatalf("New(): %q is %d characters, want 36", got, len(got))
+		}
+		for _, pos := range []int{8, 13, 18, 23} {
+			if got[pos] != '-' {
+				t.Fatalf("New(): %q has %q at index %d, want a hyphen", got, got[pos], pos)
+			}
+		}
+		if got[14] != '4' {
+			t.Fatalf("New(): %q has version character %q, want %q (RFC 9562 section 4.2)",
+				got, got[14], '4')
+		}
+		if !strings.ContainsRune("89ab", rune(got[19])) {
+			t.Fatalf("New(): %q has variant character %q, want one of \"89ab\" (RFC 9562 section 4.1)",
+				got, got[19])
+		}
+		for pos := 0; pos < len(got); pos++ {
+			switch pos {
+			case 8, 13, 18, 23:
+				continue
+			}
+			if !strings.ContainsRune(lowerHex, rune(got[pos])) {
+				t.Fatalf("New(): %q has %q at index %d, want a lowercase hex digit",
+					got, got[pos], pos)
+			}
+		}
+
+		parsed, err := Parse(got)
+		if err != nil {
+			t.Fatalf("Parse(New()): %q refused: %v", got, err)
+		}
+		if parsed != got {
+			t.Fatalf("Parse(New()): %q came back as %q, want it unchanged", got, parsed)
+		}
+
+		if _, dup := seen[got]; dup {
+			t.Fatalf("New(): %q drawn twice in %d draws", got, i+1)
+		}
+		seen[got] = struct{}{}
+	}
+}
+
+// TestParse is the exhaustive table for the parser's leniency, and every row is
+// a choice rather than an accident. The braced, urn:uuid: and 32-hex rows are
+// the three spellings the third-party parser this package replaced accepted:
+// they are here so that widening the parser back to them is a test failure
+// rather than a quiet change (#278).
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "canonical lowercase, returned unchanged",
+			in:   "550e8400-e29b-41d4-a716-446655440000",
+			want: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name: "canonical uppercase, lowercased",
+			in:   "550E8400-E29B-41D4-A716-446655440000",
+			want: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:    "braced form, accepted by the retired parser, refused here",
+			in:      "{550e8400-e29b-41d4-a716-446655440000}",
+			wantErr: errWrongLength,
+		},
+		{
+			name:    "urn:uuid: form, accepted by the retired parser, refused here",
+			in:      "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+			wantErr: errWrongLength,
+		},
+		{
+			name:    "unhyphenated 32-hex form, accepted by the retired parser, refused here",
+			in:      "550e8400e29b41d4a716446655440000",
+			wantErr: errWrongLength,
+		},
+		{
+			name:    "one character short",
+			in:      "550e8400-e29b-41d4-a716-44665544000",
+			wantErr: errWrongLength,
+		},
+		{
+			name:    "one character long",
+			in:      "550e8400-e29b-41d4-a716-4466554400000",
+			wantErr: errWrongLength,
+		},
+		{
+			name:    "non-hex character in the last position",
+			in:      "550e8400-e29b-41d4-a716-44665544000g",
+			wantErr: errNonHex,
+		},
+		{
+			name:    "underscores where the hyphens belong",
+			in:      "550e8400_e29b_41d4_a716_446655440000",
+			wantErr: errHyphen,
+		},
+		{
+			name:    "empty",
+			in:      "",
+			wantErr: errWrongLength,
+		},
+		{
+			name: "the nil UUID, which carries no version or variant",
+			in:   "00000000-0000-0000-0000-000000000000",
+			want: "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.in)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Parse(%q): got error %v, want %v", tc.in, err, tc.wantErr)
+				}
+				if got != "" {
+					t.Fatalf("Parse(%q): refused but returned %q, want the empty string", tc.in, got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Parse(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("Parse(%q): got %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// crashChildEnv marks the re-executed child of
+// TestNew_CrashesIrrecoverablyOnReaderFailure. Only the child swaps
+// crypto/rand.Reader, so the parent's binary -- and every other case in this
+// package -- keeps the real source.
+const crashChildEnv = "GOIABADA_UUIDUTIL_CRASH_CHILD"
+
+// alwaysFailingReader is a CSPRNG that has stopped answering.
+type alwaysFailingReader struct{}
+
+func (alwaysFailingReader) Read([]byte) (int, error) {
+	return 0, errors.New("uuidutil_test: entropy source is unavailable")
+}
+
+// TestNew_CrashesIrrecoverablyOnReaderFailure pins the half of New's contract
+// that no format assertion can reach: on a CSPRNG failure the process dies, and
+// no caller gets an identifier or a chance to invent one. Without it, a New
+// rewritten to `if _, err := rand.Reader.Read(b[:]); err != nil { return "" }`
+// passes every other case in this file while handing empty subjects and empty
+// session identifiers to callers that cannot tell (#278).
+//
+// It runs in a re-executed child because the failure is a runtime fatal that no
+// recover can catch, so it takes its process with it. The child needs no broken
+// OS: crypto/rand.Read reads whatever crypto/rand.Reader holds and calls the
+// fatal handler on any error from it.
+func TestNew_CrashesIrrecoverablyOnReaderFailure(t *testing.T) {
+	if os.Getenv(crashChildEnv) == "1" {
+		rand.Reader = alwaysFailingReader{}
+		defer func() {
+			// Reached only if New panicked in a catchable way, which is the
+			// contract being violated. Exit 0 so the parent's assertion fails.
+			if r := recover(); r != nil {
+				fmt.Fprintf(os.Stderr, "New() panicked recoverably with %v\n", r)
+				os.Exit(0)
+			}
+		}()
+		got := New()
+		fmt.Fprintf(os.Stderr, "New() returned %q from a failing reader\n", got)
+		os.Exit(0)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestNew_CrashesIrrecoverablyOnReaderFailure$")
+	cmd.Env = append(os.Environ(), crashChildEnv+"=1")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("child exited 0 with a failing CSPRNG, want a fatal crash; output:\n%s", out.String())
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("could not run the child: %v; output:\n%s", err, out.String())
+	}
+	const wantFatal = "crypto/rand: failed to read random data"
+	if !strings.Contains(out.String(), wantFatal) {
+		t.Fatalf("child died without %q, so it died of something other than the CSPRNG; output:\n%s",
+			wantFatal, out.String())
+	}
+}

--- a/src/core/validators/email_validator_test.go
+++ b/src/core/validators/email_validator_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/i18n"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -56,8 +56,8 @@ func TestValidateEmailUpdate(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewEmailValidator(mockDB)
 
-	subject1 := uuid.New()
-	subject2 := uuid.New()
+	subject1 := fake.UUID()
+	subject2 := fake.UUID()
 
 	tests := []struct {
 		name         string
@@ -71,10 +71,10 @@ func TestValidateEmailUpdate(t *testing.T) {
 			input: ValidateEmailInput{
 				Email:             "new@example.com",
 				EmailConfirmation: "new@example.com",
-				Subject:           subject1.String(),
+				Subject:           subject1,
 			},
 			mockSetup: func() {
-				mockDB.On("GetUserBySubject", mock.Anything, subject1.String()).Return(&models.User{Subject: subject1}, nil)
+				mockDB.On("GetUserBySubject", mock.Anything, subject1).Return(&models.User{Subject: subject1}, nil)
 				mockDB.On("GetUserByEmail", mock.Anything, "new@example.com").Return(nil, nil)
 			},
 		},
@@ -83,7 +83,7 @@ func TestValidateEmailUpdate(t *testing.T) {
 			input: ValidateEmailInput{
 				Email:             "",
 				EmailConfirmation: "",
-				Subject:           subject1.String(),
+				Subject:           subject1,
 			},
 			mockSetup:    func() {},
 			expectedCode: i18n.ErrCodeEmailRequired,
@@ -93,7 +93,7 @@ func TestValidateEmailUpdate(t *testing.T) {
 			input: ValidateEmailInput{
 				Email:             "thisemailaddressiswaytoolongandexceedsthemaximumlengthof60characters@example.com",
 				EmailConfirmation: "thisemailaddressiswaytoolongandexceedsthemaximumlengthof60characters@example.com",
-				Subject:           subject1.String(),
+				Subject:           subject1,
 			},
 			mockSetup:    func() {},
 			expectedCode: i18n.ErrCodeEmailTooLong,
@@ -104,7 +104,7 @@ func TestValidateEmailUpdate(t *testing.T) {
 			input: ValidateEmailInput{
 				Email:             "new@example.com",
 				EmailConfirmation: "different@example.com",
-				Subject:           subject1.String(),
+				Subject:           subject1,
 			},
 			mockSetup:    func() {},
 			expectedCode: i18n.ErrCodeEmailConfirmationMismatch,
@@ -114,10 +114,10 @@ func TestValidateEmailUpdate(t *testing.T) {
 			input: ValidateEmailInput{
 				Email:             "existing@example.com",
 				EmailConfirmation: "existing@example.com",
-				Subject:           subject1.String(),
+				Subject:           subject1,
 			},
 			mockSetup: func() {
-				mockDB.On("GetUserBySubject", mock.Anything, subject1.String()).Return(&models.User{Subject: subject1}, nil)
+				mockDB.On("GetUserBySubject", mock.Anything, subject1).Return(&models.User{Subject: subject1}, nil)
 				mockDB.On("GetUserByEmail", mock.Anything, "existing@example.com").Return(&models.User{Subject: subject2}, nil)
 			},
 			expectedCode: i18n.ErrCodeEmailAlreadyRegistered,
@@ -154,17 +154,17 @@ func TestValidateEmailUpdate(t *testing.T) {
 // =============================================================================
 
 func TestValidateEmailChange_Accepted(t *testing.T) {
-	subject := uuid.New()
+	subject := fake.UUID()
 
 	t.Run("address is free", func(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		validator := NewEmailValidator(mockDB)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 			&models.User{Id: 1, Subject: subject}, nil).Once()
 		mockDB.On("GetUserByEmail", mock.Anything, "new@example.com").Return(nil, nil).Once()
 
-		err := validator.ValidateEmailChange("new@example.com", subject.String())
+		err := validator.ValidateEmailChange("new@example.com", subject)
 
 		assert.NoError(t, err)
 	})
@@ -174,10 +174,10 @@ func TestValidateEmailChange_Accepted(t *testing.T) {
 		validator := NewEmailValidator(mockDB)
 
 		user := &models.User{Id: 1, Subject: subject}
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(user, nil).Once()
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(user, nil).Once()
 		mockDB.On("GetUserByEmail", mock.Anything, "same@example.com").Return(user, nil).Once()
 
-		err := validator.ValidateEmailChange("same@example.com", subject.String())
+		err := validator.ValidateEmailChange("same@example.com", subject)
 
 		assert.NoError(t, err, "keeping your own address must not be reported as taken")
 	})
@@ -189,11 +189,11 @@ func TestValidateEmailChange_Accepted(t *testing.T) {
 		email := strings.Repeat("a", 60-len("@example.com")) + "@example.com"
 		assert.Len(t, email, 60)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 			&models.User{Id: 1, Subject: subject}, nil).Once()
 		mockDB.On("GetUserByEmail", mock.Anything, email).Return(nil, nil).Once()
 
-		err := validator.ValidateEmailChange(email, subject.String())
+		err := validator.ValidateEmailChange(email, subject)
 
 		assert.NoError(t, err)
 	})
@@ -203,15 +203,15 @@ func TestValidateEmailChange_AddressTakenByAnotherUser(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewEmailValidator(mockDB)
 
-	subject := uuid.New()
-	otherSubject := uuid.New()
+	subject := fake.UUID()
+	otherSubject := fake.UUID()
 
-	mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+	mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 		&models.User{Id: 1, Subject: subject}, nil).Once()
 	mockDB.On("GetUserByEmail", mock.Anything, "taken@example.com").Return(
 		&models.User{Id: 2, Subject: otherSubject}, nil).Once()
 
-	err := validator.ValidateEmailChange("taken@example.com", subject.String())
+	err := validator.ValidateEmailChange("taken@example.com", subject)
 
 	assertLocalizedErrorCode(t, err, i18n.ErrCodeEmailAlreadyRegistered)
 }
@@ -240,7 +240,7 @@ func TestValidateEmailChange_RejectedBeforeAnyLookup(t *testing.T) {
 			// proves the short circuit.
 			validator := NewEmailValidator(mocks_data.NewDatabase(t))
 
-			err := validator.ValidateEmailChange(tc.email, uuid.New().String())
+			err := validator.ValidateEmailChange(tc.email, fake.UUID())
 
 			assertLocalizedErrorCode(t, err, tc.expectedCode)
 		})
@@ -253,7 +253,7 @@ func TestValidateEmailChange_TooLong(t *testing.T) {
 	email := strings.Repeat("a", 50) + "@example.com"
 	assert.Greater(t, len(email), 60)
 
-	err := validator.ValidateEmailChange(email, uuid.New().String())
+	err := validator.ValidateEmailChange(email, fake.UUID())
 
 	assertLocalizedErrorCode(t, err, i18n.ErrCodeEmailTooLong)
 
@@ -265,16 +265,16 @@ func TestValidateEmailChange_TooLong(t *testing.T) {
 }
 
 func TestValidateEmailChange_DatabaseErrorsPropagate(t *testing.T) {
-	subject := uuid.New()
+	subject := fake.UUID()
 	dbErr := errors.New("database is down")
 
 	t.Run("GetUserBySubject fails", func(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		validator := NewEmailValidator(mockDB)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(nil, dbErr).Once()
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(nil, dbErr).Once()
 
-		err := validator.ValidateEmailChange("new@example.com", subject.String())
+		err := validator.ValidateEmailChange("new@example.com", subject)
 
 		assert.Error(t, err)
 		_, isLocalized := err.(*i18n.LocalizedError)
@@ -285,11 +285,11 @@ func TestValidateEmailChange_DatabaseErrorsPropagate(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		validator := NewEmailValidator(mockDB)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 			&models.User{Id: 1, Subject: subject}, nil).Once()
 		mockDB.On("GetUserByEmail", mock.Anything, "new@example.com").Return(nil, dbErr).Once()
 
-		err := validator.ValidateEmailChange("new@example.com", subject.String())
+		err := validator.ValidateEmailChange("new@example.com", subject)
 
 		assert.Error(t, err)
 		_, isLocalized := err.(*i18n.LocalizedError)
@@ -362,12 +362,12 @@ func TestValidateEmailChange_DoesNotCheckConfirmation(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewEmailValidator(mockDB)
 
-	subject := uuid.New()
-	mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+	subject := fake.UUID()
+	mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 		&models.User{Id: 1, Subject: subject}, nil).Once()
 	mockDB.On("GetUserByEmail", mock.Anything, "new@example.com").Return(nil, nil).Once()
 
-	err := validator.ValidateEmailChange("new@example.com", subject.String())
+	err := validator.ValidateEmailChange("new@example.com", subject)
 
 	assert.NoError(t, err)
 }

--- a/src/core/validators/profile_validator_test.go
+++ b/src/core/validators/profile_validator_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	"github.com/leodip/goiabada/core/enums"
 	"github.com/leodip/goiabada/core/i18n"
 	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/testutil/fake"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -221,7 +221,7 @@ func TestValidateProfile_EmptyInputIsValid(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestValidateProfile_UsernameFormat(t *testing.T) {
-	subject := uuid.New()
+	subject := fake.UUID()
 
 	testCases := []struct {
 		name         string
@@ -256,12 +256,12 @@ func TestValidateProfile_UsernameFormat(t *testing.T) {
 			// The format check runs after the uniqueness lookups, so both are
 			// always reached when a username is present.
 			user := &models.User{Id: 1, Subject: subject}
-			mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(user, nil).Once()
+			mockDB.On("GetUserBySubject", mock.Anything, subject).Return(user, nil).Once()
 			mockDB.On("GetUserByUsername", mock.Anything, tc.username).Return(nil, nil).Once()
 
 			err := validator.ValidateProfile(&ValidateProfileInput{
 				Username: tc.username,
-				Subject:  subject.String(),
+				Subject:  subject,
 			})
 
 			if tc.expectedCode == "" {
@@ -277,17 +277,17 @@ func TestValidateProfile_UsernameTakenByAnotherUser(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewProfileValidator(mockDB)
 
-	subject := uuid.New()
-	otherSubject := uuid.New()
+	subject := fake.UUID()
+	otherSubject := fake.UUID()
 
-	mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+	mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 		&models.User{Id: 1, Subject: subject}, nil).Once()
 	mockDB.On("GetUserByUsername", mock.Anything, "jdoe").Return(
 		&models.User{Id: 2, Subject: otherSubject}, nil).Once()
 
 	err := validator.ValidateProfile(&ValidateProfileInput{
 		Username: "jdoe",
-		Subject:  subject.String(),
+		Subject:  subject,
 	})
 
 	assertLocalizedErrorCode(t, err, i18n.ErrCodeProfileUsernameTaken)
@@ -298,33 +298,33 @@ func TestValidateProfile_UsernameOwnedBySameUserIsAllowed(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewProfileValidator(mockDB)
 
-	subject := uuid.New()
+	subject := fake.UUID()
 	user := &models.User{Id: 1, Subject: subject}
 
-	mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(user, nil).Once()
+	mockDB.On("GetUserBySubject", mock.Anything, subject).Return(user, nil).Once()
 	mockDB.On("GetUserByUsername", mock.Anything, "jdoe").Return(user, nil).Once()
 
 	err := validator.ValidateProfile(&ValidateProfileInput{
 		Username: "jdoe",
-		Subject:  subject.String(),
+		Subject:  subject,
 	})
 
 	assert.NoError(t, err)
 }
 
 func TestValidateProfile_UsernameLookupErrorsPropagate(t *testing.T) {
-	subject := uuid.New()
+	subject := fake.UUID()
 	dbErr := errors.New("database is down")
 
 	t.Run("GetUserBySubject fails", func(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		validator := NewProfileValidator(mockDB)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(nil, dbErr).Once()
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(nil, dbErr).Once()
 
 		err := validator.ValidateProfile(&ValidateProfileInput{
 			Username: "jdoe",
-			Subject:  subject.String(),
+			Subject:  subject,
 		})
 
 		assert.Error(t, err)
@@ -336,13 +336,13 @@ func TestValidateProfile_UsernameLookupErrorsPropagate(t *testing.T) {
 		mockDB := mocks_data.NewDatabase(t)
 		validator := NewProfileValidator(mockDB)
 
-		mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(
+		mockDB.On("GetUserBySubject", mock.Anything, subject).Return(
 			&models.User{Id: 1, Subject: subject}, nil).Once()
 		mockDB.On("GetUserByUsername", mock.Anything, "jdoe").Return(nil, dbErr).Once()
 
 		err := validator.ValidateProfile(&ValidateProfileInput{
 			Username: "jdoe",
-			Subject:  subject.String(),
+			Subject:  subject,
 		})
 
 		assert.Error(t, err)
@@ -767,10 +767,10 @@ func TestValidateProfile_FullyPopulatedValidProfile(t *testing.T) {
 	mockDB := mocks_data.NewDatabase(t)
 	validator := NewProfileValidator(mockDB)
 
-	subject := uuid.New()
+	subject := fake.UUID()
 	user := &models.User{Id: 1, Subject: subject}
 
-	mockDB.On("GetUserBySubject", mock.Anything, subject.String()).Return(user, nil).Once()
+	mockDB.On("GetUserBySubject", mock.Anything, subject).Return(user, nil).Once()
 	mockDB.On("GetUserByUsername", mock.Anything, "jdoe").Return(user, nil).Once()
 
 	err := validator.ValidateProfile(&ValidateProfileInput{
@@ -785,7 +785,7 @@ func TestValidateProfile_FullyPopulatedValidProfile(t *testing.T) {
 		ZoneInfoCountryName: "Brazil",
 		ZoneInfo:            "America/Sao_Paulo",
 		Locale:              "pt-BR",
-		Subject:             subject.String(),
+		Subject:             subject,
 	})
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #278. Closes #211.

## What this is for

`github.com/google/uuid` was imported by 105 Go files and supplied one thing everywhere: a fresh
random identifier as a 36-character string. Nothing in the tree used UUID semantics beyond that,
except that `models.User.Subject` was typed `uuid.UUID`, which reached the column, the JSON body
and the JWT `sub` claim through `String()` and `MarshalText` as the same canonical string anyway.

This change retires the module for a stdlib-only `core/uuidutil` package with two functions,
`New() string` and `Parse(s string) (string, error)`, and turns `Subject` into a `string`. Every
identifier the server stores, issues or serves stays byte-identical: same 16 bytes from
`crypto/rand`, same version and variant nibbles, same 8-4-4-4-12 lowercase form.

## The rule it establishes

A failure of the system CSPRNG ends the process. It never produces a zero, partial or empty
identifier, and it never turns into a request-level error. `uuidutil.New` reads through
`crypto/rand.Read`, which on Go 1.24 and later crashes the program irrecoverably rather than
returning an error. `stringutil`'s generators, which used to answer the same failure with `""`
(#211), now go through the same call, and the two `== ""` guards written against that contract are
deleted as dead code.

`uuidutil.Parse` accepts only the canonical form. The braced, `urn:uuid:` and 32-hex spellings
that `google/uuid.Parse` accepted are refused, because nothing here produces or receives them.

## Status

**Complete.** All four stages have landed, the whole change has been reviewed over two rounds at the
final gate, and the check suite is green at `1a8c39c0` on all thirteen jobs. Decision 8 was answered
A by the owner on 2026-09-10: the module stays `// indirect` through the SQL Server and sqlite
drivers, so the goal is that no Goiabada file imports it and no module requires it directly. That
goal is met — `grep -rn 'github.com/google/uuid' src --include=*.go` reads 0 and all four `go.mod`
files list it `// indirect` — and so is the folded-in one, with `stringutil` now failing closed.

## What has landed

### Stage 1: `core/uuidutil`, and `fake.UUID` over it
Landed in `819a1737`. `src/core/uuidutil` is a new stdlib-only package: `New() string` draws 16 bytes from `crypto/rand.Read`, sets the version and variant nibbles per RFC 9562 sections 4.2 and 4.1, and formats them 8-4-4-4-12 in lowercase; `Parse(string) (string, error)` accepts only that form, in either case, and returns it lowercased, refusing the braced, `urn:uuid:` and 32-hex spellings with one of three named sentinels. `New` returns no error on purpose: `crypto/rand.Read` has not returned one since Go 1.24 and calls the runtime's fatal handler on a failed read, so a zero or partly random identifier cannot be produced. `fake.UUID` is now a wrapper over `uuidutil.New`, and `fake_test.go` checks through `uuidutil.Parse`, which retires `google/uuid` from `core/testutil/fake`.

Tiers: unit green on all three modules, 5796 pass 0 fail, gofmt guard included. Data and integration not applicable — no query, no migration and no endpoint is in the diff, and nothing outside the package's own tests calls it yet. Three mutations checked and all caught: neutralising either the version or the variant mask fails `TestNew_CanonicalV4`, and rewriting `New` to return `""` on a read error fails `TestNew_CrashesIrrecoverablyOnReaderFailure`, which re-executes the test binary as a child because the real failure is a runtime fatal no `recover` can catch.

Two things worth knowing. `New` uses `_, _ = rand.Read(...)` rather than the bare call in the design sketch, because `errcheck` is enabled for all four modules and would redden the Lint job. And a mutation in this repository has to be gofmt-clean: shortening a line inside an aligned comment block makes `TestGoSourcesAreGofmted` fail in another module first, which reports `MUTATION CAUGHT` without the test under examination ever running.

### Stage 2: `Subject` becomes a string, and the test tree stops importing `google/uuid`
Landed in `c23ef2b4`. `models.User.Subject` and `api.UserResponse.Subject` are `string` now. Every consumer already wanted the string: the column is a varchar on all four engines and was written through `driver.Valuer`, whose `Value()` is `String()`; JSON and the `sub` claim went through `MarshalText`, which emits the same 36 characters; templates rendered `String()`. So the typed value bought parse-on-read validation of the users column and of the admin console's own API responses — neither reachable from outside a deployment — while the rest of the tree spent 84 `.String()` calls unwrapping it. Not one byte that reaches a column, a claim, a JSON body or a template moves.

The guard that mattered is kept. `GetUserBySubject` still compares the stored spelling against the requested one, so a case-insensitive engine collation cannot fold a match OIDC Core section 2 says is case sensitive; its comment now rests on `uuidutil.New` being the column's only writer rather than on `uuid.UUID.Value()`.

The 95 test files stop importing the library in the same commit: fresh values come from `fake.UUID()`, well-formedness assertions from `uuidutil.Parse`, and the 19 `MustParse` literals are literals. `grep -rn 'uuid\.UUID' src --include=*.go` and `grep -rn 'Subject\.String()' src --include=*.go` both read 0.

Tiers: unit green, 5599 pass 0 fail. Data green on mysql, postgres, mssql and sqlite, 2208 pass 0 fail — `TestGetUserBySubject`, `TestGetUserBySubjectIsCaseSensitive` and `TestUnique_UserSubject` on every engine are what say the varchar scans into a `string` and the unique index still refuses a duplicate. Integration green on sqlite, 1373 pass 0 fail, over the `sub`-claim paths, userinfo, the implicit flow and the retyped user-bound-token helpers. One new case, `TestUserResponse_SubjectIsABareCanonicalString`, pins that `subject` marshals as the bare 36-character string and round-trips; mutating its JSON tag fails it.

One deviation worth knowing: `user_creator.go` and the seeder's admin user move to `uuidutil.New` here rather than in stage 3, because a `uuid.UUID` does not assign to a `string` field. That leaves stage 3 six production files, not seven; the auth code, jti, kid, session identifier and DCR prefix are untouched.

### Stage 3: production generators on `uuidutil.New`, and the module graphs tidy
Landed in `c244ec9d`. The eleven remaining production call sites become `uuidutil.New()`: the auth code keeps `strings.ReplaceAll(uuidutil.New(), "-", "")` so its 32-hex-plus-96 shape is unchanged, and the five `jti` claims, the rotator's `kid`, the seeder's two `kid` values, the session identifier and the `dcr_` client identifier are each a one-line substitution producing the same canonical 36-character lowercase v4. No Go file under `src/` imports `github.com/google/uuid` any more, and `grep -rn 'uuid\.UUID' src --include=*.go` reads 0.

`go mod tidy` in all four modules then turns the direct requirement in `core` and `authserver` into `// indirect` and leaves `adminconsole` and `cmd/goiabada-setup` untouched. No `go.sum` moved, because `github.com/microsoft/go-mssqldb@v1.10.0` and `modernc.org/sqlite@v1.57.0` both require the module and keep it in the build — the fact decision 8 was answered about.

Three of the substitution sites had no assertion that could have caught a wrong value: the auth code and the rotator's `kid` were checked with `NotEmpty`, and `generateDCRClientIdentifier` had no test at all. Each is now pinned to what it emits — the auth code's 128 characters, whose first 32 re-hyphenate into something `uuidutil.Parse` accepts and whose remaining 96 are the security alphabet's; the `kid` parsing and round-tripping; and a new `TestGenerateDCRClientIdentifier_IsThePrefixAndAUUID` reading the prefix, parsing the rest, and requiring two calls to differ. Five mutations, one per generation site with a seam over it, were all caught.

Tiers: unit green, 1515 pass 0 fail. Data green on mysql, postgres, mssql and sqlite, 1631 pass 0 fail across the four — the seeder is in the diff and every engine runs it. Integration green on sqlite, 1038 pass 0 fail, over the token issuer, userinfo and DCR paths.

### Stage 4: `stringutil` fails closed by crashing (closes #211)
Landed in `90a9c166`. `GenerateSecurityRandomString`, `GenerateRandomLetterString` and `GenerateRandomNumberString` answered a `crypto/rand` failure with `""`. They now draw through an unexported `io.Reader` whose `Read` calls `crypto/rand.Read`, so a failed draw ends the process rather than handing back a string nobody can tell apart from a real one. That is the same contract `uuidutil.New` has, which is the point of folding #211 in here: the two changes answer one question and answering it twice would leave the tree with two contracts for a while.

The wrapper's `if err != nil { return "" }` branch goes with it, as do the two `== ""` guards at `SaveLinkMarker` and `HandleAuthorizeGet` — the only two call sites that ever checked, out of sixteen. `randomStringFromReader` is untouched: signature, error, doc comment and `TestRandomStringFromReader_ErrorPropagates` all stay, because it is the seam that proves the rejection sampler stops on a short read and a caller can still supply its own source.

Two new cases, one per half. `TestGenerateSecurityRandomString_CrashesIrrecoverablyOnReaderFailure` re-executes the test binary with `crypto/rand.Reader` swapped in the child alone and asserts a non-zero exit carrying the standard library's own fatal message; reverting the wrapper to `io.ReadFull` returning `""` leaves every other case in that file green and fails only this one. `TestMustDraw_PanicsOnShortResult` holds `fake.mustDraw` directly, which survives as the fixture package's own refusal to seed a test with a degraded value. It replaces `TestLetterN_PanicsOnEntropyFailure` and its `DigitN` twin, which swapped `crypto/rand.Reader` and called through `stringutil`: after this change they would take the whole `fake` test binary down with the runtime's fatal handler instead of observing a panic. Both mutations — the wrapper reverted to fail-open, and `mustDraw` reduced to `return s` — were caught.

Tiers: unit green, 1515 pass 0 fail across all three modules. Integration green on sqlite, 1038 pass 0 fail, run because `handler_authorize.go` is in the diff. Data not applicable: no query, migration or schema is touched.

## How this was verified

**Tiers run locally, in the dev container, at every stage gate.** Unit on all three modules,
including the three `gofmt` guards and `go vet`. Data on **all four engines** — mysql, postgres,
mssql and sqlite — at stages 2 and 3, which are the stages that touch the column and the seeder.
Integration on sqlite at stages 2, 3 and 4. Stage 1 ran unit only: nothing outside the new package's
own tests called it yet, and no query, migration or endpoint was in its diff.

**Tiers run only by the check suite.** The four-engine *integration* tier, `Unit / race`, `Lint`,
`Vulnerabilities`, `Build validation` and `Versions` have no local equivalent in this run. All of
them, plus the four `Tests /` and four `Unit /` jobs, are **green at `1a8c39c0`**, which is HEAD.

**Mutation checks.** Every stage mutated its own new code and confirmed a named test failed: the two
UUID nibble masks and the fail-open rewrite of `New` (stage 1), the `subject` JSON tag (stage 2),
five generation sites (stage 3), the `stringutil` wrapper reverted to fail-open and `mustDraw`
reduced to a pass-through (stage 4). The final review re-ran compile-clean mutations at the current
tree, because seven of those were taken on trees later stages moved; all were caught.

## Deviations from the sealed plan

1. **Two production generator lines moved from stage 3 into stage 2** (`user_creator.go`,
   `database_seeder.go`). A `uuid.UUID` does not assign to a `string` field, so the type change does
   not compile without them. Stage 3 owns six production files, not seven.
2. **Stage 3 added coverage the plan did not ask for.** Three substitution sites — the auth code, the
   rotator's `kid`, and `generateDCRClientIdentifier` — had no assertion that could catch a wrong
   value. Each is now pinned. The seeder's two `kid` values are deliberately left unpinned; the
   rotator's pin covers the same contract.
3. **Two subprocess crash tests, in stages 1 and 4, against section 5's rejected list.** Forced by
   plan-review finding 4: section 5 rejected a subprocess test on the stated ground that the OS
   source cannot be made to fail, which reading Go 1.27's `crypto/rand.Read` refuted. Without them
   the branch's central claim had nothing executable behind it.
4. **Goal 1 narrowed, by decision 8**, answered A by the owner. The module cannot leave the module
   graphs while the SQL Server and sqlite drivers require it.
5. **`_, _ = rand.Read(b[:])` rather than the bare call** in the design sketch, because `errcheck`
   is enabled for all four modules and would redden Lint.
6. **`TestParse`'s prose must not name the retired module**, since goal 1's own measure counts
   comments as well as imports.

### Review

Reviewed by `openai-codex/gpt-5.6-sol` at effort `xhigh`, 2 rounds over the whole branch at the final
gate, plus 1 round over the plan before any code was written. No stage was reviewed on its own
(`LEO_REVIEW_MODE=end`).

| Round | Findings | Blocking | Outcome |
|---|---|---|---|
| plan, 1 | 5 | 1 | 4 fixed in the plan; 1 escalated as decision 8, answered A |
| final, 1 | 3 | 0 | all confirmed, all fixed, `1a8c39c0` |
| final, 2 | 0 | 0 | clean, all three axes reviewed |

- **blocking, conformance (plan):** `google/uuid` cannot leave the module graphs — the SQL Server and
  sqlite drivers require it in all four modules. Confirmed with `go mod graph`. Escalated as decision
  8; answered **A**, goal 1 narrowed to direct imports and direct requirements.
- **significant, security (plan):** the fail-closed contract had no executable case, and the reason
  section 5 gave for that was false. Fail-open mutants of both `uuidutil.New` and `stringutil` passed
  every planned test. Answered by adding the two subprocess crash tests.
- **significant, quality (plan):** `fake.mustDraw`'s guard would be untested once stage 4 deletes the
  entropy tests. Answered by a direct short-result test in stage 4.
- **significant, quality (final 1):** `TestParse` pinned no *individual* separator position — the one
  malformed row replaced all four hyphens at once, so relaxing the check at any single index left
  another underscore to raise the error and the row passed anyway. Four mutations survived the suite.
  Fixed in `1a8c39c0`: four rows, one per index, each replacing a single hyphen. All four mutations
  are now caught at the position they target.
- **minor, quality (final 1), ×2:** `sessionstore/server_side_store.go` and its test both stated that
  `stringutil` "returns `""` when the CSPRNG fails (#211)" — a contract stage 4 deleted. Both reworded
  in `1a8c39c0` to the reason that now holds.

Nothing was refuted and nothing was deferred at any round.

Full account, with the evidence, in [this comment](https://github.com/leodip/goiabada/pull/316#issuecomment-5617850368).
Deferred decisions: [none, and why](https://github.com/leodip/goiabada/pull/316#issuecomment-5617844594).
Follow-ups, fold-ins and ceilings: [this comment](https://github.com/leodip/goiabada/pull/316#issuecomment-5617848757).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
