### PR TITLE
docs(ceremony): state tables, field rule and agent-docs guard for the auth ceremony (#252)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,17 +166,19 @@ it accepts:
 | `/auth/issue` | `handler_auth_issue.go` | Issues authorization code, redirects to client |
 
 ### AuthContext field rule
-A field on `AuthContext` that accumulates across hops and is not recomputed on every hop must be
-discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
+A field on `AuthContext` that accumulates across hops and is not overwritten before it is next read
+must be discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
 with the abandoned attempt's values still on the context. There are two restart routes:
 `HandleAuthCompletedGet` when no session is reusable and level 1 was never completed, and
 `refuseIssuanceUnusableSession` at `/auth/issue` when the bound session is gone, expired or foreign
 and the request is not `prompt=none`. `AuthMethods` is the one field breaking the rule today:
 `AddAuthMethod` appends to it, nothing recomputes it, and it survives both routes onto the session
 row the second pass creates, so a restarted ceremony can mint `amr` values the second pass never
-earned (#140 fixes this; delete this sentence when it lands). Every other field is either recomputed
-on every hop (`AuthenticatedAt`, `OtpConfigGeneration`, `AcrLevel`, `OTPKeyURL`) or, like
-`ConsentedScope`, coherent by construction rather than by rule. The request-derived fields are
+earned (#140 fixes this; delete this sentence when it lands). No other field is recomputed at every hop
+either; each is instead overwritten before anything reads it again on every path out of a restart —
+`AuthenticatedAt` and `OtpConfigGeneration` at `/auth/pwd`, `AcrLevel` by `SetAcrLevel` at
+`/auth/completed`, `OTPKeyURL` on every arm of `/auth/otp`, the only hops that read it — while
+`ConsentedScope` is coherent by construction rather than by rule. The request-derived fields are
 written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
 `TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Programmatic client registration for MCP servers, native apps, etc.
 
 ## Authentication Flow (Authorization Code)
 
-The auth code flow uses a state machine tracked in `AuthContext` (stored in session cookie).
+The auth code flow uses a state machine tracked in `AuthContext` (stored in the server-side session store, keyed by a cookie (#266)).
 
 ### ACR Levels (Authentication Context Class Reference)
 Defined in `src/core/enums/enums.go`:
@@ -108,20 +108,49 @@ Defined in `src/core/enums/enums.go`:
 Target ACR determined by: `acr_values` param in authorize request → falls back to `Client.DefaultAcrLevel`
 
 ### Auth States (State Machine)
-Defined in `src/core/oauth/auth_context.go`. States transition in this order:
+The values below are the string constants declared in `src/core/oauth/auth_context.go`, and
+`AssertAgentDocs` in `core/testutil/agentdocs.go` holds this section's roster to them: a state
+declared there with no row here, or a row here naming no constant, fails every module's unit tier.
+There is no single order: a ceremony's path depends on the target ACR, the session, and `prompt`.
 
-1. **`AuthStateInitial`** - Entry point at `/auth/authorize`
-2. **`AuthStateRequiresLevel1`** - No valid session, needs level1 auth
-3. **`AuthStateLevel1Password`** - User at password form
-4. **`AuthStateLevel1PasswordCompleted`** - Password verified, deciding next step
-5. **`AuthStateRequiresLevel2`** - Level2 auth needed (based on ACR)
-6. **`AuthStateLevel2OTP`** - User at OTP form (or enrollment)
-7. **`AuthStateLevel2OTPCompleted`** - OTP verified
-8. **`AuthStateAuthenticationCompleted`** - All auth done, checking consent
-9. **`AuthStateRequiresConsent`** - Showing consent screen (if `client.ConsentRequired` or `offline_access` scope)
-10. **`AuthStateReadyToIssueCode`** - Ready to issue code and redirect to client
+| State | Assigned by | When |
+|---|---|---|
+| `initial` | `HandleAuthorizeGet` | the composite literal, before validation. Dead: no gate accepts it, so it is only ever overwritten. #248 part 2 deletes it |
+| `requires_level_1` | `HandleAuthorizeGet` | four sites: a deferred error is parked; `prompt=login`; `id_token_hint` names another user; no valid session |
+| | `HandleAuthCompletedGet` | no reusable session and `!Level1AuthCompleted` (restart route 1) |
+| | `refuseIssuanceUnusableSession` | bound session gone, expired or foreign, and not `prompt=none` (restart route 2) |
+| `level1_password` | `HandleAuthLevel1Get` | unconditional |
+| `level1_password_completed` | `HandleAuthPwdPost` | password verified, user enabled |
+| `level1_existing_session` | `HandleAuthorizeGet` | valid session, hint matches, user enabled. The SSO shortcut: password entry is skipped and `/auth/level1completed` accepts this state directly |
+| `requires_level_2` | `HandleAuthLevel1CompletedGet` | target ACR above the owned session's ACR, or above level 1 with no owned session, or the session's `OtpConfigGeneration` differs from the user's and the target is above level 1 |
+| `level2_otp` | `HandleAuthLevel2Get` | `level2_optional` with OTP enabled, or `level2_mandatory` (enrolment happens at `/auth/otp` if needed) |
+| `level2_otp_completed` | nobody | Dead: declared and assigned nowhere. #248 part 2 deletes it |
+| `authentication_completed` | `HandleAuthLevel1CompletedGet` | no step-up needed |
+| | `HandleAuthLevel2Get` | `level2_optional` and no OTP enrolled, which is the skip that bypasses `/auth/otp` entirely |
+| | `HandleAuthOtpPost` | OTP verified or enrolled |
+| `requires_consent` | `HandleAuthCompletedGet` | `prompt=consent`, or `client.ConsentRequired`, or `offline_access` in scope |
+| `ready_to_issue_code` | `handlePromptNone` | every silent check passed, skipping every hop between |
+| | `HandleAuthCompletedGet` | no consent needed |
+| | `HandleConsentGet` | scope already fully consented, no `offline_access`, no `prompt=consent` |
+| | `HandleConsentPost` | approved with at least one scope |
 
-**Shortcut for existing session**: If user has valid session, flow goes `AuthStateInitial` → `AuthStateLevel1ExistingSession` → `AuthStateLevel1PasswordCompleted` (skipping password entry), then continues from step 4.
+Each route then gates on the state it finds, and answers `rejectAuthStateMismatch` when it is not one
+it accepts:
+
+| Route | Method | Accepts | On mismatch |
+|---|---|---|---|
+| `/auth/authorize` | GET, POST | anything, mints a new context | n/a |
+| `/auth/level1` | GET | `requires_level_1` | 400 |
+| `/auth/pwd` | GET | `level1_password` | 400 |
+| `/auth/pwd` | POST | ceremony id first, then `level1_password` | 400, 400 |
+| `/auth/level1completed` | GET | `level1_password_completed`, `level1_existing_session` | **500**, the one gate c499ec51 missed when it converted the other ten to 400. #248 part 1 |
+| `/auth/level2` | GET | `requires_level_2` | 400 |
+| `/auth/otp` | GET | `level2_otp` | 400 |
+| `/auth/otp` | POST | ceremony id first, then `level2_otp` | 400, 400 |
+| `/auth/completed` | GET | `authentication_completed` | 400 |
+| `/auth/consent` | GET | `requires_consent` | 400 |
+| `/auth/consent` | POST | ceremony id first, then `requires_consent` | 400, 400 |
+| `/auth/issue` | GET | `ready_to_issue_code` | 400 |
 
 ### Flow Handlers (in order)
 | Handler | File | Purpose |
@@ -135,6 +164,21 @@ Defined in `src/core/oauth/auth_context.go`. States transition in this order:
 | `/auth/completed` | `handler_auth_completed.go` | Final auth check, scope filtering, consent check, session bump/create |
 | `/auth/consent` | `handler_consent.go` | User consent screen (if required) |
 | `/auth/issue` | `handler_auth_issue.go` | Issues authorization code, redirects to client |
+
+### AuthContext field rule
+A field on `AuthContext` that accumulates across hops and is not recomputed on every hop must be
+discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
+with the abandoned attempt's values still on the context. There are two restart routes:
+`HandleAuthCompletedGet` when no session is reusable and level 1 was never completed, and
+`refuseIssuanceUnusableSession` at `/auth/issue` when the bound session is gone, expired or foreign
+and the request is not `prompt=none`. `AuthMethods` is the one field breaking the rule today:
+`AddAuthMethod` appends to it, nothing recomputes it, and it survives both routes onto the session
+row the second pass creates, so a restarted ceremony can mint `amr` values the second pass never
+earned (#140 fixes this; delete this sentence when it lands). Every other field is either recomputed
+on every hop (`AuthenticatedAt`, `OtpConfigGeneration`, `AcrLevel`, `OTPKeyURL`) or, like
+`ConsentedScope`, coherent by construction rather than by rule. The request-derived fields are
+written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
+`TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 
 ### Deferred error redirects (#213)
 `/auth/authorize` never redirects an unauthenticated browser to a client's `redirect_uri` on a failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,8 +177,10 @@ row the second pass creates, so a restarted ceremony can mint `amr` values the s
 earned (#140 fixes this; delete this sentence when it lands). No other field is recomputed at every hop
 either; each is instead overwritten before anything reads it again on every path out of a restart —
 `AuthenticatedAt` and `OtpConfigGeneration` at `/auth/pwd`, `AcrLevel` by `SetAcrLevel` at
-`/auth/completed`, `OTPKeyURL` on every arm of `/auth/otp`, the only hops that read it — while
-`ConsentedScope` is coherent by construction rather than by rule. The request-derived fields are
+`/auth/completed` — while `ConsentedScope` is coherent by construction rather than by rule, and
+`OTPKeyURL` by reachability: the enrolment arm of `HandleAuthOtpGet` deliberately keeps a parseable
+key rather than replacing it (#242 part 3), but it is set only while the ceremony sits at
+`level2_otp`, and the one transition out of that state clears it. The request-derived fields are
 written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
 `TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,17 +166,19 @@ it accepts:
 | `/auth/issue` | `handler_auth_issue.go` | Issues authorization code, redirects to client |
 
 ### AuthContext field rule
-A field on `AuthContext` that accumulates across hops and is not recomputed on every hop must be
-discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
+A field on `AuthContext` that accumulates across hops and is not overwritten before it is next read
+must be discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
 with the abandoned attempt's values still on the context. There are two restart routes:
 `HandleAuthCompletedGet` when no session is reusable and level 1 was never completed, and
 `refuseIssuanceUnusableSession` at `/auth/issue` when the bound session is gone, expired or foreign
 and the request is not `prompt=none`. `AuthMethods` is the one field breaking the rule today:
 `AddAuthMethod` appends to it, nothing recomputes it, and it survives both routes onto the session
 row the second pass creates, so a restarted ceremony can mint `amr` values the second pass never
-earned (#140 fixes this; delete this sentence when it lands). Every other field is either recomputed
-on every hop (`AuthenticatedAt`, `OtpConfigGeneration`, `AcrLevel`, `OTPKeyURL`) or, like
-`ConsentedScope`, coherent by construction rather than by rule. The request-derived fields are
+earned (#140 fixes this; delete this sentence when it lands). No other field is recomputed at every hop
+either; each is instead overwritten before anything reads it again on every path out of a restart —
+`AuthenticatedAt` and `OtpConfigGeneration` at `/auth/pwd`, `AcrLevel` by `SetAcrLevel` at
+`/auth/completed`, `OTPKeyURL` on every arm of `/auth/otp`, the only hops that read it — while
+`ConsentedScope` is coherent by construction rather than by rule. The request-derived fields are
 written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
 `TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Programmatic client registration for MCP servers, native apps, etc.
 
 ## Authentication Flow (Authorization Code)
 
-The auth code flow uses a state machine tracked in `AuthContext` (stored in session cookie).
+The auth code flow uses a state machine tracked in `AuthContext` (stored in the server-side session store, keyed by a cookie (#266)).
 
 ### ACR Levels (Authentication Context Class Reference)
 Defined in `src/core/enums/enums.go`:
@@ -108,20 +108,49 @@ Defined in `src/core/enums/enums.go`:
 Target ACR determined by: `acr_values` param in authorize request → falls back to `Client.DefaultAcrLevel`
 
 ### Auth States (State Machine)
-Defined in `src/core/oauth/auth_context.go`. States transition in this order:
+The values below are the string constants declared in `src/core/oauth/auth_context.go`, and
+`AssertAgentDocs` in `core/testutil/agentdocs.go` holds this section's roster to them: a state
+declared there with no row here, or a row here naming no constant, fails every module's unit tier.
+There is no single order: a ceremony's path depends on the target ACR, the session, and `prompt`.
 
-1. **`AuthStateInitial`** - Entry point at `/auth/authorize`
-2. **`AuthStateRequiresLevel1`** - No valid session, needs level1 auth
-3. **`AuthStateLevel1Password`** - User at password form
-4. **`AuthStateLevel1PasswordCompleted`** - Password verified, deciding next step
-5. **`AuthStateRequiresLevel2`** - Level2 auth needed (based on ACR)
-6. **`AuthStateLevel2OTP`** - User at OTP form (or enrollment)
-7. **`AuthStateLevel2OTPCompleted`** - OTP verified
-8. **`AuthStateAuthenticationCompleted`** - All auth done, checking consent
-9. **`AuthStateRequiresConsent`** - Showing consent screen (if `client.ConsentRequired` or `offline_access` scope)
-10. **`AuthStateReadyToIssueCode`** - Ready to issue code and redirect to client
+| State | Assigned by | When |
+|---|---|---|
+| `initial` | `HandleAuthorizeGet` | the composite literal, before validation. Dead: no gate accepts it, so it is only ever overwritten. #248 part 2 deletes it |
+| `requires_level_1` | `HandleAuthorizeGet` | four sites: a deferred error is parked; `prompt=login`; `id_token_hint` names another user; no valid session |
+| | `HandleAuthCompletedGet` | no reusable session and `!Level1AuthCompleted` (restart route 1) |
+| | `refuseIssuanceUnusableSession` | bound session gone, expired or foreign, and not `prompt=none` (restart route 2) |
+| `level1_password` | `HandleAuthLevel1Get` | unconditional |
+| `level1_password_completed` | `HandleAuthPwdPost` | password verified, user enabled |
+| `level1_existing_session` | `HandleAuthorizeGet` | valid session, hint matches, user enabled. The SSO shortcut: password entry is skipped and `/auth/level1completed` accepts this state directly |
+| `requires_level_2` | `HandleAuthLevel1CompletedGet` | target ACR above the owned session's ACR, or above level 1 with no owned session, or the session's `OtpConfigGeneration` differs from the user's and the target is above level 1 |
+| `level2_otp` | `HandleAuthLevel2Get` | `level2_optional` with OTP enabled, or `level2_mandatory` (enrolment happens at `/auth/otp` if needed) |
+| `level2_otp_completed` | nobody | Dead: declared and assigned nowhere. #248 part 2 deletes it |
+| `authentication_completed` | `HandleAuthLevel1CompletedGet` | no step-up needed |
+| | `HandleAuthLevel2Get` | `level2_optional` and no OTP enrolled, which is the skip that bypasses `/auth/otp` entirely |
+| | `HandleAuthOtpPost` | OTP verified or enrolled |
+| `requires_consent` | `HandleAuthCompletedGet` | `prompt=consent`, or `client.ConsentRequired`, or `offline_access` in scope |
+| `ready_to_issue_code` | `handlePromptNone` | every silent check passed, skipping every hop between |
+| | `HandleAuthCompletedGet` | no consent needed |
+| | `HandleConsentGet` | scope already fully consented, no `offline_access`, no `prompt=consent` |
+| | `HandleConsentPost` | approved with at least one scope |
 
-**Shortcut for existing session**: If user has valid session, flow goes `AuthStateInitial` → `AuthStateLevel1ExistingSession` → `AuthStateLevel1PasswordCompleted` (skipping password entry), then continues from step 4.
+Each route then gates on the state it finds, and answers `rejectAuthStateMismatch` when it is not one
+it accepts:
+
+| Route | Method | Accepts | On mismatch |
+|---|---|---|---|
+| `/auth/authorize` | GET, POST | anything, mints a new context | n/a |
+| `/auth/level1` | GET | `requires_level_1` | 400 |
+| `/auth/pwd` | GET | `level1_password` | 400 |
+| `/auth/pwd` | POST | ceremony id first, then `level1_password` | 400, 400 |
+| `/auth/level1completed` | GET | `level1_password_completed`, `level1_existing_session` | **500**, the one gate c499ec51 missed when it converted the other ten to 400. #248 part 1 |
+| `/auth/level2` | GET | `requires_level_2` | 400 |
+| `/auth/otp` | GET | `level2_otp` | 400 |
+| `/auth/otp` | POST | ceremony id first, then `level2_otp` | 400, 400 |
+| `/auth/completed` | GET | `authentication_completed` | 400 |
+| `/auth/consent` | GET | `requires_consent` | 400 |
+| `/auth/consent` | POST | ceremony id first, then `requires_consent` | 400, 400 |
+| `/auth/issue` | GET | `ready_to_issue_code` | 400 |
 
 ### Flow Handlers (in order)
 | Handler | File | Purpose |
@@ -135,6 +164,21 @@ Defined in `src/core/oauth/auth_context.go`. States transition in this order:
 | `/auth/completed` | `handler_auth_completed.go` | Final auth check, scope filtering, consent check, session bump/create |
 | `/auth/consent` | `handler_consent.go` | User consent screen (if required) |
 | `/auth/issue` | `handler_auth_issue.go` | Issues authorization code, redirects to client |
+
+### AuthContext field rule
+A field on `AuthContext` that accumulates across hops and is not recomputed on every hop must be
+discarded when the ceremony restarts, because a restart sends the browser back to `requires_level_1`
+with the abandoned attempt's values still on the context. There are two restart routes:
+`HandleAuthCompletedGet` when no session is reusable and level 1 was never completed, and
+`refuseIssuanceUnusableSession` at `/auth/issue` when the bound session is gone, expired or foreign
+and the request is not `prompt=none`. `AuthMethods` is the one field breaking the rule today:
+`AddAuthMethod` appends to it, nothing recomputes it, and it survives both routes onto the session
+row the second pass creates, so a restarted ceremony can mint `amr` values the second pass never
+earned (#140 fixes this; delete this sentence when it lands). Every other field is either recomputed
+on every hop (`AuthenticatedAt`, `OtpConfigGeneration`, `AcrLevel`, `OTPKeyURL`) or, like
+`ConsentedScope`, coherent by construction rather than by rule. The request-derived fields are
+written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
+`TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 
 ### Deferred error redirects (#213)
 `/auth/authorize` never redirects an unauthenticated browser to a client's `redirect_uri` on a failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,10 @@ row the second pass creates, so a restarted ceremony can mint `amr` values the s
 earned (#140 fixes this; delete this sentence when it lands). No other field is recomputed at every hop
 either; each is instead overwritten before anything reads it again on every path out of a restart —
 `AuthenticatedAt` and `OtpConfigGeneration` at `/auth/pwd`, `AcrLevel` by `SetAcrLevel` at
-`/auth/completed`, `OTPKeyURL` on every arm of `/auth/otp`, the only hops that read it — while
-`ConsentedScope` is coherent by construction rather than by rule. The request-derived fields are
+`/auth/completed` — while `ConsentedScope` is coherent by construction rather than by rule, and
+`OTPKeyURL` by reachability: the enrolment arm of `HandleAuthOtpGet` deliberately keeps a parseable
+key rather than replacing it (#242 part 3), but it is set only while the ceremony sits at
+`level2_otp`, and the one transition out of that state clears it. The request-derived fields are
 written once and only at `/auth/authorize` — the composite literal in `HandleAuthorizeGet` plus
 `TargetAcrLevel`, set immediately after validation and nowhere else — which #248 pins with a test.
 

--- a/site/src/content/docs/concepts/acr-amr.mdx
+++ b/site/src/content/docs/concepts/acr-amr.mdx
@@ -46,6 +46,8 @@ The AMR claim in the ID token contains all methods used during authentication. F
 - Password only: `"amr": ["pwd"]`
 - Password + OTP: `"amr": ["pwd", "otp"]`
 
+Goiabada never emits the `mfa` value. Check `amr` for the methods and `acr` for the level: `["pwd", "otp"]` already tells you two factors were used.
+
 ## Configuring ACR levels
 
 ### Default ACR per client
@@ -146,6 +148,8 @@ If the session's ACR is **lower** than the requested ACR, the user must perform 
 - Result: User must enter their OTP code
 
 After step-up, the session's ACR is upgraded to the higher level. This upgrade persists for the session lifetime. The user won't need to step up again for the same or lower ACR levels.
+
+The `auth_time` claim moves too: it becomes the time the OTP was entered, not the time of the first sign-in. Only `prompt=none` and plain session reuse keep the earlier time, and no claim carries the first factor's time after a step-up.
 
 <Aside type="note">
 ACR levels can only be **upgraded** during a session, never downgraded. Once a user authenticates at `level2_mandatory`, their session stays at that level until it expires.

--- a/site/src/content/docs/concepts/acr-amr.mdx
+++ b/site/src/content/docs/concepts/acr-amr.mdx
@@ -149,7 +149,7 @@ If the session's ACR is **lower** than the requested ACR, the user must perform 
 
 After step-up, the session's ACR is upgraded to the higher level. This upgrade persists for the session lifetime. The user won't need to step up again for the same or lower ACR levels.
 
-The `auth_time` claim moves too: it becomes the time the OTP was entered, not the time of the first sign-in. Only `prompt=none` and plain session reuse keep the earlier time, and no claim carries the first factor's time after a step-up.
+The `auth_time` claim moves too: it becomes the time the OTP was verified, not the time of the first sign-in. Only `prompt=none` and plain session reuse keep the earlier time, and no claim carries the first factor's time after a step-up.
 
 <Aside type="note">
 ACR levels can only be **upgraded** during a session, never downgraded. Once a user authenticates at `level2_mandatory`, their session stays at that level until it expires.

--- a/site/src/content/docs/concepts/acr-amr.mdx
+++ b/site/src/content/docs/concepts/acr-amr.mdx
@@ -46,7 +46,7 @@ The AMR claim in the ID token contains all methods used during authentication. F
 - Password only: `"amr": ["pwd"]`
 - Password + OTP: `"amr": ["pwd", "otp"]`
 
-Goiabada never emits the `mfa` value. Check `amr` for the methods and `acr` for the level: `["pwd", "otp"]` already tells you two factors were used.
+Goiabada never emits the `mfa` value, because it would add nothing that is not already there: `amr` lists the methods and `acr` names the level. Read those two claims rather than looking for `mfa`.
 
 ## Configuring ACR levels
 

--- a/site/src/content/docs/concepts/authorization-lifecycle.mdx
+++ b/site/src/content/docs/concepts/authorization-lifecycle.mdx
@@ -218,7 +218,7 @@ The authorization code is generated and delivered to the client using the respon
 
 The code is then exchanged for tokens at the token endpoint.
 
-The `auth_time` claim in the resulting ID token reflects when the authorization code was created, except for `prompt=none`, which preserves the original authentication time from the session for consistency.
+The `auth_time` claim in the resulting ID token is the moment the user last entered a credential, not the moment the code was issued. A session reused without re-authentication, including `prompt=none`, keeps the session's time.
 
 ## How parameters interact
 

--- a/site/src/content/docs/concepts/authorization-lifecycle.mdx
+++ b/site/src/content/docs/concepts/authorization-lifecycle.mdx
@@ -218,7 +218,7 @@ The authorization code is generated and delivered to the client using the respon
 
 The code is then exchanged for tokens at the token endpoint.
 
-The `auth_time` claim in the resulting ID token is the moment the user last entered a credential, not the moment the code was issued. A session reused without re-authentication, including `prompt=none`, keeps the session's time.
+The `auth_time` claim in the resulting ID token is the moment the user's last credential was verified, not the moment the code was issued. A session reused without re-authentication, including `prompt=none`, keeps the session's time.
 
 ## How parameters interact
 

--- a/src/adminconsole/internal/server/agentdocs_lint_test.go
+++ b/src/adminconsole/internal/server/agentdocs_lint_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/leodip/goiabada/core/testutil"
+)
+
+// TestAgentDocsAreCurrent fails the adminconsole unit tier when CLAUDE.md and
+// AGENTS.md have drifted apart, or when the states CLAUDE.md's "Auth States"
+// section lists are not exactly the ones src/core/oauth/auth_context.go
+// declares. testutil.AssertAgentDocs carries the reasoning, including why the
+// roster is checked and the transitions are not. Core and the auth server call
+// it from their own tiers.
+func TestAgentDocsAreCurrent(t *testing.T) {
+	testutil.AssertAgentDocs(t)
+}

--- a/src/authserver/internal/handlers/handler_auth_completed.go
+++ b/src/authserver/internal/handlers/handler_auth_completed.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/leodip/goiabada/core/config"
 	"github.com/leodip/goiabada/core/constants"
@@ -89,8 +88,10 @@ func HandleAuthCompletedGet(
 		// authContext.AuthenticatedAt is set when the user actually enters credentials in
 		// this ceremony, by the password handler and by the OTP handler. It is nil for SSO
 		// session reuse (existing session flows through level1completed without hitting
-		// either). Used only to decide whether to refresh the session's AuthTime below:
-		// it is NOT proof of level 1, since OTP alone sets it (#129 decision 15).
+		// either). It decides whether the session's AuthTime is refreshed below and, on both
+		// arms, is the value written: it is the instant the credential was accepted, which is
+		// what auth_time means (#252 decision 8). It is NOT proof of level 1, since OTP alone
+		// sets it (#129 decision 15).
 		userReallyAuthenticated := authContext.AuthenticatedAt != nil && !authContext.AuthenticatedAt.IsZero()
 
 		// The session this ceremony actually bound to, which is what the ACR below is taken
@@ -139,8 +140,17 @@ func HandleAuthCompletedGet(
 				// BumpUserSession preserves the old AuthTime (correct for SSO reuse
 				// in handler_authorize.go), but here the user actually entered
 				// credentials again, so refresh AuthTime to reflect that.
-				utcNow := time.Now().UTC()
-				bumpedSession.AuthTime = utcNow
+				//
+				// The value is the one the credential handler captured, never the clock read
+				// here. auth_time is what max_age is measured against, "the last time the
+				// End-User was actively authenticated by the OP" in OIDC Core 3.1.2.1, and
+				// the browser owns the hop between the credential and this handler: reading
+				// the clock here lets a tab paused after the password was accepted and
+				// resumed hours later mint a token saying the user authenticated just now,
+				// so a relying party that asked for a fresh sign-in is told it got one
+				// (#252 decision 8). userReallyAuthenticated is exactly the guard that makes
+				// the dereference safe: non-nil and non-zero.
+				bumpedSession.AuthTime = authContext.AuthenticatedAt.UTC()
 				err = database.UpdateUserSession(nil, bumpedSession)
 				if err != nil {
 					httpHelper.InternalServerError(w, r, err)
@@ -282,9 +292,16 @@ func HandleAuthCompletedGet(
 			}
 
 			// start new session
+			// AuthenticatedAt is the credential's instant, and it is what the new row's
+			// AuthTime is stamped with rather than the clock inside StartNewUserSession, for
+			// the reason the reuse arm above gives (#252 decision 8). It is always set here:
+			// the gate above refuses to mint a session without Level1AuthCompleted, and the
+			// password handler is the only writer of that field, setting AuthenticatedAt
+			// beside it.
 			newSession, err := userSessionManager.StartNewUserSession(
 				w, r, authContext.UserId, client.Id, authContext.AuthMethods, targetAcrLevel.String(),
-				authContext.AuthStateGeneration, authContext.OtpConfigGeneration)
+				authContext.AuthStateGeneration, authContext.OtpConfigGeneration,
+				authContext.AuthenticatedAt)
 			if err != nil {
 				httpHelper.InternalServerError(w, r, err)
 				return

--- a/src/authserver/internal/handlers/handler_auth_completed.go
+++ b/src/authserver/internal/handlers/handler_auth_completed.go
@@ -297,7 +297,9 @@ func HandleAuthCompletedGet(
 			// the reason the reuse arm above gives (#252 decision 8). It is always set here:
 			// the gate above refuses to mint a session without Level1AuthCompleted, and the
 			// password handler is the only writer of that field, setting AuthenticatedAt
-			// beside it.
+			// beside it. StartNewUserSession refuses a nil or zero instant rather than
+			// inventing one, so if that invariant ever breaks this arm answers 500 instead of
+			// minting a session that claims a sign-in happened just now.
 			newSession, err := userSessionManager.StartNewUserSession(
 				w, r, authContext.UserId, client.Id, authContext.AuthMethods, targetAcrLevel.String(),
 				authContext.AuthStateGeneration, authContext.OtpConfigGeneration,

--- a/src/authserver/internal/handlers/handler_auth_completed_test.go
+++ b/src/authserver/internal/handlers/handler_auth_completed_test.go
@@ -269,7 +269,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AuthTime: newAuthTime,
 		}
 		userSessionManager.On("StartNewUserSession", rr, req, int64(2), int64(1), "pwd",
-			enums.AcrLevel1.String(), int64(3), (*int64)(nil)).
+			enums.AcrLevel1.String(), int64(3), (*int64)(nil), &pwdAuthTime).
 			Run(func(mock.Arguments) { sequence = append(sequence, "session-created") }).
 			Return(newSession, nil)
 
@@ -419,7 +419,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AuthTime: newAuthTime,
 		}
 		userSessionManager.On("StartNewUserSession", rr, req, int64(2), int64(1), "pwd",
-			enums.AcrLevel1.String(), int64(3), (*int64)(nil)).Return(newSession, nil)
+			enums.AcrLevel1.String(), int64(3), (*int64)(nil), &pwdAuthTime).Return(newSession, nil)
 
 		user := &models.User{Id: 2, Enabled: true}
 		database.On("GetUserById", mock.Anything, int64(2)).Return(user, nil)
@@ -518,7 +518,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AuthTime: newAuthTime,
 		}
 		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd",
-			enums.AcrLevel1.String(), int64(3), (*int64)(nil)).Return(newSession, nil)
+			enums.AcrLevel1.String(), int64(3), (*int64)(nil), &pwdAuthTime).Return(newSession, nil)
 
 		user := &models.User{Id: 1, Enabled: true}
 		database.On("GetUserById", mock.Anything, int64(1)).Return(user, nil)
@@ -636,8 +636,13 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		assert.ErrorIs(t, stub.bodyErr, deleteError, "the body hands its error to the helper, which rolls back")
 		assertNotAttempted(t, database, "RevokeCodesBySessionIdentifier",
 			"GetRefreshTokensBySessionIdentifier", "UpdateRefreshToken", "UpdateUserSession")
+		// Nine mock.Anything, one per parameter. AssertNotCalled compares the whole argument
+		// list, so a count that does not match the method's never matches a call either and
+		// the assertion passes however often the method ran. It was seven here, one short of
+		// the eight parameters the method had, so it asserted nothing until now (#252).
 		userSessionManager.AssertNotCalled(t, "StartNewUserSession", mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything)
 		userSessionManager.AssertNotCalled(t, "BumpUserSession", mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything)
 		authHelper.AssertNotCalled(t, "SaveAuthContext", mock.Anything, mock.Anything, mock.Anything)
@@ -732,7 +737,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 
 		startError := errors.New("the replacement session could not be created")
 		userSessionManager.On("StartNewUserSession", rr, req, int64(2), int64(1), "pwd",
-			enums.AcrLevel1.String(), int64(3), (*int64)(nil)).Return(nil, startError)
+			enums.AcrLevel1.String(), int64(3), (*int64)(nil), &pwdAuthTime).Return(nil, startError)
 
 		httpHelper.On("InternalServerError", rr, req, mock.MatchedBy(func(err error) bool {
 			return err.Error() == startError.Error()
@@ -783,8 +788,13 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/auth/completed", nil)
 		rr := httptest.NewRecorder()
 
-		// Re-auth case (e.g. prompt=login): AuthenticatedAt set by password handler
-		pwdAuthTime := time.Now().UTC()
+		// Re-auth case (e.g. prompt=login): AuthenticatedAt set by password handler.
+		//
+		// Deliberately 90 minutes old, which is the whole point of the case. The browser owns
+		// the hop from /auth/pwd to here, so the credential's instant and this handler's clock
+		// are two different times whenever the browser pauses, and only an old capture can tell
+		// the two apart. "now" would pass against either behaviour (#252 decision 8).
+		pwdAuthTime := time.Now().UTC().Add(-90 * time.Minute)
 		authContext := &oauth.AuthContext{
 			AuthState:       oauth.AuthStateAuthenticationCompleted,
 			ClientId:        "test-client",
@@ -801,7 +811,9 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			return r.Context().Value(constants.ContextKeySessionIdentifier) == sessionIdentifier
 		})).Return(authContext, nil)
 
-		oldAuthTime := time.Now().UTC().Add(-1 * time.Hour)
+		// The session's previous AuthTime, older still, so "the row was written" and "the row
+		// was written with the captured instant" are distinguishable.
+		oldAuthTime := time.Now().UTC().Add(-4 * time.Hour)
 		userSession := &models.UserSession{
 			Id:       1,
 			UserId:   1,
@@ -824,9 +836,11 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		userSessionManager.On("BumpUserSession", req, sessionIdentifier, int64(1),
 			"", enums.AcrLevel1.String()).Return(userSession, nil)
 
-		// Re-auth: AuthTime is refreshed and session is updated
+		// Re-auth: AuthTime is refreshed and the session row is written. The value is the
+		// captured credential instant exactly, not merely something newer than what the row
+		// held: Equal here is what fails if the handler reads the clock instead.
 		database.On("UpdateUserSession", mock.Anything, mock.MatchedBy(func(s *models.UserSession) bool {
-			return s.Id == userSession.Id && !s.AuthTime.IsZero() && s.AuthTime.After(oldAuthTime)
+			return s.Id == userSession.Id && s.AuthTime.Equal(pwdAuthTime)
 		})).Return(nil)
 
 		auditLogger.On("Log", constants.AuditBumpedUserSession, mock.Anything).Return()
@@ -839,10 +853,11 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 
 		permissionChecker.On("FilterOutScopesWhereUserIsNotAuthorized", "openid profile", user).Return("openid profile", nil)
 
+		// And the context carries that same instant onward, which is what /auth/issue stamps
+		// onto the code and the token issuer then signs as auth_time.
 		authHelper.On("SaveAuthContext", rr, req, mock.MatchedBy(func(ac *oauth.AuthContext) bool {
 			return ac.AuthState == oauth.AuthStateReadyToIssueCode &&
-				ac.AuthenticatedAt != nil && !ac.AuthenticatedAt.IsZero() &&
-				ac.AuthenticatedAt.After(oldAuthTime)
+				ac.AuthenticatedAt != nil && ac.AuthenticatedAt.Equal(pwdAuthTime)
 		})).Return(nil)
 
 		handler.ServeHTTP(rr, req)
@@ -970,7 +985,11 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 		// This ceremony did level 1: handler_auth_pwd sets both of these. Without
 		// Level1AuthCompleted the #129 gate restarts level 1 rather than starting a
 		// session, so this subtest is also the positive control for that gate.
-		pwdAuthTime := time.Now().UTC()
+		//
+		// Deliberately 90 minutes old, so the StartNewUserSession expectation below pins that
+		// the handler forwards the captured credential instant rather than reading the clock:
+		// with "now" the assertion would pass against either behaviour (#252 decision 8).
+		pwdAuthTime := time.Now().UTC().Add(-90 * time.Minute)
 		authContext := &oauth.AuthContext{
 			AuthState:   oauth.AuthStateAuthenticationCompleted,
 			ClientId:    "test-client",
@@ -1017,7 +1036,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AcrLevel: enums.AcrLevel1.String(),
 			AuthTime: sessionAuthTime,
 		}
-		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil)).Return(newUserSession, nil)
+		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil), &pwdAuthTime).Return(newUserSession, nil)
 
 		auditLogger.On("Log", constants.AuditStartedNewUserSesson, mock.Anything).Return()
 
@@ -1393,7 +1412,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			OtpConfigGeneration: 4,
 		}
 		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd otp",
-			enums.AcrLevel2Optional.String(), int64(7), &captured).Return(newUserSession, nil)
+			enums.AcrLevel2Optional.String(), int64(7), &captured, &pwdAuthTime).Return(newUserSession, nil)
 
 		auditLogger.On("Log", constants.AuditStartedNewUserSesson, mock.Anything).Return()
 
@@ -2300,7 +2319,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AcrLevel: enums.AcrLevel1.String(),
 			AuthTime: sessionAuthTime,
 		}
-		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil)).Return(newUserSession, nil)
+		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil), &pwdAuthTime).Return(newUserSession, nil)
 
 		auditLogger.On("Log", constants.AuditStartedNewUserSesson, mock.Anything).Return()
 
@@ -2388,7 +2407,7 @@ func TestHandleAuthCompletedGet(t *testing.T) {
 			AcrLevel: enums.AcrLevel1.String(),
 			AuthTime: sessionAuthTime,
 		}
-		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil)).Return(newUserSession, nil)
+		userSessionManager.On("StartNewUserSession", rr, req, int64(1), int64(1), "pwd", enums.AcrLevel1.String(), int64(7), (*int64)(nil), &pwdAuthTime).Return(newUserSession, nil)
 
 		auditLogger.On("Log", constants.AuditStartedNewUserSesson, mock.Anything).Return()
 

--- a/src/authserver/internal/handlers/interfaces.go
+++ b/src/authserver/internal/handlers/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"database/sql"
 	"net/http"
+	"time"
 
 	"github.com/leodip/goiabada/core/communication"
 	"github.com/leodip/goiabada/core/models"
@@ -76,7 +77,8 @@ type UserSessionManager interface {
 	HasValidUserSession(ctx context.Context, userSession *models.UserSession, requestedMaxAgeInSeconds *int) bool
 	StartNewUserSession(w http.ResponseWriter, r *http.Request,
 		userId int64, clientId int64, authMethods string, acrLevel string,
-		authStateGeneration int64, otpConfigGeneration *int64) (*models.UserSession, error)
+		authStateGeneration int64, otpConfigGeneration *int64,
+		authenticatedAt *time.Time) (*models.UserSession, error)
 
 	// BumpUserSession updates an existing session's last accessed time and client list.
 	// It also handles ACR/AMR step-up: if the user completed a higher level of authentication

--- a/src/authserver/internal/server/agentdocs_lint_test.go
+++ b/src/authserver/internal/server/agentdocs_lint_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/leodip/goiabada/core/testutil"
+)
+
+// TestAgentDocsAreCurrent fails the authserver unit tier when CLAUDE.md and
+// AGENTS.md have drifted apart, or when the states CLAUDE.md's "Auth States"
+// section lists are not exactly the ones src/core/oauth/auth_context.go
+// declares. testutil.AssertAgentDocs carries the reasoning, including why the
+// roster is checked and the transitions are not. Core and the admin console call
+// it from their own tiers.
+func TestAgentDocsAreCurrent(t *testing.T) {
+	testutil.AssertAgentDocs(t)
+}

--- a/src/authserver/tests/integration/auth_time_credential_instant_test.go
+++ b/src/authserver/tests/integration/auth_time_credential_instant_test.go
@@ -1,0 +1,251 @@
+package integrationtests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/leodip/goiabada/core/config"
+	"github.com/leodip/goiabada/core/encryption"
+	"github.com/leodip/goiabada/core/enums"
+	"github.com/leodip/goiabada/core/hashutil"
+	"github.com/leodip/goiabada/core/models"
+	"github.com/leodip/goiabada/core/oauth"
+	"github.com/leodip/goiabada/core/testutil/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+// browserPause is how long the ceremony sits after the password is accepted and before the
+// redirect chain that completes it. It is the whole instrument of this file: the credential's
+// instant and the completion's instant are the same number until something separates them, so
+// without a pause a token carrying either one passes.
+//
+// Two seconds rather than something longer because auth_time is emitted as Unix seconds and the
+// assertions compare on that grid: one second of truncation has to be small against the gap. It
+// is also two seconds added to the integration tier, so it buys the separation and no more.
+const browserPause = 2 * time.Second
+
+// pausedCeremony is what one such ceremony observed: the claim, and the two windows it has to be
+// told apart from.
+type pausedCeremony struct {
+	authTime  time.Time
+	sid       string
+	pwdBefore time.Time // just before the password POST
+	pwdAfter  time.Time // just after it returned
+	resumedAt time.Time // after the pause, when the browser went on to /auth/level1completed
+}
+
+// TestAuthTime_IsTheInstantTheCredentialWasAccepted drives the whole stack, both session arms,
+// and asserts the ID token's auth_time names the moment the password was accepted rather than
+// the moment the ceremony finished.
+//
+// OIDC Core 1.0 section 3.1.2.1 defines max_age as "the allowable elapsed time in seconds since
+// the last time the End-User was actively authenticated by the OP", and section 2 defines
+// auth_time as the "Time when the End-User authentication occurred". A relying party that wants
+// a guaranteed-fresh sign-in before something sensitive sends max_age and then reads auth_time
+// out of the token to check it got one.
+//
+// The two instants are milliseconds apart until a browser pauses, and the browser owns that gap:
+// /auth/pwd accepts the credential, then the browser is redirected onward to /auth/completed,
+// which is where the session row is written. A tab left sitting after the password was accepted
+// and resumed later used to produce a token saying the user had actively authenticated just now,
+// so a relying party asking for a fresh sign-in was told it got one, about whoever was holding
+// that browser when it resumed (#252 decision 8).
+//
+// Unit coverage for the two writes is in handler_auth_completed_test.go and
+// usersession_manager_start_test.go. This test exists because those mock the layer below them:
+// only a real ceremony shows the value surviving the AuthContext, the code row and the token
+// issuer to reach the claim a relying party actually reads.
+func TestAuthTime_IsTheInstantTheCredentialWasAccepted(t *testing.T) {
+	clientSecret := fake.Password(32)
+	clientSecretEncrypted, err := encryption.EncryptData(clientSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &models.Client{
+		ClientIdentifier:                        "test-client-" + fake.LetterN(8),
+		ClientSecretEncrypted:                   clientSecretEncrypted,
+		Enabled:                                 true,
+		AuthorizationCodeEnabled:                true,
+		ConsentRequired:                         false,
+		DefaultAcrLevel:                         enums.AcrLevel1,
+		TokenExpirationInSeconds:                300,
+		RefreshTokenOfflineIdleTimeoutInSeconds: 3600,
+		RefreshTokenOfflineMaxLifetimeInSeconds: 86400,
+	}
+	if err := database.CreateClient(nil, client); err != nil {
+		t.Fatal(err)
+	}
+
+	redirectUri := &models.RedirectURI{
+		ClientId: client.Id,
+		URI:      "https://example.com/callback",
+	}
+	if err := database.CreateRedirectURI(nil, redirectUri); err != nil {
+		t.Fatal(err)
+	}
+
+	password := fake.Password(8)
+	passwordHashed, err := hashutil.HashPassword(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user := &models.User{
+		Subject:      fake.UUID(),
+		Enabled:      true,
+		Email:        fake.Email(),
+		PasswordHash: passwordHashed,
+	}
+	if err := database.CreateUser(nil, user); err != nil {
+		t.Fatal(err)
+	}
+
+	// One client for both ceremonies, so the second arrives carrying the first's cookie, which
+	// is what makes it the reuse arm.
+	httpClient := createHttpClient(t)
+
+	// The create arm: nothing in the jar yet, so /auth/completed mints a session and
+	// StartNewUserSession stamps AuthTime.
+	created := runPausedCeremony(t, httpClient, client.ClientIdentifier, clientSecret,
+		redirectUri.URI, user.Email, password, "")
+	assertAuthTimeIsTheCredentialInstant(t, created, "create arm")
+
+	// The reuse arm: the same browser, prompt=login, so the ceremony re-authenticates against
+	// the session it already holds and /auth/completed refreshes that row's AuthTime instead.
+	reused := runPausedCeremony(t, httpClient, client.ClientIdentifier, clientSecret,
+		redirectUri.URI, user.Email, password, "&prompt=login")
+	assertAuthTimeIsTheCredentialInstant(t, reused, "reuse arm")
+
+	// sid is the user session's identifier, and a bump leaves it alone where a fresh session
+	// mints a new one. Equal here is what says the second ceremony really took the reuse arm
+	// rather than quietly exercising the create arm twice.
+	assert.NotEmpty(t, created.sid, "the ID token must carry sid for this comparison to mean anything")
+	assert.Equal(t, created.sid, reused.sid,
+		"prompt=login in the same browser must reuse the session, so that the second ceremony "+
+			"exercises the bump arm of /auth/completed and not the create arm again")
+
+	// And the refresh really moved: the two ceremonies are at least a pause apart, so a reuse
+	// arm that failed to write at all would show up here as an unchanged claim.
+	assert.True(t, reused.authTime.After(created.authTime),
+		"re-authenticating must move auth_time forward (first=%v, second=%v)",
+		created.authTime, reused.authTime)
+}
+
+// assertAuthTimeIsTheCredentialInstant holds the claim to the window the password was accepted
+// in, and away from the window the ceremony completed in.
+func assertAuthTimeIsTheCredentialInstant(t *testing.T, c pausedCeremony, arm string) {
+	t.Helper()
+
+	// auth_time is emitted as Unix seconds, so every comparison is on that grid: truncation
+	// only ever moves a value down, which keeps both bounds below honest.
+	assert.GreaterOrEqual(t, c.authTime.Unix(), c.pwdBefore.Unix(),
+		"%s: auth_time %v must not predate the password submission at %v", arm, c.authTime, c.pwdBefore)
+	assert.LessOrEqual(t, c.authTime.Unix(), c.pwdAfter.Unix(),
+		"%s: auth_time %v must be the instant the password was accepted, and the POST had "+
+			"returned by %v", arm, c.authTime, c.pwdAfter)
+
+	// The one that fails if the handler reads its own clock: the ceremony did not resume until
+	// resumedAt, so a completion-time stamp lands at or after it.
+	assert.Less(t, c.authTime.Unix(), c.resumedAt.Unix(),
+		"%s: auth_time %v names the completion of the ceremony rather than the credential; the "+
+			"browser only resumed at %v, so a relying party sending max_age would be told this "+
+			"sign-in was %v fresher than it is",
+		arm, c.authTime, c.resumedAt, c.resumedAt.Sub(c.authTime))
+}
+
+// runPausedCeremony drives one authorization code ceremony to a token, pausing between the
+// password being accepted and the redirect chain that completes it. prompt is appended to the
+// authorization request verbatim, so "" is a plain sign-in and "&prompt=login" forces one.
+func runPausedCeremony(t *testing.T, httpClient *http.Client, clientIdentifier string,
+	clientSecret string, redirectUri string, email string, password string,
+	prompt string) pausedCeremony {
+
+	t.Helper()
+
+	codeVerifier := "code-verifier-" + fake.LetterN(16)
+	codeChallenge := oauth.GeneratePKCECodeChallenge(codeVerifier)
+
+	destUrl := config.GetAuthServer().BaseURL + "/auth/authorize/?client_id=" + clientIdentifier +
+		"&redirect_uri=" + url.QueryEscape(redirectUri) +
+		"&response_type=code" +
+		"&code_challenge_method=S256" +
+		"&code_challenge=" + codeChallenge +
+		"&scope=" + url.QueryEscape("openid profile") +
+		"&state=" + fake.LetterN(8) +
+		"&nonce=" + fake.LetterN(8) +
+		prompt
+
+	resp, err := httpClient.Get(destUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation := assertRedirect(t, resp, "/auth/level1")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/pwd")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The credential's window. Bracketing the POST rather than reading the clock once is what
+	// makes the assertions exact without depending on how long the hash took.
+	pwdBefore := time.Now().UTC()
+	resp = authenticateWithPassword(t, httpClient, redirectLocation, resp, email, password)
+	pwdAfter := time.Now().UTC()
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/level1completed")
+
+	// The browser pauses here, holding a redirect it has not followed. Everything after this
+	// point runs at least browserPause after the password was accepted.
+	time.Sleep(browserPause)
+	resumedAt := time.Now().UTC()
+
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/completed")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	redirectLocation = assertRedirect(t, resp, "/auth/issue")
+	resp = loadPage(t, httpClient, redirectLocation)
+	defer func() { _ = resp.Body.Close() }()
+
+	code, _ := getCodeAndStateFromUrl(t, resp)
+
+	data := postToTokenEndpoint(t, httpClient, config.GetAuthServer().BaseURL+"/auth/token",
+		url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientIdentifier},
+			"client_secret": {clientSecret},
+			"code":          {code},
+			"redirect_uri":  {redirectUri},
+			"code_verifier": {codeVerifier},
+		})
+
+	idToken, ok := data["id_token"].(string)
+	if !ok {
+		t.Fatalf("the token response carried no id_token: %v", data)
+	}
+	claims := decodeJWTPayload(t, idToken)
+
+	authTime, ok := claims["auth_time"].(float64)
+	if !ok {
+		t.Fatalf("the ID token carried no auth_time claim: %v", claims)
+	}
+	sid, _ := claims["sid"].(string)
+
+	return pausedCeremony{
+		authTime:  time.Unix(int64(authTime), 0).UTC(),
+		sid:       sid,
+		pwdBefore: pwdBefore,
+		pwdAfter:  pwdAfter,
+		resumedAt: resumedAt,
+	}
+}

--- a/src/core/testutil/agentdocs.go
+++ b/src/core/testutil/agentdocs.go
@@ -1,0 +1,249 @@
+package testutil
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// AssertAgentDocs holds CLAUDE.md and AGENTS.md to two rules: the two files are
+// byte-identical, and the roster of states in CLAUDE.md's "Auth States (State
+// Machine)" section is exactly the set of AuthState* string constants declared
+// in src/core/oauth/auth_context.go.
+//
+// Both rules exist because the two files are prose about code, and prose about
+// code is the one thing in this repository nothing else checks. The ceremony's
+// state list sat in CLAUDE.md describing a machine that had moved underneath it:
+// it named ten states in a numbered order the handlers do not follow, omitted
+// level1_existing_session entirely, and opened by saying the context lives in a
+// session cookie, which stopped being true when #266 moved the store
+// server-side. Every one of those was true when written (#252).
+//
+// The files are co-maintained copies for two different tools, which is the
+// second rule's whole reason: an edit that lands in one and not the other leaves
+// two agents reading different descriptions of the same handlers, and a plain
+// diff is the only thing that ever notices. The drift this guard was written
+// against was four lines about test fixtures present in CLAUDE.md and missing
+// from AGENTS.md.
+//
+// The roster rule checks membership, not transitions. Reconstructing the state
+// graph from the handlers would be a second implementation of the thing being
+// documented, and it would go red on every comment edit; the roster is the part
+// that goes stale silently, when a state is added or, as #248 is about to do,
+// deleted.
+//
+// Scope is the source root's parent, because SourceRoot returns the directory
+// holding the four go.mod files and the two agent files live one level above it.
+// Each module's unit tier calls this, so the guard fires whichever tier is run.
+func AssertAgentDocs(t *testing.T) {
+	t.Helper()
+
+	findings := checkAgentDocs(filepath.Dir(SourceRoot(t)))
+	for _, f := range findings {
+		t.Error(f)
+	}
+}
+
+// agentDocsHeading is the section of CLAUDE.md the roster rule reads. The
+// section runs to the next heading at the same level or above.
+const agentDocsHeading = "### Auth States (State Machine)"
+
+// agentDocsStateCell matches a first table cell that is exactly one backticked
+// state value. It is deliberately narrower than "a backticked token anywhere in
+// the row": the accepted-by table repeats most state values in its Accepts
+// column, so a rule that accepted any occurrence in the section would still pass
+// after a state's assigned-by row was deleted. The first column of the
+// assigned-by table carries a state value or nothing, which is what makes it
+// readable as a roster; route cells like `/auth/pwd` do not match.
+var agentDocsStateCell = regexp.MustCompile("^`([a-z0-9_]+)`$")
+
+// checkAgentDocs returns one finding per rule violation, ordered rule 1 then
+// rule 2 and sorted within rule 2 so the message is stable. It returns strings
+// rather than errors because every caller is an assertion: a stack captured here
+// would point at this file rather than at the prose that is wrong.
+func checkAgentDocs(root string) []string {
+	var findings []string
+
+	claude, claudeErr := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if claudeErr != nil {
+		findings = append(findings, fmt.Sprintf("reading CLAUDE.md: %v", claudeErr))
+	}
+	agents, agentsErr := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if agentsErr != nil {
+		findings = append(findings, fmt.Sprintf("reading AGENTS.md: %v", agentsErr))
+	}
+
+	if claudeErr == nil && agentsErr == nil && string(claude) != string(agents) {
+		findings = append(findings, firstDifference(string(claude), string(agents)))
+	}
+
+	declared, declErr := declaredAuthStates(filepath.Join(root, "src", "core", "oauth", "auth_context.go"))
+	switch {
+	case declErr != nil:
+		findings = append(findings, fmt.Sprintf("reading src/core/oauth/auth_context.go: %v", declErr))
+	case len(declared) == 0:
+		// A parse that finds nothing would otherwise make every roster check
+		// pass vacuously, which is the one direction a guard like this fails in
+		// silently.
+		findings = append(findings, "src/core/oauth/auth_context.go declares no AuthState* string constants")
+	}
+
+	if claudeErr != nil || declErr != nil || len(declared) == 0 {
+		return findings
+	}
+
+	section, ok := agentDocsSection(string(claude))
+	if !ok {
+		findings = append(findings, fmt.Sprintf("CLAUDE.md has no %q section", agentDocsHeading))
+		return findings
+	}
+
+	roster := rosterStates(section)
+
+	var missing, unknown []string
+	for state := range declared {
+		if !roster[state] {
+			missing = append(missing, state)
+		}
+	}
+	for state := range roster {
+		if !declared[state] {
+			unknown = append(unknown, state)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unknown)
+
+	for _, state := range missing {
+		findings = append(findings, fmt.Sprintf(
+			"state %q is declared in src/core/oauth/auth_context.go but has no row in the %q section of CLAUDE.md",
+			state, agentDocsHeading))
+	}
+	for _, state := range unknown {
+		findings = append(findings, fmt.Sprintf(
+			"the %q section of CLAUDE.md has a row for state %q, which src/core/oauth/auth_context.go does not declare",
+			agentDocsHeading, state))
+	}
+
+	return findings
+}
+
+// firstDifference names the line the two files start disagreeing at, because a
+// whole-file diff in a test failure is unreadable and a bare "they differ" sends
+// the reader to run the diff themselves.
+func firstDifference(claude, agents string) string {
+	claudeLines := strings.Split(claude, "\n")
+	agentsLines := strings.Split(agents, "\n")
+
+	for i := 0; i < len(claudeLines) || i < len(agentsLines); i++ {
+		c, a := "<end of file>", "<end of file>"
+		if i < len(claudeLines) {
+			c = claudeLines[i]
+		}
+		if i < len(agentsLines) {
+			a = agentsLines[i]
+		}
+		if c != a {
+			return fmt.Sprintf("CLAUDE.md and AGENTS.md differ at line %d; they are co-maintained copies and must be identical\n\tCLAUDE.md: %s\n\tAGENTS.md: %s",
+				i+1, c, a)
+		}
+	}
+	// Unreachable while the caller compares the contents first, and cheaper to
+	// state than to leave as a nil return somebody has to reason about.
+	return "CLAUDE.md and AGENTS.md differ, but no differing line was found"
+}
+
+// declaredAuthStates returns the unquoted value of every AuthState* string
+// declaration in the file. The declarations live under `var (` today; const is
+// read the same way so that tightening them to constants is not a guard change.
+//
+// Parsing rather than grepping is the point: a regex over the source would
+// equally match the name in a comment, in a test fixture, or in the handler that
+// assigns it, and the roster has to be the declarations exactly.
+func declaredAuthStates(path string) (map[string]bool, error) {
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	states := map[string]bool{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || (gen.Tok != token.VAR && gen.Tok != token.CONST) {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range value.Names {
+				if !strings.HasPrefix(name.Name, "AuthState") || i >= len(value.Values) {
+					continue
+				}
+				lit, ok := value.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				unquoted, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				states[unquoted] = true
+			}
+		}
+	}
+	return states, nil
+}
+
+// agentDocsSection returns the lines between the heading and the next heading at
+// the same level or above, which is where the roster has to live.
+func agentDocsSection(doc string) ([]string, bool) {
+	lines := strings.Split(doc, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimRight(line, " \t") == agentDocsHeading {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "### ") || strings.HasPrefix(lines[i], "## ") {
+			return lines[start:i], true
+		}
+	}
+	return lines[start:], true
+}
+
+// rosterStates reads the first cell of every table row in the section. The
+// header and separator rows contribute nothing because their first cells are not
+// backticked tokens, and a continuation row's empty first cell contributes
+// nothing either.
+func rosterStates(section []string) map[string]bool {
+	states := map[string]bool{}
+	for _, line := range section {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+		cells := strings.Split(trimmed, "|")
+		if len(cells) < 2 {
+			continue
+		}
+		if m := agentDocsStateCell.FindStringSubmatch(strings.TrimSpace(cells[1])); m != nil {
+			states[m[1]] = true
+		}
+	}
+	return states
+}

--- a/src/core/testutil/agentdocs_lint_test.go
+++ b/src/core/testutil/agentdocs_lint_test.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "testing"
+
+// TestAgentDocsAreCurrent fails the core unit tier when CLAUDE.md and AGENTS.md
+// have drifted apart, or when the states CLAUDE.md's "Auth States" section lists
+// are not exactly the ones src/core/oauth/auth_context.go declares.
+// AssertAgentDocs carries the reasoning, including why the roster is checked and
+// the transitions are not. The auth server and the admin console call it from
+// their own tiers.
+func TestAgentDocsAreCurrent(t *testing.T) {
+	AssertAgentDocs(t)
+}

--- a/src/core/testutil/agentdocs_test.go
+++ b/src/core/testutil/agentdocs_test.go
@@ -1,0 +1,247 @@
+package testutil
+
+// Seam 1: the rule table checkAgentDocs enforces, over fixture agent files and a fixture
+// auth_context.go written into a temp tree and read through the same function the real caller uses.
+//
+// The synthetic half exists for the reason errors_lint_test.go's does: the real half cannot fail
+// informatively. Once the tree is correct by construction, a guard that had quietly stopped
+// matching anything would pass exactly as a working one does, and nothing would be holding the rule
+// (#252).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClaudeLines is the fixture CLAUDE.md, one line per element so every case that asserts a line
+// number can be read against it. Line numbers below are 1-based, so line N is index N-1.
+//
+// Three shapes in it are load-bearing and every case leans on at least one: the continuation row at
+// line 13 has an empty first cell, the route table at lines 17 and 18 repeats two state values in a
+// later column, and the `bogus_state` at line 23 sits below the next `###` heading.
+var fakeClaudeLines = []string{
+	"# Fake repository notes", // 1
+	"",                        // 2
+	"## Authentication Flow (Authorization Code)", // 3
+	"",                                // 4
+	"### Auth States (State Machine)", // 5
+	"The values below are the constants in `src/core/oauth/auth_context.go`.", // 6
+	"",                               // 7
+	"| State | Assigned by | When |", // 8
+	"|---|---|---|",                  // 9
+	"| `initial` | `HandleAuthorizeGet` | the composite literal |",               // 10
+	"| `level2_otp` | `HandleAuthLevel2Get` | level2_mandatory |",                // 11
+	"| `ready_to_issue_code` | `handlePromptNone` | every silent check passed |", // 12
+	"| | `HandleConsentPost` | approved with at least one scope |",               // 13
+	"", // 14
+	"| Route | Method | Accepts | On mismatch |",            // 15
+	"|---|---|---|---|",                                     // 16
+	"| `/auth/otp` | GET | `level2_otp` | 400 |",            // 17
+	"| `/auth/issue` | GET | `ready_to_issue_code` | 400 |", // 18
+	"",                             // 19
+	"### Flow Handlers (in order)", // 20
+	"| Handler | File |",           // 21
+	"|---|---|",                    // 22
+	"| `bogus_state` | `handler_auth_pwd.go` |", // 23
+	"", // 24
+}
+
+// The fixture auth_context.go. The real file declares the states under `var (`, so that is the
+// default; the const variant is here because tightening them to constants must not be a change to
+// the guard.
+const (
+	fakeStatesVar = `package oauth
+
+var (
+	AuthStateInitial          = "initial"
+	AuthStateLevel2OTP        = "level2_otp"
+	AuthStateReadyToIssueCode = "ready_to_issue_code"
+)
+`
+	fakeStatesConst = `package oauth
+
+const (
+	AuthStateInitial          = "initial"
+	AuthStateLevel2OTP        = "level2_otp"
+	AuthStateReadyToIssueCode = "ready_to_issue_code"
+)
+`
+	fakeStatesExtra = `package oauth
+
+var (
+	AuthStateInitial          = "initial"
+	AuthStateLevel2OTP        = "level2_otp"
+	AuthStateReadyToIssueCode = "ready_to_issue_code"
+	AuthStateRequiresConsent  = "requires_consent"
+)
+`
+	fakeStatesNone = `package oauth
+
+var (
+	sessionCookieName = "session"
+)
+`
+)
+
+// TestAgentDocs_TheRuleTable writes one fixture tree per row of the rule and asserts the exact set
+// of findings. Every passing row is a shape that must survive the check untouched; every failing
+// row asserts the message, because a finding that fires with unusable text sends the next reader to
+// re-derive what the guard already knew.
+func TestAgentDocs_TheRuleTable(t *testing.T) {
+	const missingHeading = `# Fake repository notes
+
+### Auth States
+| State | Assigned by | When |
+|---|---|---|
+| ` + "`initial`" + ` | x | y |
+`
+
+	cases := []struct {
+		name   string
+		claude []string
+		agents []string // nil means AGENTS.md is a copy of claude
+		states string
+		want   []string
+	}{
+		{
+			name:   "identical files and a full roster pass",
+			claude: fakeClaudeLines,
+			states: fakeStatesVar,
+			want:   nil,
+		},
+		{
+			name:   "the same, with the states declared as constants",
+			claude: fakeClaudeLines,
+			states: fakeStatesConst,
+			want:   nil,
+		},
+		{
+			name:   "a one-line difference in AGENTS.md fails naming the first differing line",
+			claude: fakeClaudeLines,
+			agents: replaceLine(fakeClaudeLines, 6, "The values below are the constants, probably."),
+			states: fakeStatesVar,
+			want: []string{
+				"CLAUDE.md and AGENTS.md differ at line 6; they are co-maintained copies and must be identical\n" +
+					"\tCLAUDE.md: The values below are the constants in `src/core/oauth/auth_context.go`.\n" +
+					"\tAGENTS.md: The values below are the constants, probably.",
+			},
+		},
+		{
+			name:   "a shorter AGENTS.md fails at the line where it ends",
+			claude: fakeClaudeLines,
+			agents: fakeClaudeLines[:5],
+			states: fakeStatesVar,
+			want: []string{
+				"CLAUDE.md and AGENTS.md differ at line 6; they are co-maintained copies and must be identical\n" +
+					"\tCLAUDE.md: The values below are the constants in `src/core/oauth/auth_context.go`.\n" +
+					"\tAGENTS.md: <end of file>",
+			},
+		},
+		{
+			name:   "a declared state with no row fails naming the value",
+			claude: fakeClaudeLines,
+			states: fakeStatesExtra,
+			want: []string{
+				`state "requires_consent" is declared in src/core/oauth/auth_context.go but has no row in the "### Auth States (State Machine)" section of CLAUDE.md`,
+			},
+		},
+		{
+			// The reason the roster reads the first cell rather than the whole section: level2_otp
+			// is still on line 17, in the route table's Accepts column, so a rule that accepted any
+			// occurrence would see nothing wrong here.
+			name:   "a state left only in a later column, its own row deleted, fails naming the value",
+			claude: deleteLine(fakeClaudeLines, 11),
+			states: fakeStatesVar,
+			want: []string{
+				`state "level2_otp" is declared in src/core/oauth/auth_context.go but has no row in the "### Auth States (State Machine)" section of CLAUDE.md`,
+			},
+		},
+		{
+			name:   "a first-cell token with no declaration fails naming the token",
+			claude: insertLine(fakeClaudeLines, 14, "| `level2_otp_completed` | nobody | dead |"),
+			states: fakeStatesVar,
+			want: []string{
+				`the "### Auth States (State Machine)" section of CLAUDE.md has a row for state "level2_otp_completed", which src/core/oauth/auth_context.go does not declare`,
+			},
+		},
+		{
+			name:   "a declaration block with no AuthState names fails rather than passing vacuously",
+			claude: fakeClaudeLines,
+			states: fakeStatesNone,
+			want:   []string{"src/core/oauth/auth_context.go declares no AuthState* string constants"},
+		},
+		{
+			name:   "a missing heading fails",
+			claude: strings.Split(strings.TrimSuffix(missingHeading, "\n"), "\n"),
+			states: fakeStatesVar,
+			want:   []string{`CLAUDE.md has no "### Auth States (State Machine)" section`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agents := tc.agents
+			if agents == nil {
+				agents = tc.claude
+			}
+			root := writeFakeTree(t, tc.claude, agents, tc.states)
+
+			assert.Equal(t, tc.want, checkAgentDocs(root))
+		})
+	}
+}
+
+// TestAgentDocs_AMissingAgentsFileFails is its own case because the finding carries the operating
+// system's own "no such file" text and the path separator it uses, neither of which belongs in a
+// table asserting exact strings.
+func TestAgentDocs_AMissingAgentsFileFails(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "CLAUDE.md"), strings.Join(fakeClaudeLines, "\n"))
+	writeFile(t, filepath.Join(root, "src", "core", "oauth", "auth_context.go"), fakeStatesVar)
+
+	findings := checkAgentDocs(root)
+
+	require.Len(t, findings, 1, "the roster still checks out, so the missing file is the only finding")
+	assert.True(t, strings.HasPrefix(findings[0], "reading AGENTS.md: "), findings[0])
+}
+
+func writeFakeTree(t *testing.T, claude, agents []string, states string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "CLAUDE.md"), strings.Join(claude, "\n"))
+	writeFile(t, filepath.Join(root, "AGENTS.md"), strings.Join(agents, "\n"))
+	writeFile(t, filepath.Join(root, "src", "core", "oauth", "auth_context.go"), states)
+	return root
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// replaceLine, deleteLine and insertLine take 1-based line numbers so a case reads against the
+// numbered fixture above. Each copies, because the fixture is shared by every case.
+func replaceLine(lines []string, n int, with string) []string {
+	out := append([]string(nil), lines...)
+	out[n-1] = with
+	return out
+}
+
+func deleteLine(lines []string, n int) []string {
+	out := append([]string(nil), lines[:n-1]...)
+	return append(out, lines[n:]...)
+}
+
+func insertLine(lines []string, n int, line string) []string {
+	out := append([]string(nil), lines[:n-1]...)
+	out = append(out, line)
+	return append(out, lines[n-1:]...)
+}

--- a/src/core/user/mocks/user_session_manager_mock.go
+++ b/src/core/user/mocks/user_session_manager_mock.go
@@ -9,6 +9,7 @@ package mocks_user
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/leodip/goiabada/core/models"
 	mock "github.com/stretchr/testify/mock"
@@ -191,8 +192,8 @@ func (_c *UserSessionManager_HasValidUserSession_Call) RunAndReturn(run func(ctx
 }
 
 // StartNewUserSession provides a mock function for the type UserSessionManager
-func (_mock *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64) (*models.UserSession, error) {
-	ret := _mock.Called(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration)
+func (_mock *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64, authenticatedAt *time.Time) (*models.UserSession, error) {
+	ret := _mock.Called(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration, authenticatedAt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartNewUserSession")
@@ -200,18 +201,18 @@ func (_mock *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *h
 
 	var r0 *models.UserSession
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64) (*models.UserSession, error)); ok {
-		return returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration)
+	if returnFunc, ok := ret.Get(0).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64, *time.Time) (*models.UserSession, error)); ok {
+		return returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration, authenticatedAt)
 	}
-	if returnFunc, ok := ret.Get(0).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64) *models.UserSession); ok {
-		r0 = returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration)
+	if returnFunc, ok := ret.Get(0).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64, *time.Time) *models.UserSession); ok {
+		r0 = returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration, authenticatedAt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.UserSession)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64) error); ok {
-		r1 = returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration)
+	if returnFunc, ok := ret.Get(1).(func(http.ResponseWriter, *http.Request, int64, int64, string, string, int64, *int64, *time.Time) error); ok {
+		r1 = returnFunc(w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration, authenticatedAt)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -232,11 +233,12 @@ type UserSessionManager_StartNewUserSession_Call struct {
 //   - acrLevel string
 //   - authStateGeneration int64
 //   - otpConfigGeneration *int64
-func (_e *UserSessionManager_Expecter) StartNewUserSession(w any, r any, userId any, clientId any, authMethods any, acrLevel any, authStateGeneration any, otpConfigGeneration any) *UserSessionManager_StartNewUserSession_Call {
-	return &UserSessionManager_StartNewUserSession_Call{Call: _e.mock.On("StartNewUserSession", w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration)}
+//   - authenticatedAt *time.Time
+func (_e *UserSessionManager_Expecter) StartNewUserSession(w any, r any, userId any, clientId any, authMethods any, acrLevel any, authStateGeneration any, otpConfigGeneration any, authenticatedAt any) *UserSessionManager_StartNewUserSession_Call {
+	return &UserSessionManager_StartNewUserSession_Call{Call: _e.mock.On("StartNewUserSession", w, r, userId, clientId, authMethods, acrLevel, authStateGeneration, otpConfigGeneration, authenticatedAt)}
 }
 
-func (_c *UserSessionManager_StartNewUserSession_Call) Run(run func(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64)) *UserSessionManager_StartNewUserSession_Call {
+func (_c *UserSessionManager_StartNewUserSession_Call) Run(run func(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64, authenticatedAt *time.Time)) *UserSessionManager_StartNewUserSession_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 http.ResponseWriter
 		if args[0] != nil {
@@ -270,6 +272,10 @@ func (_c *UserSessionManager_StartNewUserSession_Call) Run(run func(w http.Respo
 		if args[7] != nil {
 			arg7 = args[7].(*int64)
 		}
+		var arg8 *time.Time
+		if args[8] != nil {
+			arg8 = args[8].(*time.Time)
+		}
 		run(
 			arg0,
 			arg1,
@@ -279,6 +285,7 @@ func (_c *UserSessionManager_StartNewUserSession_Call) Run(run func(w http.Respo
 			arg5,
 			arg6,
 			arg7,
+			arg8,
 		)
 	})
 	return _c
@@ -289,7 +296,7 @@ func (_c *UserSessionManager_StartNewUserSession_Call) Return(userSession *model
 	return _c
 }
 
-func (_c *UserSessionManager_StartNewUserSession_Call) RunAndReturn(run func(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64) (*models.UserSession, error)) *UserSessionManager_StartNewUserSession_Call {
+func (_c *UserSessionManager_StartNewUserSession_Call) RunAndReturn(run func(w http.ResponseWriter, r *http.Request, userId int64, clientId int64, authMethods string, acrLevel string, authStateGeneration int64, otpConfigGeneration *int64, authenticatedAt *time.Time) (*models.UserSession, error)) *UserSessionManager_StartNewUserSession_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/src/core/user/usersession_manager.go
+++ b/src/core/user/usersession_manager.go
@@ -61,11 +61,30 @@ func (u *UserSessionManager) HasValidUserSession(ctx context.Context, userSessio
 // observed nothing, which writes 0, and for a brand new session that means it owes a
 // level 2 re-prompt whenever the user's counter is already above 0. That is the
 // fail-closed direction and the only one a nil can safely take (#242).
+//
+// authenticatedAt is the instant this ceremony's last credential was accepted, captured by
+// the password handler and overwritten by the OTP handler. It becomes the session's AuthTime
+// and so the auth_time claim, which OIDC Core 3.1.2.1 makes max_age's reference point: "the
+// last time the End-User was actively authenticated by the OP". Reading the clock here
+// instead would name the moment this function ran, and the browser owns the hop between the
+// two -- a tab left sitting after the password was accepted and resumed hours later would
+// mint a session claiming the user had just authenticated, so a relying party asking for a
+// fresh sign-in with max_age would be told it got one (#252 decision 8). Started and
+// LastAccessed stay on now: they measure the session's own life, not the credential's.
+// Nil or zero falls back to now, which is all the information there is to write; the one
+// caller cannot produce it, because /auth/completed refuses to mint a session without
+// Level1AuthCompleted and only the password handler sets that, alongside authenticatedAt.
 func (u *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.Request,
 	userId int64, clientId int64, authMethods string, acrLevel string,
-	authStateGeneration int64, otpConfigGeneration *int64) (*models.UserSession, error) {
+	authStateGeneration int64, otpConfigGeneration *int64,
+	authenticatedAt *time.Time) (*models.UserSession, error) {
 
 	utcNow := time.Now().UTC()
+
+	authTime := utcNow
+	if authenticatedAt != nil && !authenticatedAt.IsZero() {
+		authTime = authenticatedAt.UTC()
+	}
 
 	observedOtpConfigGeneration := int64(0)
 	if otpConfigGeneration != nil {
@@ -84,7 +103,7 @@ func (u *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.
 		IpAddress:         ipWithoutPort,
 		AuthMethods:       authMethods,
 		AcrLevel:          acrLevel,
-		AuthTime:          utcNow,
+		AuthTime:          authTime,
 		UserId:            userId,
 		DeviceName:        useragent.GetDeviceName(r),
 		DeviceType:        useragent.GetDeviceType(r),

--- a/src/core/user/usersession_manager.go
+++ b/src/core/user/usersession_manager.go
@@ -71,20 +71,23 @@ func (u *UserSessionManager) HasValidUserSession(ctx context.Context, userSessio
 // mint a session claiming the user had just authenticated, so a relying party asking for a
 // fresh sign-in with max_age would be told it got one (#252 decision 8). Started and
 // LastAccessed stay on now: they measure the session's own life, not the credential's.
-// Nil or zero falls back to now, which is all the information there is to write; the one
-// caller cannot produce it, because /auth/completed refuses to mint a session without
-// Level1AuthCompleted and only the password handler sets that, alongside authenticatedAt.
+// Nil or zero is refused, before anything is written: a session with no credential instant
+// has nothing true to put in auth_time, and falling back to now would recreate the false
+// freshness this parameter exists to remove, one broken caller away. The one caller cannot
+// produce it, because /auth/completed refuses to mint a session without Level1AuthCompleted
+// and only the password handler sets that, alongside authenticatedAt; the refusal is what
+// makes that invariant fail closed rather than an argument in a comment.
 func (u *UserSessionManager) StartNewUserSession(w http.ResponseWriter, r *http.Request,
 	userId int64, clientId int64, authMethods string, acrLevel string,
 	authStateGeneration int64, otpConfigGeneration *int64,
 	authenticatedAt *time.Time) (*models.UserSession, error) {
 
-	utcNow := time.Now().UTC()
-
-	authTime := utcNow
-	if authenticatedAt != nil && !authenticatedAt.IsZero() {
-		authTime = authenticatedAt.UTC()
+	if authenticatedAt == nil || authenticatedAt.IsZero() {
+		return nil, errs.New("StartNewUserSession: no credential instant captured; refusing to mint a session whose auth_time would be invented")
 	}
+	authTime := authenticatedAt.UTC()
+
+	utcNow := time.Now().UTC()
 
 	observedOtpConfigGeneration := int64(0)
 	if otpConfigGeneration != nil {

--- a/src/core/user/usersession_manager_start_test.go
+++ b/src/core/user/usersession_manager_start_test.go
@@ -95,7 +95,7 @@ func TestStartNewUserSession_PopulatesSessionFields(t *testing.T) {
 	captured := m.expectSuccessfulPersist(123, nil)
 
 	before := time.Now().UTC()
-	result, err := m.manager.StartNewUserSession(recorder, req, 123, 7, "pwd otp", enums.AcrLevel2Mandatory.String(), 0, nil)
+	result, err := m.manager.StartNewUserSession(recorder, req, 123, 7, "pwd otp", enums.AcrLevel2Mandatory.String(), 0, nil, nil)
 	after := time.Now().UTC()
 
 	assert.NoError(t, err)
@@ -115,7 +115,10 @@ func TestStartNewUserSession_PopulatesSessionFields(t *testing.T) {
 	// one. Compare against the nil spelling itself.
 	assert.NotEqual(t, "00000000-0000-0000-0000-000000000000", parsed)
 
-	// Started, LastAccessed and AuthTime are all stamped with the same UTC now.
+	// Started, LastAccessed and AuthTime are all stamped with the same UTC now. AuthTime is
+	// only "now" here because this call captured no credential instant, which is the nil
+	// fallback; when one is captured it wins, and
+	// TestStartNewUserSession_AuthTimeIsTheCapturedCredentialInstant pins that.
 	for name, value := range map[string]time.Time{
 		"Started":      result.Started,
 		"LastAccessed": result.LastAccessed,
@@ -155,7 +158,7 @@ func TestStartNewUserSession_RecordsTheClient(t *testing.T) {
 	m.store.On("Get", mock.Anything, testSessionName).Return(m.session, nil).Once()
 	m.store.On("Save", mock.Anything, mock.Anything, m.session).Return(nil).Once()
 
-	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.Clients, 1)
@@ -177,7 +180,7 @@ func TestStartNewUserSession_WritesIdentifierIntoTheCookieSession(t *testing.T) 
 
 	m.expectSuccessfulPersist(123, nil)
 
-	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, result.SessionIdentifier, m.session.Values[constants.SessionKeySessionIdentifier])
@@ -211,7 +214,7 @@ func TestStartNewUserSession_IpAddressExtraction(t *testing.T) {
 			m.expectSuccessfulPersist(123, nil)
 
 			result, err := m.manager.StartNewUserSession(
-				httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+				httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantIp, result.IpAddress)
@@ -243,7 +246,7 @@ func TestStartNewUserSession_DeletesMatchingSessionFromSameDeviceAndIp(t *testin
 	m.db.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil).Once()
 
 	_, err := m.manager.StartNewUserSession(
-		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 	assert.NoError(t, err)
 }
@@ -297,7 +300,7 @@ func TestStartNewUserSession_KeepsSessionsFromOtherDevicesOrIps(t *testing.T) {
 
 			_, err := m.manager.StartNewUserSession(
 				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 			assert.NoError(t, err)
 		})
@@ -336,7 +339,7 @@ func TestStartNewUserSession_DoesNotDeleteTheSessionItJustCreated(t *testing.T) 
 	m.store.On("Save", mock.Anything, mock.Anything, m.session).Return(nil).Once()
 
 	_, err := m.manager.StartNewUserSession(
-		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 	assert.NoError(t, err)
 }
@@ -440,7 +443,7 @@ func TestStartNewUserSession_ErrorsPropagate(t *testing.T) {
 
 			result, err := m.manager.StartNewUserSession(
 				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result, "no session may be returned alongside an error")
@@ -461,7 +464,7 @@ func TestStartNewUserSession_WrapsSessionStoreReadError(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 0, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to get the session")
@@ -501,7 +504,7 @@ func TestStartNewUserSession_StampsAuthStateGeneration(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, nil)
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
@@ -524,7 +527,7 @@ func TestStartNewUserSession_StampsOtpConfigGeneration(t *testing.T) {
 	observed := int64(9)
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, &observed)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, &observed, nil)
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
@@ -546,10 +549,109 @@ func TestStartNewUserSession_NilOtpConfigGenerationLandsAtZero(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, nil)
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
 		assert.EqualValues(t, 0, (*captured).OtpConfigGeneration)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// AuthTime: the credential's instant, not this function's clock (#252 decision 8)
+// -----------------------------------------------------------------------------
+
+// AuthTime is the auth_time claim, and OIDC Core 3.1.2.1 makes it max_age's reference point:
+// "the allowable elapsed time in seconds since the last time the End-User was actively
+// authenticated by the OP". The credential is accepted at /auth/pwd or /auth/otp and the
+// session is created two hops later at /auth/completed, with the browser driving the gap, so
+// the two instants are the same only when nobody pauses.
+//
+// 90 minutes is well past any max_age a relying party would send and far outside the window a
+// clock read inside the call could land in, so the assertion cannot pass by coincidence.
+// Started and LastAccessed must stay on now: they measure the session's own life, and pulling
+// them back would shorten it against the idle timeout and the max lifetime.
+func TestStartNewUserSession_AuthTimeIsTheCapturedCredentialInstant(t *testing.T) {
+	m := newStartSessionMocks(t)
+	captured := m.expectSuccessfulPersist(123, nil)
+
+	credentialAcceptedAt := time.Now().UTC().Add(-90 * time.Minute)
+
+	before := time.Now().UTC()
+	result, err := m.manager.StartNewUserSession(
+		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, &credentialAcceptedAt)
+	after := time.Now().UTC()
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
+		assert.True(t, (*captured).AuthTime.Equal(credentialAcceptedAt),
+			"the persisted AuthTime must be the captured credential instant, got %v want %v",
+			(*captured).AuthTime, credentialAcceptedAt)
+	}
+	assert.True(t, result.AuthTime.Equal(credentialAcceptedAt),
+		"the returned session must carry it too: /auth/completed reads AuthTime back off this "+
+			"row and puts it on the AuthContext, which is what the code and then the token sign")
+
+	assert.False(t, result.Started.Before(before), "Started must stay on now")
+	assert.False(t, result.Started.After(after), "Started must stay on now")
+	assert.Equal(t, result.Started, result.LastAccessed)
+	assert.True(t, result.AuthTime.Before(result.Started),
+		"a paused ceremony produces an AuthTime older than the session it creates")
+}
+
+// A non-UTC capture is normalised rather than stored as it arrives. Nothing in the ceremony
+// produces one today (both credential handlers capture time.Now().UTC()), but the column is
+// read back and compared against UTC values by every session view, and a location riding along
+// on the model is the kind of thing that survives until a formatter prints the wrong hour.
+func TestStartNewUserSession_AuthTimeIsNormalisedToUTC(t *testing.T) {
+	m := newStartSessionMocks(t)
+	captured := m.expectSuccessfulPersist(123, nil)
+
+	zone := time.FixedZone("UTC+7", 7*60*60)
+	credentialAcceptedAt := time.Now().In(zone).Add(-30 * time.Minute)
+
+	_, err := m.manager.StartNewUserSession(
+		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, &credentialAcceptedAt)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
+		assert.Equal(t, time.UTC, (*captured).AuthTime.Location(),
+			"AuthTime must be stored in UTC, like Started and LastAccessed")
+		assert.True(t, (*captured).AuthTime.Equal(credentialAcceptedAt),
+			"normalising the location must not move the instant")
+	}
+}
+
+// Nil and zero both mean "this call captured no credential instant", and the only information
+// left to write is now. The one production caller cannot reach either: /auth/completed refuses
+// to mint a session without Level1AuthCompleted, and the password handler that sets it sets
+// AuthenticatedAt beside it. The fallback exists so the field is never left at Go's zero time,
+// which would read as 1 January year 1 in the auth_time claim and in every session view.
+func TestStartNewUserSession_NoCapturedInstantFallsBackToNow(t *testing.T) {
+	var zeroTime time.Time
+	for name, capture := range map[string]*time.Time{
+		"nil":  nil,
+		"zero": &zeroTime,
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := newStartSessionMocks(t)
+			captured := m.expectSuccessfulPersist(123, nil)
+
+			before := time.Now().UTC()
+			_, err := m.manager.StartNewUserSession(
+				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
+				123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, capture)
+			after := time.Now().UTC()
+
+			assert.NoError(t, err)
+			if assert.NotNil(t, *captured, "CreateUserSession was never called") {
+				authTime := (*captured).AuthTime
+				assert.False(t, authTime.IsZero(), "the zero time must never reach the column")
+				assert.False(t, authTime.Before(before), "AuthTime must fall back to now")
+				assert.False(t, authTime.After(after), "AuthTime must fall back to now")
+			}
+		})
 	}
 }

--- a/src/core/user/usersession_manager_start_test.go
+++ b/src/core/user/usersession_manager_start_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/leodip/goiabada/core/uuidutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	mocks_data "github.com/leodip/goiabada/core/data/mocks"
 	mocks_sessionstore "github.com/leodip/goiabada/core/sessionstore/mocks"
@@ -59,6 +60,15 @@ func newStartSessionMocks(t *testing.T) *startSessionMocks {
 	}
 }
 
+// someCredentialInstant is the captured credential instant for the tests that are not about
+// AuthTime. StartNewUserSession refuses nil and zero, so every legitimate call carries one; a
+// fixed offset into the past rather than now, so no assertion in those tests can lean on
+// AuthTime coinciding with the clock.
+func someCredentialInstant() *time.Time {
+	instant := time.Now().UTC().Add(-5 * time.Minute)
+	return &instant
+}
+
 func newSessionRequest(remoteAddr string, userAgent string) *http.Request {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.RemoteAddr = remoteAddr
@@ -93,9 +103,10 @@ func TestStartNewUserSession_PopulatesSessionFields(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	captured := m.expectSuccessfulPersist(123, nil)
+	credentialAcceptedAt := someCredentialInstant()
 
 	before := time.Now().UTC()
-	result, err := m.manager.StartNewUserSession(recorder, req, 123, 7, "pwd otp", enums.AcrLevel2Mandatory.String(), 0, nil, nil)
+	result, err := m.manager.StartNewUserSession(recorder, req, 123, 7, "pwd otp", enums.AcrLevel2Mandatory.String(), 0, nil, credentialAcceptedAt)
 	after := time.Now().UTC()
 
 	assert.NoError(t, err)
@@ -115,21 +126,22 @@ func TestStartNewUserSession_PopulatesSessionFields(t *testing.T) {
 	// one. Compare against the nil spelling itself.
 	assert.NotEqual(t, "00000000-0000-0000-0000-000000000000", parsed)
 
-	// Started, LastAccessed and AuthTime are all stamped with the same UTC now. AuthTime is
-	// only "now" here because this call captured no credential instant, which is the nil
-	// fallback; when one is captured it wins, and
-	// TestStartNewUserSession_AuthTimeIsTheCapturedCredentialInstant pins that.
+	// Started and LastAccessed are stamped with the same UTC now: they measure the session's
+	// own life. AuthTime is the captured credential instant, never this call's clock;
+	// TestStartNewUserSession_AuthTimeIsTheCapturedCredentialInstant pins the distance
+	// between the two, and TestStartNewUserSession_RefusesAMissingCredentialInstant that no
+	// call runs without one.
 	for name, value := range map[string]time.Time{
 		"Started":      result.Started,
 		"LastAccessed": result.LastAccessed,
-		"AuthTime":     result.AuthTime,
 	} {
 		assert.False(t, value.Before(before), "%s must not predate the call", name)
 		assert.False(t, value.After(after), "%s must not postdate the call", name)
 		assert.Equal(t, time.UTC, value.Location(), "%s must be stored in UTC", name)
 	}
 	assert.Equal(t, result.Started, result.LastAccessed)
-	assert.Equal(t, result.Started, result.AuthTime)
+	assert.True(t, result.AuthTime.Equal(*credentialAcceptedAt), "AuthTime must be the captured instant")
+	assert.Equal(t, time.UTC, result.AuthTime.Location(), "AuthTime must be stored in UTC")
 
 	assert.EqualValues(t, 0, result.OtpConfigGeneration,
 		"a nil capture must land the session at generation 0, which is the fail-closed value: "+
@@ -158,7 +170,7 @@ func TestStartNewUserSession_RecordsTheClient(t *testing.T) {
 	m.store.On("Get", mock.Anything, testSessionName).Return(m.session, nil).Once()
 	m.store.On("Save", mock.Anything, mock.Anything, m.session).Return(nil).Once()
 
-	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 	assert.Len(t, result.Clients, 1)
@@ -180,7 +192,7 @@ func TestStartNewUserSession_WritesIdentifierIntoTheCookieSession(t *testing.T) 
 
 	m.expectSuccessfulPersist(123, nil)
 
-	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+	result, err := m.manager.StartNewUserSession(httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 	assert.Equal(t, result.SessionIdentifier, m.session.Values[constants.SessionKeySessionIdentifier])
@@ -214,7 +226,7 @@ func TestStartNewUserSession_IpAddressExtraction(t *testing.T) {
 			m.expectSuccessfulPersist(123, nil)
 
 			result, err := m.manager.StartNewUserSession(
-				httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+				httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantIp, result.IpAddress)
@@ -246,7 +258,7 @@ func TestStartNewUserSession_DeletesMatchingSessionFromSameDeviceAndIp(t *testin
 	m.db.On("DeleteUserSession", mock.Anything, int64(42)).Return(nil).Once()
 
 	_, err := m.manager.StartNewUserSession(
-		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 }
@@ -300,7 +312,7 @@ func TestStartNewUserSession_KeepsSessionsFromOtherDevicesOrIps(t *testing.T) {
 
 			_, err := m.manager.StartNewUserSession(
 				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 			assert.NoError(t, err)
 		})
@@ -339,7 +351,7 @@ func TestStartNewUserSession_DoesNotDeleteTheSessionItJustCreated(t *testing.T) 
 	m.store.On("Save", mock.Anything, mock.Anything, m.session).Return(nil).Once()
 
 	_, err := m.manager.StartNewUserSession(
-		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+		httptest.NewRecorder(), req, 123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 }
@@ -443,7 +455,7 @@ func TestStartNewUserSession_ErrorsPropagate(t *testing.T) {
 
 			result, err := m.manager.StartNewUserSession(
 				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+				123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 			assert.Error(t, err)
 			assert.Nil(t, result, "no session may be returned alongside an error")
@@ -464,7 +476,7 @@ func TestStartNewUserSession_WrapsSessionStoreReadError(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 0, nil, someCredentialInstant())
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to get the session")
@@ -504,7 +516,7 @@ func TestStartNewUserSession_StampsAuthStateGeneration(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
@@ -527,7 +539,7 @@ func TestStartNewUserSession_StampsOtpConfigGeneration(t *testing.T) {
 	observed := int64(9)
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, &observed, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, &observed, someCredentialInstant())
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
@@ -549,7 +561,7 @@ func TestStartNewUserSession_NilOtpConfigGenerationLandsAtZero(t *testing.T) {
 
 	_, err := m.manager.StartNewUserSession(
 		httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
-		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, nil)
+		123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, someCredentialInstant())
 
 	assert.NoError(t, err)
 	if assert.NotNil(t, *captured, "CreateUserSession was never called") {
@@ -624,12 +636,15 @@ func TestStartNewUserSession_AuthTimeIsNormalisedToUTC(t *testing.T) {
 	}
 }
 
-// Nil and zero both mean "this call captured no credential instant", and the only information
-// left to write is now. The one production caller cannot reach either: /auth/completed refuses
-// to mint a session without Level1AuthCompleted, and the password handler that sets it sets
-// AuthenticatedAt beside it. The fallback exists so the field is never left at Go's zero time,
-// which would read as 1 January year 1 in the auth_time claim and in every session view.
-func TestStartNewUserSession_NoCapturedInstantFallsBackToNow(t *testing.T) {
+// Nil and zero both mean "this call captured no credential instant", and there is nothing true
+// to write into AuthTime, so the call is refused before anything is touched: no transaction, no
+// row, no cookie. Falling back to now here would recreate the exact defect #252 decision 8
+// removed, one broken caller away -- a session claiming the user authenticated at the moment
+// the redirect landed, whoever was holding the browser. The one production caller cannot reach
+// this branch: /auth/completed refuses to mint a session without Level1AuthCompleted, and the
+// password handler that sets it sets AuthenticatedAt beside it. The refusal is what turns that
+// invariant from an argument in a comment into a check that fails closed.
+func TestStartNewUserSession_RefusesAMissingCredentialInstant(t *testing.T) {
 	var zeroTime time.Time
 	for name, capture := range map[string]*time.Time{
 		"nil":  nil,
@@ -637,21 +652,27 @@ func TestStartNewUserSession_NoCapturedInstantFallsBackToNow(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := newStartSessionMocks(t)
-			captured := m.expectSuccessfulPersist(123, nil)
+			recorder := httptest.NewRecorder()
 
-			before := time.Now().UTC()
-			_, err := m.manager.StartNewUserSession(
-				httptest.NewRecorder(), newSessionRequest("192.168.1.50:54321", chromeUserAgent),
+			result, err := m.manager.StartNewUserSession(
+				recorder, newSessionRequest("192.168.1.50:54321", chromeUserAgent),
 				123, 7, "pwd", enums.AcrLevel1.String(), 7, nil, capture)
-			after := time.Now().UTC()
 
-			assert.NoError(t, err)
-			if assert.NotNil(t, *captured, "CreateUserSession was never called") {
-				authTime := (*captured).AuthTime
-				assert.False(t, authTime.IsZero(), "the zero time must never reach the column")
-				assert.False(t, authTime.Before(before), "AuthTime must fall back to now")
-				assert.False(t, authTime.After(after), "AuthTime must fall back to now")
-			}
+			require.ErrorContains(t, err, "no credential instant captured")
+			assert.Nil(t, result, "a refused call must hand back no session")
+
+			// Nothing may have been written on either side of the refusal: the argument
+			// counts below match each method's arity, because AssertNotCalled compares the
+			// whole argument list and a wrong count would match nothing and assert nothing.
+			m.db.AssertNotCalled(t, "RunInTransaction", mock.Anything)
+			m.db.AssertNotCalled(t, "CreateUserSession", mock.Anything, mock.Anything)
+			m.db.AssertNotCalled(t, "CreateUserSessionClient", mock.Anything, mock.Anything)
+			m.db.AssertNotCalled(t, "GetUserSessionsByUserId", mock.Anything, mock.Anything)
+			m.db.AssertNotCalled(t, "DeleteUserSession", mock.Anything, mock.Anything)
+			m.store.AssertNotCalled(t, "Get", mock.Anything, mock.Anything)
+			m.store.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+			assert.Empty(t, recorder.Header().Values("Set-Cookie"),
+				"no cookie may be written for a session that was never created")
 		})
 	}
 }


### PR DESCRIPTION
Issue #252: document the ceremony's state machine and the two decisions the #239 review closed.

## What this change is for

`CLAUDE.md` and `AGENTS.md` describe the authorization-code ceremony as a numbered list of states that
"transition in this order", with no gates and no transitions, and open by saying the context is stored
in a session cookie, which #266 made false. This change replaces the list with two tables built from
today's handlers (which handler assigns each state and when; which state each route accepts and what
it answers on a mismatch), states the rule for `AuthContext` fields across a restart and names the
one field that breaks it today (`AuthMethods`, #140), and adds a guard so the two agent files cannot
drift from the constants or from each other. On the site, `acr-amr.mdx` gains two sentences saying
`mfa` is not emitted and what `auth_time` means after a step-up, and `authorization-lifecycle.mdx`
stops saying `auth_time` is the code's creation time.

## The rules it establishes

- `CLAUDE.md` and `AGENTS.md` are byte-identical, and every `AuthState*` constant value appears in the
  Auth States section of `CLAUDE.md`, and every state that section names is a constant. Held by
  `TestAgentDocsAreCurrent` in all three module tiers, through `core/testutil.AssertAgentDocs`.
- `auth_time` is the moment the user last entered a credential. A step-up moves it; only silent
  (`prompt=none`) and SSO reuse keep the earlier value. This documents the code as it has behaved
  since #60; the issue body had it inverted.
- `mfa` is not emitted in `amr`: nothing in RFC 8176 or OIDC Core requires it, and `amr` plus `acr`
  already carry the fact.

**Status:** complete. Both stages landed, the final review is clean at round 2, the one blocking
question it raised was answered by the user and applied, and the check suite is green on the final
commit `25367f84`
([run](https://github.com/leodip/goiabada/actions/runs/34687781866), 13 of 13 jobs). Ready for review.

## What has landed

### Stage 1: the state tables, the field rule and the agent-docs guard
`aa0d6fa9`. The `### Auth States (State Machine)` section of `CLAUDE.md` is now two tables rebuilt
from today's handlers: an assigned-by table of 18 rows (every state, the handler that writes it, and
the condition), and an accepted-by table of 12 rows (route, method, states accepted, status on
mismatch). Both dead constants are marked dead with #248 part 2 as the pointer, and marked
differently because they are dead differently: `initial` is written by the composite literal but
accepted by no gate, `level2_otp_completed` is written by nobody. The SSO shortcut and the
`level2_optional` skip are rows rather than a footnote. The intro sentence now says the context lives
in the server-side store keyed by a cookie (#266).

A new `### AuthContext field rule` section states the rule, names the two restart routes, and names
`AuthMethods` as the one field breaking it today, with #140 as the pointer and an explicit note that
the sentence is owed deletion when #140 lands. `AGENTS.md` is a byte-identical copy, which also
landed the "Test fixtures" paragraph it had drifted without.

The guard is `core/testutil.AssertAgentDocs`: the two files identical, reporting the first differing
line; and the section's roster equal to the `AuthState*` constants parsed out of `auth_context.go`
with `go/parser`. The roster rule reads the *first cell* of each row rather than any occurrence in
the section, because the accepted-by table repeats most values in its `Accepts` column and a looser
rule would still pass after a state's own row was deleted. Transitions are deliberately not checked.
`TestAgentDocsAreCurrent` calls it from all three module tiers; `TestAgentDocs_TheRuleTable` holds
the rules against a temp tree, 10 cases, each asserting the finding's text.

Unit green, 5981 ok 0 fail. Data and integration not applicable: no handler, route, query or
migration moved. Both guard rules mutation-tested and caught (`AGENTS.md` drifted one line; a state
constant's value renamed). One deviation: `check-anchors.sh` went red on `claude/state-intro` because
step 1 rewrote the exact sentence that anchor located, so section 0 was re-swept to the new text.

### Stage 2: the site's `mfa`, step-up `auth_time` and lifecycle sentences
`856ac120`. Three sentences, on two pages.

`concepts/acr-amr.mdx`, after the `amr` examples: Goiabada never emits the `mfa` value, and an
application reads `amr` for the methods and `acr` for the level. RFC 8176 section 2 defines `mfa` and
registers it and asks for nothing further, OIDC Core section 2 only says `amr` values SHOULD come
from that registry, and `["pwd", "otp"]` already says two factors were used.

Same page, after the step-up paragraph: `auth_time` becomes the time the OTP was entered, only
`prompt=none` and plain session reuse keep the earlier time, and no claim carries the first factor's
time after a step-up. `concepts/authorization-lifecycle.mdx` Stage 5 said `auth_time` "reflects when
the authorization code was created", which is false on the SSO reuse arm and imprecise on every other
one, since a consent screen can sit between the credential and the code indefinitely; it now says the
moment the user last entered a credential, and that a reused session keeps the session's time.

Sizes, `check-docs.sh --working`: the AMR section 87 to 112 words, the step-up section 109 to 150,
lifecycle Stage 5 84 to 90. Two sentences each, as the agreement capped them, and no sibling warning
on either page. The step-up sentence was written against a re-run of the two unit tests that pin the
behaviour, not from the review's snapshot.

Unit green, 5981 ok 0 fail, though no Go file moved; the site builds, 43 pages, no new warning. Data
and integration not applicable. Two deviations: the dev container has no `npm`, so the site build ran
on the host against the committed lockfile; and the lifecycle sentence was cut from 39 words back to
35 to hold the "same length" cap the agreement set for it.

### After the final review: `auth_time` is the credential's instant, not the ceremony's
`ca1e9daf`. Round 1 found the two sentences stage 2 wrote disagreeing with the code they described.
They say `auth_time` is the moment the user entered a password or an OTP; the code read the clock
again at `/auth/completed` and used the instant it had already captured as nothing but a yes/no
flag. The browser owns the hop between those two writes, so a tab left sitting after the password
was accepted and resumed later minted a token saying the user had actively authenticated just now —
and a relying party that sent `max_age` and read `auth_time` back to confirm a fresh sign-in was
told it had one, about whoever was holding that browser when it resumed.

The user chose to move the code rather than reword the sentences (**decision 8** on this thread),
which is why a documentation change ends with a handler in it. The reuse arm in
`handler_auth_completed.go` now writes `authContext.AuthenticatedAt`, and `StartNewUserSession`
takes the instant as a parameter and stamps it on the new row. `Started` and `LastAccessed` stay on
now: they measure the session's own life, and pulling them back would shorten it against the idle
timeout and the max lifetime. SSO reuse and `prompt=none` are untouched — nothing was captured, so
the session keeps the timestamp it had. The sentences on the two pages stand exactly as stage 2
wrote them; no documentation changed in this commit.

Both arms are tested with a capture 90 minutes old, which is the only thing that tells the two
instants apart: "now" passes against either behaviour. `TestAuthTime_IsTheInstantTheCredentialWasAccepted`
drives the whole stack on both arms with the browser pausing two seconds after the password is
accepted, and asserts the ID token's `auth_time` falls inside the window the password was submitted
in and strictly before the browser resumed; it reads `sid` to prove the second ceremony really took
the reuse arm. Unit 6184/0, data (sqlite) 537/0, integration (sqlite) 1374/0. Four mutations, all
caught.

This is a deviation from the agreement worth naming: section 4 said "No handler, model or schema
moves", and this commit moves two. It is the user's call, taken with the cost in front of them.

### After round 2: why `OTPKeyURL` is safe across a restart
`25367f84`. Round 2 was clean and raised one follow-up, which was verified against the source and
taken here rather than filed. The field rule listed `OTPKeyURL` among the fields "overwritten before
anything reads it again", on "every arm of `/auth/otp`". `handler_auth_otp.go:121-131` deliberately
does the opposite: the enrolment arm regenerates the key **only when parsing the stored one fails**,
because replacing it on every GET replaced the seed behind a QR code the user had already scanned
(#242 part 3). The conclusion held and only the reason was false; the correct reason is
reachability. `handler_auth_otp.go` is the field's only reader and writer, both its routes gate on
`level2_otp`, and the one transition out of that state clears it, so neither restart route can reach
a stale key. Both agent files edited identically; `cmp CLAUDE.md AGENTS.md` empty. Unit 5986/0, no Go
file moved.

## Tiers

**Locally, in the dev container.** Unit, all three modules, at every stage and at the final commit:
5986 pass / 0 fail at `25367f84`, 6184 / 0 at `ca1e9daf` where the new Go tests landed. Data (sqlite)
537 / 0 and integration (sqlite) 1374 / 0 at `ca1e9daf`, including the new
`TestAuthTime_IsTheInstantTheCredentialWasAccepted` at 4.23s. Both are recorded not applicable at the
two documentation stages and at `25367f84`, which move no Go file, query, handler, route or
migration. Plus the Astro site build at stage 2, 43 pages, no new warning, and `check-anchors.sh`
31 of 31 after every commit.

**In the check suite, and only there.** The data and integration tiers on MySQL, PostgreSQL and SQL
Server; the race detector leg; Lint, Vulnerabilities, Versions and Build validation. All thirteen
jobs are green on the final commit `25367f84`
([run](https://github.com/leodip/goiabada/actions/runs/34687781866)) and were green on `ca1e9daf` too,
which is where the four-engine claim for the new integration test rests.

## Deviations from the agreement

1. **Section 4 said "No handler, model or schema moves"; two Go files move.** The consequence of
   decision 8, answered by the user on this thread with the cost in front of them.
   `handler_auth_completed.go`, `core/user/usersession_manager.go`, the interface and its generated
   mock, plus the tests.
2. **The field rule is longer than budgeted.** Section 2 asked for "four or five sentences"; it is
   six, and 250 words. Recorded rather than trimmed: two review rounds established that each field
   needs its own reason rather than a shared one, and cutting to the stated length would mean
   dropping something section 2 asked for or restoring a reason the source contradicts.
3. **The site build ran on the host, not in the dev container**, which has no `npm`. Against the
   committed lockfile.
4. **`check-anchors.sh` went red at stage 1** because the step rewrote the exact sentence an anchor
   located. Section 0 was re-swept to the new text rather than the edit being reverted.

### Review

Reviewed by `openai-codex/gpt-5.6-sol` at effort `xhigh`, 2 rounds over the whole branch, plus one
round at the plan gate before any code was written. No stage was reviewed on its own.

| Gate | Round | Findings | Blocking | Outcome |
|---|---|---|---|---|
| plan | 1 | 5 | 2 | all fixed in the plan, before implementation |
| final | 1 | 4 | 1 | `2f4f2be7`, `ca1e9daf` |
| final | 2 | 0 | 0 | clean; one follow-up it raised was taken in `25367f84` |

- **blocking, security (final 1):** the two new documentation sentences called `auth_time` the moment
  the credential was accepted, while both writes read the clock again at `/auth/completed` — so a
  browser that paused mid-ceremony minted a token claiming a sign-in that had just happened, and a
  relying party using `max_age` was told it was fresh. Escalated as decision 8 rather than fixed
  either way, because the two repairs pointed in opposite directions. Fixed in `ca1e9daf` on the
  user's answer: both arms now write the captured credential instant.
- **significant, conformance (final 1):** the new `mfa` sentence asserted `["pwd", "otp"]` proves two
  factors were used, contradicting this same branch's field rule while #140 is open. Fixed in
  `2f4f2be7`: it now claims only what holds whatever #140 does.
- **blocking, correctness (plan 1), two of them:** the roster guard was specified against `const`
  while the constants sit under `var (`, and against whole-section occurrence, which would still pass
  after a state's own row was deleted; and `SourceRoot` returns `src`, so the checker would have
  looked for the agent files inside it. Both fixed in `plan.md` before implementation.

Full account, with the evidence, the mutation tables and what each round ran, in
[this comment](https://github.com/leodip/goiabada/pull/322#issuecomment-5645300616).

## The rest of the run's account

- [Deferred decisions](https://github.com/leodip/goiabada/pull/322#issuecomment-5645288818): none.
  Decision 8 was escalated and answered rather than assumed; the comment says what reversing it costs.
- [Follow-ups, fold-ins and ceilings](https://github.com/leodip/goiabada/pull/322#issuecomment-5645291380):
  two additions to open issues (#140 and #248), with the `gh` commands that file them; five things
  folded in rather than filed; no ceiling markers.

## For the release notes

`auth_time` in the ID token now names the instant the user's password or OTP was accepted, rather
than the instant the sign-in redirect chain finished. The two are milliseconds apart in an ordinary
sign-in and nothing needs doing on upgrade. They differ when a browser pauses mid-ceremony: such a
sign-in now reports its true age, so a relying party using `max_age` to demand a fresh
authentication will correctly judge it stale and re-prompt, where before it was told the sign-in had
just happened. Single sign-on and `prompt=none` are unchanged: a session reused without
re-authentication keeps the timestamp it had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
