### PR TITLE
Dev setup: ports-free compose override so extra test stacks can run beside the dev container

### DIFF
--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -1,0 +1,102 @@
+# Dev container
+
+`devcontainer.json` plus `docker-compose.yml` is the stack VS Code opens for human development:
+a `devcontainer` service with the checkout mounted at `/workspaces/goiabada`, MySQL, PostgreSQL,
+SQL Server and Mailpit on a private network, and four ports published to the host so a person can
+reach the databases and the Mailpit UI: 13306, 15432, 11433 and 8025. Nothing below changes that
+stack.
+
+## A second stack beside it
+
+`docker-compose.worktree.yml` is an override for **automated** stacks: independent copies of the
+same five services, one per git worktree, so a test run in one worktree cannot touch another's
+files or databases, and a rebuild or reopen of the human container in VS Code cannot kill a run
+in flight. Its whole content is `ports: !reset []` on the four services that publish a port. That
+is the only thing that stops a plain `docker compose up` with a new project name from starting
+next to the live stack: the tests reach the databases by service name on the project's own
+network with fixed internal ports, and Compose prefixes the network, the volumes and the built
+image with the project name. Everything else is inherited, so `run-tests.sh` runs inside the
+second stack unchanged.
+
+### Start
+
+Run from anywhere. `--project-directory` pins the compose files' relative paths (the build
+context, the `../..` bind mount) to the worktree, so the stack mounts that checkout rather than
+whichever directory you happen to be in. Pick a project name that is not `goiabada`.
+
+```sh
+WT=/path/to/worktree          # the checkout this stack must mount
+NAME=goiabada-wt-130          # any name but goiabada, which is the human stack
+
+docker compose -p "$NAME" \
+  --project-directory "$WT/src/.devcontainer" \
+  -f "$WT/src/.devcontainer/docker-compose.yml" \
+  -f "$WT/src/.devcontainer/docker-compose.worktree.yml" \
+  up -d --wait --wait-timeout 300
+```
+
+`!reset` in an override needs Compose 2.24 or later.
+
+### Wait for readiness
+
+`up --wait` returns when every service is running, or healthy where the image declares a
+healthcheck. Only Mailpit declares one. MySQL, PostgreSQL and above all SQL Server report
+`running` well before they accept connections, and a fresh stack has no warm server to hide
+that, so wait for each database before running anything. The devcontainer image ships no
+database client; each database image ships its own, so ask each server through its own
+container:
+
+```sh
+until docker exec "$NAME-mysql-server-1" mysqladmin -P 13306 -uroot -pmySqlPass123 ping --silent >/dev/null 2>&1; do sleep 2; done
+until docker exec "$NAME-postgres-server-1" pg_isready -p 15432 -U postgres >/dev/null 2>&1; do sleep 2; done
+until docker exec "$NAME-mssql-server-1" /opt/mssql-tools18/bin/sqlcmd -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' >/dev/null 2>&1; do sleep 2; done
+```
+
+### Use
+
+The devcontainer's environment comes from `containerEnv` in `devcontainer.json`, which Compose
+never reads. VS Code injects it for the human container; for an automated stack pass every
+entry as `-e KEY=VALUE` on each `docker exec`, or the launched authserver has no configuration,
+drops into first-run setup and the integration tier times out with zero tests. `CGO_ENABLED=0`
+is among those entries and matters for the build.
+
+```sh
+docker exec -u vscode -w /workspaces/goiabada/src/authserver \
+  -e GOIABADA_DB_TYPE=mssql -e ... \
+  "$NAME-devcontainer-1" ./run-tests.sh --type data
+```
+
+One invocation of `run-tests.sh` per container at a time. It removes `/tmp/goiabada*.db*` and
+kills whatever listens on 19090 and 19091 in its own container, so two concurrent runs in one
+container would collide; separate stacks are unaffected.
+
+From Git Bash on Windows, export `MSYS_NO_PATHCONV=1` first. Otherwise the shell rewrites the
+`-w /workspaces/...` and `/opt/mssql-tools18/...` arguments above into Windows paths before
+docker sees them, and the exec fails with `Cwd must be an absolute path` or a missing binary.
+
+### Stop
+
+Take the stack down with its volumes, or the next stack under the same name inherits its
+databases:
+
+```sh
+docker compose -p "$NAME" \
+  --project-directory "$WT/src/.devcontainer" \
+  -f "$WT/src/.devcontainer/docker-compose.yml" \
+  -f "$WT/src/.devcontainer/docker-compose.worktree.yml" \
+  down -v
+```
+
+### How many
+
+Each stack costs roughly what the human one does, most of it SQL Server, which needs at least
+2 GB and is capped at 4 GB in `docker-compose.yml`. Measure before assuming there is room for
+another:
+
+```sh
+docker stats --no-stream
+```
+
+The override deliberately tunes nothing: a `command` in an override replaces rather than
+appends, so a MySQL buffer-pool flag would silently drop `--port=13306`, and SQL Server cannot
+safely go below its minimum.

--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -60,7 +60,7 @@ wait_for() {  # wait_for <label> <deadline-seconds> <probe command...>
     sleep 2
   done
 }
-wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysqladmin --connect-timeout=3 -P 13306 -uroot -pmySqlPass123 ping --silent &&
+wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysql --connect-timeout=3 -h 127.0.0.1 -P 13306 -uroot -pmySqlPass123 -e 'select 1' &&
 wait_for postgres 120 docker exec "$NAME-postgres-server-1" pg_isready -t 3 -p 15432 -U postgres &&
 wait_for mssql    300 docker exec "$NAME-mssql-server-1"    /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' ||
 exit 1
@@ -70,8 +70,12 @@ The three are chained so the first database that misses its deadline ends the wa
 failure; without the chain a later success would hide an earlier timeout.
 
 SQL Server gets the longest deadline because it is the slowest to accept its first login on a
-fresh volume. `sqlcmd` exits non-zero on a refused login as well as on an unreachable server,
-so a wrong password hits the deadline rather than looping past it.
+fresh volume. Each probe is a real login over TCP on the port the tests use, and each exits
+non-zero on a refused login as well as on an unreachable server, so a wrong password hits the
+deadline rather than looping past it. The MySQL probe is `mysql -e 'select 1'` with an explicit
+`-h 127.0.0.1` rather than `mysqladmin ping`: with no host the client takes the Unix socket and
+ignores `-P`, which answers during first-run initialisation while networking is still off, and
+`mysqladmin ping` exits zero on access denied.
 
 ### Use
 

--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -60,10 +60,14 @@ wait_for() {  # wait_for <label> <deadline-seconds> <probe command...>
     sleep 2
   done
 }
-wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysqladmin --connect-timeout=3 -P 13306 -uroot -pmySqlPass123 ping --silent
-wait_for postgres 120 docker exec "$NAME-postgres-server-1" pg_isready -t 3 -p 15432 -U postgres
-wait_for mssql    300 docker exec "$NAME-mssql-server-1"    /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1'
+wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysqladmin --connect-timeout=3 -P 13306 -uroot -pmySqlPass123 ping --silent &&
+wait_for postgres 120 docker exec "$NAME-postgres-server-1" pg_isready -t 3 -p 15432 -U postgres &&
+wait_for mssql    300 docker exec "$NAME-mssql-server-1"    /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' ||
+exit 1
 ```
+
+The three are chained so the first database that misses its deadline ends the wait with a
+failure; without the chain a later success would hide an earlier timeout.
 
 SQL Server gets the longest deadline because it is the slowest to accept its first login on a
 fresh volume. `sqlcmd` exits non-zero on a refused login as well as on an unreachable server,

--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -46,11 +46,28 @@ that, so wait for each database before running anything. The devcontainer image 
 database client; each database image ships its own, so ask each server through its own
 container:
 
+Every probe is bounded twice: a short client timeout, so one hung connection cannot stall the
+loop (the MySQL image's default `--connect-timeout` is 43,200 seconds), and a deadline on the
+whole wait, so a server that is running but broken, or a wrong password, fails the run instead
+of holding it forever:
+
 ```sh
-until docker exec "$NAME-mysql-server-1" mysqladmin -P 13306 -uroot -pmySqlPass123 ping --silent >/dev/null 2>&1; do sleep 2; done
-until docker exec "$NAME-postgres-server-1" pg_isready -p 15432 -U postgres >/dev/null 2>&1; do sleep 2; done
-until docker exec "$NAME-mssql-server-1" /opt/mssql-tools18/bin/sqlcmd -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' >/dev/null 2>&1; do sleep 2; done
+wait_for() {  # wait_for <label> <deadline-seconds> <probe command...>
+  local label=$1 deadline=$2; shift 2
+  local t0=$SECONDS
+  until "$@" >/dev/null 2>&1; do
+    if (( SECONDS - t0 >= deadline )); then echo "$label not ready after ${deadline}s" >&2; return 1; fi
+    sleep 2
+  done
+}
+wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysqladmin --connect-timeout=3 -P 13306 -uroot -pmySqlPass123 ping --silent
+wait_for postgres 120 docker exec "$NAME-postgres-server-1" pg_isready -t 3 -p 15432 -U postgres
+wait_for mssql    300 docker exec "$NAME-mssql-server-1"    /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1'
 ```
+
+SQL Server gets the longest deadline because it is the slowest to accept its first login on a
+fresh volume. `sqlcmd` exits non-zero on a refused login as well as on an unreachable server,
+so a wrong password hits the deadline rather than looping past it.
 
 ### Use
 

--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -60,9 +60,9 @@ wait_for() {  # wait_for <label> <deadline-seconds> <probe command...>
     sleep 2
   done
 }
-wait_for mysql    120 docker exec "$NAME-mysql-server-1"    mysql --connect-timeout=3 -h 127.0.0.1 -P 13306 -uroot -pmySqlPass123 -e 'select 1' &&
-wait_for postgres 120 docker exec "$NAME-postgres-server-1" pg_isready -t 3 -p 15432 -U postgres &&
-wait_for mssql    300 docker exec "$NAME-mssql-server-1"    /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S localhost,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' ||
+wait_for mysql    120 docker exec "$NAME-mysql-server-1"   mysql --connect-timeout=3 -h mysql-server -P 13306 -uroot -pmySqlPass123 -e 'select 1' &&
+wait_for postgres 120 docker exec -e PGCONNECT_TIMEOUT=3 -e PGPASSWORD=myPostgresPass123 "$NAME-postgres-server-1"   psql -h postgres-server -p 15432 -U postgres -c 'select 1' &&
+wait_for mssql    300 docker exec "$NAME-mssql-server-1"   /opt/mssql-tools18/bin/sqlcmd -l 3 -t 3 -S mssql-server,11433 -U sa -P 'YourStr0ngPassw0rd!' -C -Q 'select 1' ||
 exit 1
 ```
 
@@ -70,12 +70,14 @@ The three are chained so the first database that misses its deadline ends the wa
 failure; without the chain a later success would hide an earlier timeout.
 
 SQL Server gets the longest deadline because it is the slowest to accept its first login on a
-fresh volume. Each probe is a real login over TCP on the port the tests use, and each exits
-non-zero on a refused login as well as on an unreachable server, so a wrong password hits the
-deadline rather than looping past it. The MySQL probe is `mysql -e 'select 1'` with an explicit
-`-h 127.0.0.1` rather than `mysqladmin ping`: with no host the client takes the Unix socket and
-ignores `-P`, which answers during first-run initialisation while networking is still off, and
-`mysqladmin ping` exits zero on access denied.
+fresh volume. Each probe is an authenticated query over TCP through the same service name, port
+and credentials the tests use, so it is answered by the same rule the tests will be, and each
+exits non-zero on a refused login as well as on an unreachable server, so a wrong password hits
+the deadline rather than looping past it. Two shortcuts that look equivalent are not:
+`mysqladmin ping` and `pg_isready` do not authenticate, and both take a Unix socket when no host
+is given, which answers before networking is up. And `127.0.0.1` is not the tests' path either:
+PostgreSQL's `pg_hba.conf` trusts loopback without a password, so only the service name reaches
+the `scram-sha-256` rule the tests are held to.
 
 ### Use
 

--- a/src/.devcontainer/docker-compose.worktree.yml
+++ b/src/.devcontainer/docker-compose.worktree.yml
@@ -1,0 +1,25 @@
+# Override for automated stacks: same services, no host-published ports.
+#
+# Apply it on top of docker-compose.yml, with a project name, to bring up an
+# independent copy of the dev stack beside the one VS Code runs, one per git
+# worktree. The four `ports:` entries in docker-compose.yml are the only thing
+# that stops a second stack from starting: they exist for a person with a
+# browser or a database client, not for the tests, which reach the databases
+# by service name on the project's private network. Everything else (image,
+# service names, internal ports, `command`, volumes) is inherited unchanged,
+# so run-tests.sh works inside the second stack as it is.
+#
+# `!reset` needs Compose 2.24 or later. Never apply this file to the human
+# container: VS Code reads docker-compose.yml alone, and keeps its ports.
+#
+# See README.md in this directory for how to start, wait for, use and tear
+# down such a stack.
+services:
+  mysql-server:
+    ports: !reset []
+  postgres-server:
+    ports: !reset []
+  mssql-server:
+    ports: !reset []
+  mailpit:
+    ports: !reset []


### PR DESCRIPTION
Closes #318.

## What

- `src/.devcontainer/docker-compose.worktree.yml`: an override whose whole content is `ports: !reset []` on `mysql-server`, `postgres-server`, `mssql-server` and `mailpit`. Those four host-published ports were the only thing stopping a second stack under another project name from starting beside the live one. Everything else is inherited, so `run-tests.sh` runs in the second stack unchanged, and the human container, which VS Code opens from `docker-compose.yml` alone, keeps its ports.
- `src/.devcontainer/README.md`: how to start a stack from a worktree with `--project-directory` and absolute `-f` paths, wait for readiness, exec into it with the `containerEnv` entries as `-e` flags (Compose never reads `devcontainer.json`), one `run-tests.sh` invocation per container, `down -v` to tear down, and `docker stats --no-stream` to measure before adding another.

## Readiness

`up --wait` covers Mailpit only, since the database images declare no healthcheck. The README's wait is three authenticated `select 1` queries over TCP through the same service name, port and credentials the tests use, each with a 3-second client timeout, each under a per-database deadline, chained so the first miss ends the wait with a failure. `mysqladmin ping` and `pg_isready` were rejected because they do not authenticate and take the Unix socket when no host is given, and loopback was rejected because the PostgreSQL image's `pg_hba.conf` trusts it without a password.

## Verified

- `docker compose -f docker-compose.yml -f docker-compose.worktree.yml config` shows no `ports:` on any service.
- A `goiabada-wt-test` stack came up beside the live dev container from a second worktree, with its own volumes and network, and `docker inspect` showed `/workspaces/goiabada` mounted from that worktree.
- `run-tests.sh --type data` passed on all four engines in both containers at the same time.
- The human container's ID and start time were unchanged throughout, and its ports are intact.
- The README's readiness block, run verbatim against the live stack, exits 0; with a wrong password substituted at any of the three positions it names the database and exits 1.

## Out of scope, as in the issue

Per-worktree database name suffixes, healthchecks on the database services, and moving `containerEnv` into an `env_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9PkqExKU3jmpFCfSpHwde
