### PR TITLE
Define and enforce the shared-kernel boundary (#332)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ src/
 - **Auth Server** (`src/authserver/go.mod`): Main auth endpoints, token issuance
 - **Admin Console** (`src/adminconsole/go.mod`): Admin management UI
 
+Which module owns what, and the rules that keep it that way, are in `ARCHITECTURE.md` at the
+repository root. It is enforced rather than descriptive: see **Architecture guard** under Testing.
+
 ## Key Directories
 
 ### Core (`src/core/`)
@@ -331,6 +334,16 @@ file under `src/` to gofmt's formatting through `core/testutil.AssertGofmted`. T
 repository-wide from each tier because `cmd/goiabada-setup` has no tier of its own. CI's Lint job
 checks the same thing per module, where an unformatted file also costs that module its vet,
 unparam and golangci-lint run.
+
+**Architecture guard**: `ARCHITECTURE.md` at the repository root records the allowed module edges,
+the intended final owner of every top-level `core` package, the temporary exceptions to those rules,
+and the third-party modules the admin console must not compile. Its three tables are data, not
+prose: `AssertArchitecture` in `core/testutil/architecture.go` parses them and checks them against
+the real import graph, and all three module unit tiers call it. The check runs in both directions,
+which is what makes the document a burn-down list rather than a wish — an edge the tables do not
+allow is a failure, and so is an exception left standing for an edge that no longer exists, so the
+issue that removes an edge has to remove its row with it (#332). A new top-level `core` package
+fails the tier until the table says where it belongs.
 
 **Schema golden files**: each engine's fully migrated catalog is recorded in
 `src/core/data/<engine>db/schema.golden`, and the data tier compares a freshly migrated database

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,9 +126,9 @@ Notes on rows that are not self-evident:
 - `core/audit` holds no package of its own. It is a directory containing `mocks` and nothing else,
   and nothing in the repository imports it — not one production file, not one test. #333 deletes it.
 - `core/mocks` and `core/testutil` are kernel because they are test support compiled into no binary.
-  They are still held to the kernel rule: `core/testutil` imports `core/uuidutil` today, and that is
-  an exception below rather than a waiver, because #360 moves `uuidutil` and the edge has to be
-  noticed then.
+  They are still held to the kernel rule: `core/testutil/fake` imports `core/uuidutil` today, and
+  that is an exception below rather than a waiver, because #360 moves `uuidutil` and the edge has to
+  be noticed then.
 - `core/api` stays, but only as declarations. The model-aware `ToResponse` mapping leaves in #349
   and the model-typed fields leave in #350; what remains is the wire contract the admin console
   decodes.
@@ -168,6 +168,12 @@ removes it. An exception is not a waiver: when the edge goes, the row must go wi
 fails until it does. That is how the epic burns down — #335 already instructs its implementer to
 "remove the exact architecture exceptions introduced by #332 for these edges".
 
+Both ends name a package, never a module and never a parent. `adminconsole/internal/handlers` is
+granted its dependency on `core/models`; `adminconsole` is not, and neither is
+`adminconsole/internal/handlers/adminuserhandlers`, which is why it has a row of its own. A
+module-wide grant would let a second package acquire the same dependency in silence, and the count
+of rows is the only measure of how much is left to do.
+
 ### Temporary exceptions
 
 | from | to | issue |
@@ -177,13 +183,20 @@ fails until it does. That is how the epic burns down — #335 already instructs 
 | `core/handlerhelpers` | `core/hashutil` | #360 |
 | `core/handlerhelpers` | `core/models` | #337 |
 | `core/i18n` | `core/models` | #337 |
-| `core/testutil` | `core/uuidutil` | #360 |
-| `adminconsole` | `core/communication` | #347 |
-| `adminconsole` | `core/models` | #350 |
-| `adminconsole` | `core/user` | #346 |
+| `core/testutil/fake` | `core/uuidutil` | #360 |
+| `adminconsole/internal/apiclient` | `core/models` | #350 |
+| `adminconsole/internal/handlers` | `core/communication` | #347 |
+| `adminconsole/internal/handlers` | `core/models` | #350 |
+| `adminconsole/internal/handlers` | `core/user` | #346 |
+| `adminconsole/internal/handlers/accounthandlers` | `core/models` | #350 |
+| `adminconsole/internal/handlers/adminclienthandlers` | `core/models` | #350 |
+| `adminconsole/internal/handlers/admingrouphandlers` | `core/models` | #350 |
+| `adminconsole/internal/handlers/adminresourcehandlers` | `core/models` | #350 |
+| `adminconsole/internal/handlers/adminuserhandlers` | `core/models` | #350 |
+| `adminconsole/internal/middleware` | `core/models` | #350 |
 
-A `from` of `adminconsole` or `authserver` means any production package in that module. A `from`
-naming a `core` package means that package.
+Sixteen rows, and #350 owns nine of them: the admin console's dependency on persistence models is
+the single largest piece of the boundary still to close.
 
 ## Foreign modules the admin console must not compile
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,245 @@
+# Architecture
+
+This file records which module owns what, and it is executable. The three tables below —
+[package ownership](#package-ownership), [temporary exceptions](#temporary-exceptions) and
+[foreign modules](#foreign-modules-the-admin-console-must-not-compile) — are parsed by
+`AssertArchitecture` in `src/core/testutil/architecture.go`, which every module's unit tier calls.
+A row that stops describing the tree fails the tier, in both directions: an edge the tables do not
+allow is a finding, and so is an exception listed for an edge that no longer exists.
+
+That is the whole point of writing it down here rather than in prose. The dependency direction
+between these three modules is not visible at a call site and is not a compile error until the day
+it becomes a cycle, so it is the kind of rule that decays silently. This repository already learned
+that lesson once about prose: `AssertAgentDocs` exists because the state machine documented in
+`CLAUDE.md` had moved underneath the description while every test stayed green (#252).
+
+The refactor that these rules were written for is the 29-issue Core Refactor epic. Its full
+checklist lives in [#332](https://github.com/leodip/goiabada/issues/332); every `moves in` and
+`cleared by` cell below names one of its issues.
+
+## Module graph
+
+Four Go modules live under `src/`:
+
+| module | what it is |
+|---|---|
+| `core` | the shared kernel: contracts both processes compile |
+| `authserver` | the OAuth2/OIDC provider process |
+| `adminconsole` | the admin UI process, which is an OAuth *client* of the auth server |
+| `cmd/goiabada-setup` | the standalone setup wizard |
+
+`authserver`, `adminconsole` and `cmd/goiabada-setup` may import `core`. Nothing else is allowed:
+`core` may not import any of the three, and `authserver` and `adminconsole` may not import each
+other. The two processes talk over HTTP, never by linking each other's code, and the admin console
+is an ordinary API client of the auth server — a consumer of its wire contract, not a peer with
+access to its internals.
+
+This much holds today with no exceptions. The rules below are the ones that do not.
+
+## Definitions
+
+The epic moves code on the strength of five distinctions, so they are written down before the table
+that applies them.
+
+- **Shared contract** — a type or function both processes compile, whose shape is fixed either by a
+  specification outside this repository or by the HTTP boundary between the two processes. Stable
+  by obligation rather than by habit: changing one is a change to something external. Belongs in
+  `core`.
+- **Application service** — behaviour implementing one process's policy: issuing a code, rotating a
+  key, deciding a session is still valid, delivering mail. Belongs to that process even when its
+  inputs and outputs look generic, because the policy is what makes it correct, and the policy is
+  owned by exactly one process.
+- **Adapter** — code binding a contract to one concrete technology or topology: a database engine,
+  an SMTP server, an HTTP backend for a session store. Belongs to the process that owns the
+  resource. An adapter is the usual way a heavy third-party dependency enters a binary.
+- **Persistence model** — a struct whose field tags, null handling and scan behaviour describe a
+  database row. It belongs with the database, and it is not a wire DTO even when it serializes to
+  JSON that looks right.
+- **Wire DTO** — a struct whose field tags describe JSON crossing the HTTP boundary between the two
+  processes. Belongs in `core`, and must not embed a persistence model: doing so republishes the
+  database's shape as the API's, so a column rename becomes a breaking API change (#350).
+
+The test that decides `core` membership is not "is it reusable" but "do both processes consume it,
+or is it an intentionally stable cross-process contract". Reusability is a property of almost any
+well-written package and is the reason `core` grew into a second application.
+
+## Package ownership
+
+Every top-level package under `src/core` has a row. `owner` is where the package must end up, not
+where it is today.
+
+- `kernel` — stays in `core`.
+- `authserver` / `adminconsole` — moves to that module.
+- `split` — part stays in `core` and part moves; the named issue decides the line. No edge rule
+  applies to a split package until its issue lands, because at package granularity there is nothing
+  yet to check.
+- `delete` — has no future; the named issue removes it.
+
+A row whose owner is not `kernel` names the issue that moves it. A `kernel` row names none.
+
+### Package ownership
+
+| package | owner | moves in |
+|---|---|---|
+| `core/api` | kernel | — |
+| `core/audit` | delete | #333 |
+| `core/auditlog` | authserver | #359 |
+| `core/cmd` | authserver | #358 |
+| `core/communication` | authserver | #347 |
+| `core/config` | split | #351 |
+| `core/constants` | split | #352 |
+| `core/countries` | kernel | — |
+| `core/customerrors` | kernel | — |
+| `core/data` | authserver | #359 |
+| `core/encryption` | authserver | #360 |
+| `core/enums` | kernel | — |
+| `core/errs` | kernel | — |
+| `core/handlerhelpers` | kernel | — |
+| `core/hashutil` | authserver | #360 |
+| `core/i18n` | kernel | — |
+| `core/imaging` | authserver | #348 |
+| `core/locales` | kernel | — |
+| `core/logging` | kernel | — |
+| `core/middleware` | split | #335 |
+| `core/mocks` | kernel | — |
+| `core/models` | authserver | #359 |
+| `core/oauth` | split | #338 |
+| `core/oauthdb` | authserver | #340 |
+| `core/oidc` | authserver | #360 |
+| `core/otp` | authserver | #348 |
+| `core/phonecountries` | authserver | #345 |
+| `core/ratelimit` | authserver | #336 |
+| `core/rsautil` | authserver | #360 |
+| `core/sessionstore` | split | #334 |
+| `core/stringutil` | kernel | — |
+| `core/testutil` | kernel | — |
+| `core/timezones` | kernel | — |
+| `core/uithemes` | authserver | #348 |
+| `core/urlutil` | authserver | #360 |
+| `core/user` | authserver | #346 |
+| `core/useragent` | authserver | #346 |
+| `core/uuidutil` | authserver | #360 |
+| `core/validators` | split | #344 |
+
+Notes on rows that are not self-evident:
+
+- `core/audit` holds no package of its own. It is a directory containing `mocks` and nothing else,
+  and nothing in the repository imports it — not one production file, not one test. #333 deletes it.
+- `core/mocks` and `core/testutil` are kernel because they are test support compiled into no binary.
+  They are still held to the kernel rule: `core/testutil` imports `core/uuidutil` today, and that is
+  an exception below rather than a waiver, because #360 moves `uuidutil` and the edge has to be
+  noticed then.
+- `core/api` stays, but only as declarations. The model-aware `ToResponse` mapping leaves in #349
+  and the model-typed fields leave in #350; what remains is the wire contract the admin console
+  decodes.
+- `core/oauth` is the largest split. The admin console is an OAuth client: it needs token response
+  values, PKCE and JWT/JWKS validation. It does not issue codes or tokens and does not rotate
+  signing keys. #338 draws that line; #339, #341, #342 and #343 carry the provider half away.
+
+## Rules
+
+The guard reports findings by these names.
+
+1. **module direction** — only the edges in [Module graph](#module-graph). Checked in production
+   and test files alike, because a test that imports across a forbidden edge still proves the two
+   modules are coupled.
+2. **kernel purity** — a `kernel` package may not import a package owned by `authserver`,
+   `adminconsole` or `delete`. This is the rule that keeps `core` from being an application.
+3. **process isolation** — `adminconsole` may not import an `authserver`-owned package, and vice
+   versa. `cmd/goiabada-setup` may import neither.
+4. **dead package** — a `delete` package must have no importer anywhere, production or test. If one
+   appears, the row is wrong and the package is not dead.
+5. **foreign closure** — the modules in
+   [Foreign modules](#foreign-modules-the-admin-console-must-not-compile) must be reachable from the
+   admin console's production packages exactly as declared there.
+6. **table hygiene** — every top-level `core` package has exactly one ownership row; every non-kernel
+   row names an issue and every kernel row names none; every exception corresponds to a violation
+   that exists right now; every violation has an exception.
+
+Rules 2, 3 and 4 read production files only. A test may import a mock, a fixture or a helper from
+anywhere; that is what test code is for, and holding it to the production graph would make
+`core/testutil` unusable from the tiers that call it. Rule 1 is the exception, for the reason given
+above. Rule 5 reads production files because it is about what lands in a shipped binary.
+
+## Temporary exceptions
+
+Each row is one exact package edge that exists today and violates a rule above, with the issue that
+removes it. An exception is not a waiver: when the edge goes, the row must go with it, and the guard
+fails until it does. That is how the epic burns down — #335 already instructs its implementer to
+"remove the exact architecture exceptions introduced by #332 for these edges".
+
+### Temporary exceptions
+
+| from | to | issue |
+|---|---|---|
+| `core/api` | `core/models` | #350 |
+| `core/customerrors` | `core/models` | #350 |
+| `core/handlerhelpers` | `core/hashutil` | #360 |
+| `core/handlerhelpers` | `core/models` | #337 |
+| `core/i18n` | `core/models` | #337 |
+| `core/testutil` | `core/uuidutil` | #360 |
+| `adminconsole` | `core/communication` | #347 |
+| `adminconsole` | `core/models` | #350 |
+| `adminconsole` | `core/user` | #346 |
+
+A `from` of `adminconsole` or `authserver` means any production package in that module. A `from`
+naming a `core` package means that package.
+
+## Foreign modules the admin console must not compile
+
+The admin console is a web UI that talks to the auth server over HTTP. It opens no database, sends
+no mail and generates no TOTP codes, so the libraries that do those things have no business in its
+binary. They are there anyway: `adminconsole/go.mod` lists all four database drivers as indirect
+dependencies, every one of them arriving through `core`.
+
+This is the concrete harm the epic exists to fix, and it is measurable, so the guard measures it.
+`reachable today` is asserted against the real transitive import closure of the admin console's
+production packages. A module listed `no` that becomes reachable is a regression; a module listed
+`yes` that stops being reachable is a row to delete. `cleared by` is the issue expected to do it and
+is documentation only — if an earlier issue gets there first, the guard says so and the row changes
+then.
+
+### Foreign modules
+
+| module | why it must not be there | reachable today | cleared by |
+|---|---|---|---|
+| `modernc.org/sqlite` | SQLite driver | yes | #359 |
+| `github.com/go-sql-driver/mysql` | MySQL driver | yes | #359 |
+| `github.com/jackc/pgx/v5` | PostgreSQL driver | yes | #359 |
+| `github.com/microsoft/go-mssqldb` | SQL Server driver | yes | #359 |
+| `github.com/huandu/go-sqlbuilder` | SQL construction | yes | #359 |
+| `github.com/mileusna/useragent` | session user-agent parsing | yes | #346 |
+| `github.com/pquerna/otp` | TOTP generation | no | — |
+
+Every driver arrives the same way, through one edge:
+
+```
+adminconsole/cmd/goiabada-adminconsole -> core/oauth -> core/data -> core/data/<engine> -> driver
+```
+
+`core/data/database.go` imports all four engine packages, so importing `core/data` at all compiles
+every driver. Five of the core packages the admin console imports reach `core/data`: `core/oauth`,
+`core/user`, `core/middleware`, `core/validators` and `core/sessionstore`. Closing one path changes
+nothing on its own, which is why the table asserts reachability rather than counting edges.
+
+`github.com/pquerna/otp` is listed at `no` deliberately. It is not reachable now, `core/otp` moves
+to the auth server in #348, and the row states that it must not arrive in the meantime.
+
+## The guard
+
+`AssertArchitecture` lives in `src/core/testutil/architecture.go` and is called from all three
+module unit tiers, so it fires whichever tier runs — the same arrangement as the gofmt, error,
+slog and agent-document guards.
+
+It reads imports from the AST rather than matching text, so an import inside a comment or a string
+is not a finding and a renamed import alias still is one. It parses production and test files
+separately because the rules above treat them differently.
+
+`src/core/testutil/architecture_lint_test.go` is the core tier's caller;
+`src/core/testutil/architecture_rules_test.go` holds the guard's own tests. They run the rule table
+against fixture trees written into a temp directory, one fixture per rule and per deliberate
+leniency, and then take the real tables apart one row at a time — dropping each exception and
+flipping each declared reachability — because the tree satisfies this document by construction, so
+passing proves nothing on its own. A guard that has quietly stopped matching anything passes a clean
+tree exactly the way it passes a correct one; `errors_lint_test.go` sets out the same reasoning for
+the same problem (#279).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,7 +82,6 @@ A row whose owner is not `kernel` names the issue that moves it. A `kernel` row 
 | package | owner | moves in |
 |---|---|---|
 | `core/api` | kernel | — |
-| `core/audit` | delete | #333 |
 | `core/auditlog` | authserver | #359 |
 | `core/cmd` | authserver | #358 |
 | `core/communication` | authserver | #347 |
@@ -123,8 +122,10 @@ A row whose owner is not `kernel` names the issue that moves it. A `kernel` row 
 
 Notes on rows that are not self-evident:
 
-- `core/audit` holds no package of its own. It is a directory containing `mocks` and nothing else,
-  and nothing in the repository imports it — not one production file, not one test. #333 deletes it.
+- There is no `core/audit` row because there is no `core/audit` in the repository. #333 lists it for
+  deletion, and it does exist as a directory of generated mocks in a working tree that has run the
+  mock generator, but git has never tracked a file under it. A row for it fails the completeness
+  rule, which is how this was found.
 - `core/mocks` and `core/testutil` are kernel because they are test support compiled into no binary.
   They are still held to the kernel rule: `core/testutil/fake` imports `core/uuidutil` today, and
   that is an exception below rather than a waiver, because #360 moves `uuidutil` and the edge has to
@@ -221,7 +222,6 @@ then.
 | `github.com/jackc/pgx/v5` | PostgreSQL driver | yes | #359 |
 | `github.com/microsoft/go-mssqldb` | SQL Server driver | yes | #359 |
 | `github.com/huandu/go-sqlbuilder` | SQL construction | yes | #359 |
-| `github.com/mileusna/useragent` | session user-agent parsing | yes | #346 |
 | `github.com/pquerna/otp` | TOTP generation | no | — |
 
 Every driver arrives the same way, through one edge:
@@ -237,6 +237,12 @@ nothing on its own, which is why the table asserts reachability rather than coun
 
 `github.com/pquerna/otp` is listed at `no` deliberately. It is not reachable now, `core/otp` moves
 to the auth server in #348, and the row states that it must not arrive in the meantime.
+
+The table is a declared list, not a discovery mechanism: it asserts these modules and says nothing
+about a dependency nobody has written a row for. Closing that would mean an allowlist of every
+module the admin console legitimately compiles, churned on every dependency change, which is a wider
+rule than #332 asks for. #360 is where the categories in its point 5 — database drivers, sqlbuilder,
+OTP and image libraries, provider-only crypto — are checked off, and each is listed here.
 
 ## The guard
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,11 +217,11 @@ then.
 
 | module | why it must not be there | reachable today | cleared by |
 |---|---|---|---|
-| `modernc.org/sqlite` | SQLite driver | yes | #359 |
-| `github.com/go-sql-driver/mysql` | MySQL driver | yes | #359 |
-| `github.com/jackc/pgx/v5` | PostgreSQL driver | yes | #359 |
-| `github.com/microsoft/go-mssqldb` | SQL Server driver | yes | #359 |
-| `github.com/huandu/go-sqlbuilder` | SQL construction | yes | #359 |
+| `modernc.org/sqlite` | SQLite driver | yes | #353 |
+| `github.com/go-sql-driver/mysql` | MySQL driver | yes | #353 |
+| `github.com/jackc/pgx/v5` | PostgreSQL driver | yes | #353 |
+| `github.com/microsoft/go-mssqldb` | SQL Server driver | yes | #353 |
+| `github.com/huandu/go-sqlbuilder` | SQL construction | yes | #353 |
 | `github.com/pquerna/otp` | TOTP generation | no | — |
 
 Every driver arrives the same way, through one edge:
@@ -234,6 +234,14 @@ adminconsole/cmd/goiabada-adminconsole -> core/oauth -> core/data -> core/data/<
 every driver. Five of the core packages the admin console imports reach `core/data`: `core/oauth`,
 `core/user`, `core/middleware`, `core/validators` and `core/sessionstore`. Closing one path changes
 nothing on its own, which is why the table asserts reachability rather than counting edges.
+
+All five rows say #353 rather than #359, which is worth explaining because the ordering does not
+suggest it. `core/data/database.go` is the only production file in `core` that imports an engine
+package — every other importer is an auth-server test — so it is the single cut point, and #353
+point 7 already requires that `core/data` stop importing the four engines. The drivers therefore
+leave the admin console's binary at 22/29, six issues before the persistence packages themselves
+move. #353 reads like a staging step, so the effect is easy to miss; the guard will not miss it,
+because these rows go stale the moment it lands.
 
 `github.com/pquerna/otp` is listed at `no` deliberately. It is not reachable now, `core/otp` moves
 to the auth server in #348, and the row states that it must not arrive in the meantime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ src/
 - **Auth Server** (`src/authserver/go.mod`): Main auth endpoints, token issuance
 - **Admin Console** (`src/adminconsole/go.mod`): Admin management UI
 
+Which module owns what, and the rules that keep it that way, are in `ARCHITECTURE.md` at the
+repository root. It is enforced rather than descriptive: see **Architecture guard** under Testing.
+
 ## Key Directories
 
 ### Core (`src/core/`)
@@ -331,6 +334,16 @@ file under `src/` to gofmt's formatting through `core/testutil.AssertGofmted`. T
 repository-wide from each tier because `cmd/goiabada-setup` has no tier of its own. CI's Lint job
 checks the same thing per module, where an unformatted file also costs that module its vet,
 unparam and golangci-lint run.
+
+**Architecture guard**: `ARCHITECTURE.md` at the repository root records the allowed module edges,
+the intended final owner of every top-level `core` package, the temporary exceptions to those rules,
+and the third-party modules the admin console must not compile. Its three tables are data, not
+prose: `AssertArchitecture` in `core/testutil/architecture.go` parses them and checks them against
+the real import graph, and all three module unit tiers call it. The check runs in both directions,
+which is what makes the document a burn-down list rather than a wish — an edge the tables do not
+allow is a failure, and so is an exception left standing for an edge that no longer exists, so the
+issue that removes an edge has to remove its row with it (#332). A new top-level `core` package
+fails the tier until the table says where it belongs.
 
 **Schema golden files**: each engine's fully migrated catalog is recorded in
 `src/core/data/<engine>db/schema.golden`, and the data tier compares a freshly migrated database

--- a/src/adminconsole/internal/server/architecture_lint_test.go
+++ b/src/adminconsole/internal/server/architecture_lint_test.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/leodip/goiabada/core/testutil"
+)
+
+// TestArchitectureBoundaryHolds fails the admin console unit tier when the tree has
+// drifted from the module and package ownership rules recorded in
+// ARCHITECTURE.md: an import the tables do not allow, an exception listed for an
+// edge that no longer exists, a core package with no ownership row, or a
+// third-party module reaching the admin console when the document says it does
+// not. testutil.AssertArchitecture carries the reasoning, including why the
+// rules live in the document rather than in Go. Core and the auth server call it from
+// their own tiers.
+func TestArchitectureBoundaryHolds(t *testing.T) {
+	testutil.AssertArchitecture(t)
+}

--- a/src/authserver/internal/server/architecture_lint_test.go
+++ b/src/authserver/internal/server/architecture_lint_test.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/leodip/goiabada/core/testutil"
+)
+
+// TestArchitectureBoundaryHolds fails the authserver unit tier when the tree has
+// drifted from the module and package ownership rules recorded in
+// ARCHITECTURE.md: an import the tables do not allow, an exception listed for an
+// edge that no longer exists, a core package with no ownership row, or a
+// third-party module reaching the admin console when the document says it does
+// not. testutil.AssertArchitecture carries the reasoning, including why the
+// rules live in the document rather than in Go. Core and the admin console call it from
+// their own tiers.
+func TestArchitectureBoundaryHolds(t *testing.T) {
+	testutil.AssertArchitecture(t)
+}

--- a/src/core/testutil/architecture.go
+++ b/src/core/testutil/architecture.go
@@ -432,6 +432,22 @@ func (g *importGraph) moduleDir(importPath string) string {
 	return best
 }
 
+// relPath returns the import path as a directory relative to the source root, which is how the
+// exception table names both ends of an edge. An exception is granted to the package that holds the
+// import, never to its module or to its parent: guidance point 4 of #332 asks for exact package
+// edges, and a module-wide grant would let a second package acquire the same dependency in silence.
+func (g *importGraph) relPath(importPath string) string {
+	dir := g.moduleDir(importPath)
+	if dir == "" {
+		return importPath
+	}
+	module := g.modules[dir]
+	if importPath == module {
+		return dir
+	}
+	return dir + "/" + strings.TrimPrefix(importPath, module+"/")
+}
+
 // topCorePackage returns the top-level core package an import path belongs to, as "core/<name>", or
 // "" when the path is not under core. Ownership is recorded per top-level package because that is
 // the granularity the epic moves things at.
@@ -494,12 +510,12 @@ func checkArchitecture(tables architectureTables, graph *importGraph) []string {
 		owners[row.pkg] = row.owner
 	}
 
-	violations := map[edge][]string{}
-	for e, sites := range kernelPurityViolations(owners, graph) {
-		violations[e] = append(violations[e], sites...)
+	violations := map[edge]bool{}
+	for e := range kernelPurityViolations(owners, graph) {
+		violations[e] = true
 	}
-	for e, sites := range processIsolationViolations(owners, graph) {
-		violations[e] = append(violations[e], sites...)
+	for e := range processIsolationViolations(owners, graph) {
+		violations[e] = true
 	}
 
 	findings = append(findings, checkModuleDirection(graph)...)
@@ -542,21 +558,21 @@ func checkModuleDirection(graph *importGraph) []string {
 // kernelPurityViolations reports every edge from a kernel package into a package owned by one of
 // the processes or already marked for deletion. A split package is not a target: until its issue
 // draws the line, there is nothing at package granularity to check.
-func kernelPurityViolations(owners map[string]string, graph *importGraph) map[edge][]string {
-	violations := map[edge][]string{}
-	for pkg, imports := range graph.prod {
-		from := graph.topCorePackage(pkg)
+func kernelPurityViolations(owners map[string]string, g *importGraph) map[edge]bool {
+	violations := map[edge]bool{}
+	for pkg, imports := range g.prod {
+		from := g.topCorePackage(pkg)
 		if from == "" || owners[from] != ownerKernel {
 			continue
 		}
 		for _, imported := range imports {
-			to := graph.topCorePackage(imported)
+			to := g.topCorePackage(imported)
 			if to == "" || to == from {
 				continue
 			}
 			switch owners[to] {
 			case ownerAuthserver, ownerAdminconsole, ownerDelete:
-				violations[edge{from: from, to: to}] = append(violations[edge{from: from, to: to}], pkg)
+				violations[edge{from: g.relPath(pkg), to: g.relPath(imported)}] = true
 			}
 		}
 	}
@@ -566,28 +582,28 @@ func kernelPurityViolations(owners map[string]string, graph *importGraph) map[ed
 // processIsolationViolations reports every edge from one module into a core package owned by the
 // other, and every edge from the setup wizard into a core package owned by either. The wizard ships
 // as a standalone binary, so a package it pulls in is a package a user downloads.
-func processIsolationViolations(owners map[string]string, graph *importGraph) map[edge][]string {
+func processIsolationViolations(owners map[string]string, g *importGraph) map[edge]bool {
 	forbidden := map[string][]string{
 		"adminconsole":       {ownerAuthserver},
 		"authserver":         {ownerAdminconsole},
 		"cmd/goiabada-setup": {ownerAuthserver, ownerAdminconsole},
 	}
 
-	violations := map[edge][]string{}
-	for pkg, imports := range graph.prod {
-		from := graph.moduleDir(pkg)
+	violations := map[edge]bool{}
+	for pkg, imports := range g.prod {
+		from := g.moduleDir(pkg)
 		refused, ok := forbidden[from]
 		if !ok {
 			continue
 		}
 		for _, imported := range imports {
-			to := graph.topCorePackage(imported)
+			to := g.topCorePackage(imported)
 			if to == "" {
 				continue
 			}
 			for _, owner := range refused {
 				if owners[to] == owner {
-					violations[edge{from: from, to: to}] = append(violations[edge{from: from, to: to}], pkg)
+					violations[edge{from: g.relPath(pkg), to: g.relPath(imported)}] = true
 				}
 			}
 		}
@@ -717,7 +733,7 @@ func isStdlib(importPath string) bool {
 // reconcileExceptions is the burn-down. Every violation must be listed, and every listed exception
 // must still be a violation: an exception that stopped matching anything is the signal that the
 // issue which removed the edge forgot to remove its row.
-func reconcileExceptions(tables architectureTables, violations map[edge][]string) []string {
+func reconcileExceptions(tables architectureTables, violations map[edge]bool) []string {
 	listed := map[edge]exceptionRow{}
 	var findings []string
 
@@ -742,18 +758,17 @@ func reconcileExceptions(tables architectureTables, violations map[edge][]string
 		}
 	}
 
-	for e, sites := range violations {
+	for e := range violations {
 		if _, ok := listed[e]; ok {
 			continue
 		}
-		sort.Strings(sites)
 		rule := "kernel purity"
 		if !strings.HasPrefix(e.from, "core/") {
 			rule = "process isolation"
 		}
 		findings = append(findings, fmt.Sprintf(
-			"%s: %s imports %s at %s, and %s lists no exception for that edge; move the code or add a row naming the issue that will",
-			rule, e.from, e.to, strings.Join(sites, ", "), architectureDoc))
+			"%s: %s imports %s, and %s lists no exception for that edge; move the code or add a row naming the issue that will",
+			rule, e.from, e.to, architectureDoc))
 	}
 
 	return findings

--- a/src/core/testutil/architecture.go
+++ b/src/core/testutil/architecture.go
@@ -1,0 +1,825 @@
+package testutil
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/leodip/goiabada/core/errs"
+)
+
+// AssertArchitecture holds the repository's module and package ownership rules to the tree they
+// describe. The rules themselves are not written here: they are the three tables in
+// ARCHITECTURE.md at the repository root, which this function parses and then checks against the
+// real import graph. That file names each rule and carries the reasoning; this one decides.
+//
+// Putting the data in the document rather than in Go is the same choice AssertAgentDocs made for
+// the ceremony's state roster (#252). A dependency rule is prose about code, and prose about code
+// is the one thing nothing else in this repository checks. The direction between these modules is
+// invisible at every call site and is not a compile error until the day it becomes an import cycle,
+// so it decays without anything going red: core grew an application inside it exactly that way, one
+// reasonable-looking import at a time, until the admin console's binary linked four database
+// drivers it has no use for.
+//
+// The checks run in both directions, which is what makes the document a burn-down list rather than
+// a wish. An edge the tables do not allow is a finding. So is an exception listed for an edge that
+// no longer exists: when #335 moves the settings middleware, the exception rows it was granted stop
+// matching anything and the tier fails until they are deleted. Without that half, the exception list
+// would only ever grow, and a waiver nobody is forced to revisit is indistinguishable from a rule
+// that was never written.
+//
+// Scope is the source root for the graph and its parent for the document, because SourceRoot
+// returns the directory holding the four go.mod files and ARCHITECTURE.md sits one level above it.
+// Each module's unit tier calls this, so the guard fires whichever tier is run.
+func AssertArchitecture(t *testing.T) {
+	t.Helper()
+
+	root := SourceRoot(t)
+
+	doc, err := os.ReadFile(filepath.Join(filepath.Dir(root), architectureDoc))
+	if err != nil {
+		t.Fatalf("reading %s: %v", architectureDoc, err)
+	}
+
+	tables, findings := parseArchitectureDoc(string(doc))
+
+	graph, err := buildImportGraph(root)
+	if err != nil {
+		t.Fatalf("reading the import graph under %s: %v", root, err)
+	}
+	// A graph that somehow held no packages would satisfy every rule below, which is the one way a
+	// guard like this fails silently in the direction that matters.
+	if len(graph.prod) == 0 {
+		t.Fatalf("found no production Go packages under %s", root)
+	}
+
+	findings = append(findings, checkArchitecture(tables, graph)...)
+
+	sort.Strings(findings)
+	for _, f := range findings {
+		t.Error(f)
+	}
+}
+
+// architectureDoc is the file holding the rules, relative to the repository root.
+const architectureDoc = "ARCHITECTURE.md"
+
+// The three headings whose tables are data. Each is the deepest heading of its section, so the
+// prose above it is free to change without touching the parser.
+const (
+	ownershipHeading = "### Package ownership"
+	exceptionHeading = "### Temporary exceptions"
+	foreignHeading   = "### Foreign modules"
+)
+
+// The owner values a package row may carry. Their meanings are in ARCHITECTURE.md; what matters
+// here is that kernel is the only one that may not name an issue, and delete is the only one whose
+// package must have no importer at all.
+const (
+	ownerKernel       = "kernel"
+	ownerAuthserver   = "authserver"
+	ownerAdminconsole = "adminconsole"
+	ownerSplit        = "split"
+	ownerDelete       = "delete"
+)
+
+// moduleDirs are the four go.mod directories, relative to the source root, in the order a reader
+// expects them. gofmt.go's modules list identifies the source root while ascending; this one is
+// what the graph resolves import paths against, and the two are deliberately the same set.
+var moduleDirs = []string{"core", "authserver", "adminconsole", "cmd/goiabada-setup"}
+
+type ownerRow struct {
+	pkg   string
+	owner string
+	issue string
+	line  int
+}
+
+type exceptionRow struct {
+	from  string
+	to    string
+	issue string
+	line  int
+}
+
+type foreignRow struct {
+	module    string
+	reachable bool
+	clearedBy string
+	line      int
+}
+
+type architectureTables struct {
+	owners     []ownerRow
+	exceptions []exceptionRow
+	foreign    []foreignRow
+}
+
+// importGraph is the tree as the compiler sees it: one entry per package directory holding at least
+// one Go file, mapping its import path to the paths it imports. Production and test files are kept
+// apart because the rules treat them differently — a test may import a mock or a fixture from
+// anywhere, and holding test code to the production graph would make core/testutil unusable from
+// the very tiers that call this guard.
+type importGraph struct {
+	prod     map[string][]string
+	test     map[string][]string
+	modules  map[string]string // directory relative to the source root -> module import path
+	corePkgs []string          // top-level core packages on disk, as "core/<name>"
+}
+
+// parseArchitectureDoc reads the three data tables. A malformed row is a finding rather than a
+// parse failure, so one bad cell reports itself instead of silently shortening a table and turning
+// every edge it covered into a violation.
+func parseArchitectureDoc(doc string) (architectureTables, []string) {
+	var tables architectureTables
+	var findings []string
+
+	lines := strings.Split(doc, "\n")
+
+	ownership, ok := tableUnder(lines, ownershipHeading)
+	if !ok {
+		findings = append(findings, fmt.Sprintf("%s has no %q table", architectureDoc, ownershipHeading))
+	}
+	for _, row := range ownership {
+		if len(row.cells) != 3 {
+			findings = append(findings, fmt.Sprintf("%s:%d: an ownership row needs 3 cells, found %d", architectureDoc, row.line, len(row.cells)))
+			continue
+		}
+		tables.owners = append(tables.owners, ownerRow{pkg: row.cells[0], owner: row.cells[1], issue: row.cells[2], line: row.line})
+	}
+
+	exceptions, ok := tableUnder(lines, exceptionHeading)
+	if !ok {
+		findings = append(findings, fmt.Sprintf("%s has no %q table", architectureDoc, exceptionHeading))
+	}
+	for _, row := range exceptions {
+		if len(row.cells) != 3 {
+			findings = append(findings, fmt.Sprintf("%s:%d: an exception row needs 3 cells, found %d", architectureDoc, row.line, len(row.cells)))
+			continue
+		}
+		tables.exceptions = append(tables.exceptions, exceptionRow{from: row.cells[0], to: row.cells[1], issue: row.cells[2], line: row.line})
+	}
+
+	foreign, ok := tableUnder(lines, foreignHeading)
+	if !ok {
+		findings = append(findings, fmt.Sprintf("%s has no %q table", architectureDoc, foreignHeading))
+	}
+	for _, row := range foreign {
+		if len(row.cells) != 4 {
+			findings = append(findings, fmt.Sprintf("%s:%d: a foreign-module row needs 4 cells, found %d", architectureDoc, row.line, len(row.cells)))
+			continue
+		}
+		reachable, rErr := parseYesNo(row.cells[2])
+		if rErr != nil {
+			findings = append(findings, fmt.Sprintf("%s:%d: the %q row's reachability is %q, which is neither yes nor no", architectureDoc, row.line, row.cells[0], row.cells[2]))
+			continue
+		}
+		tables.foreign = append(tables.foreign, foreignRow{module: row.cells[0], reachable: reachable, clearedBy: row.cells[3], line: row.line})
+	}
+
+	return tables, findings
+}
+
+type docRow struct {
+	cells []string
+	line  int
+}
+
+// tableUnder returns the body rows of the first markdown table following the heading, with the
+// header and its separator dropped. The table ends at the first line that is not a table row, so
+// the prose after it is never read as data.
+func tableUnder(lines []string, heading string) ([]docRow, bool) {
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == heading {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+
+	var rows []docRow
+	seen := 0
+	for i := start; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			if seen > 0 {
+				break
+			}
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			break
+		}
+		seen++
+		// The header row and the |---|---| separator under it carry no data.
+		if seen <= 2 {
+			continue
+		}
+		rows = append(rows, docRow{cells: splitRow(trimmed), line: i + 1})
+	}
+	return rows, true
+}
+
+// splitRow turns "| `core/api` | kernel | — |" into its three cells, with the pipes, the padding
+// and the backticks removed. Backticks are stripped because every identifier in the document is
+// written as code and none of them contain one.
+func splitRow(line string) []string {
+	trimmed := strings.Trim(strings.TrimSpace(line), "|")
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, 0, len(parts))
+	for _, p := range parts {
+		cells = append(cells, strings.TrimSpace(strings.ReplaceAll(p, "`", "")))
+	}
+	return cells
+}
+
+func parseYesNo(cell string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(cell)) {
+	case "yes":
+		return true, nil
+	case "no":
+		return false, nil
+	}
+	return false, errs.Errorf("%q is neither yes nor no", cell)
+}
+
+// issueRef matches the "#332" form every issue cell uses.
+var issueRef = regexp.MustCompile(`^#\d+$`)
+
+// noIssue reports whether a cell means "no issue". The document writes an em dash; a hyphen and an
+// empty cell are accepted because they mean the same thing to a reader and refusing them would be a
+// finding about typography rather than about the tree.
+func noIssue(cell string) bool {
+	switch strings.TrimSpace(cell) {
+	case "—", "–", "-", "":
+		return true
+	}
+	return false
+}
+
+// buildImportGraph parses every Go file under root for its imports alone and groups them by package
+// directory. Imports are read from the AST rather than matched in the text, so an import path
+// inside a comment or a string literal is not an edge and an aliased import still is one.
+func buildImportGraph(root string) (*importGraph, error) {
+	graph := &importGraph{
+		prod:    map[string][]string{},
+		test:    map[string][]string{},
+		modules: map[string]string{},
+	}
+
+	for _, dir := range moduleDirs {
+		path, err := modulePath(filepath.Join(root, filepath.FromSlash(dir), "go.mod"))
+		if err != nil {
+			return nil, err
+		}
+		graph.modules[dir] = path
+	}
+
+	prod := map[string]map[string]bool{}
+	test := map[string]map[string]bool{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return errs.Wrapf(relErr, "relating %s to %s", path, root)
+		}
+		rel = filepath.ToSlash(rel)
+
+		pkg, ok := graph.importPath(filepath.ToSlash(filepath.Dir(rel)))
+		if !ok {
+			// A Go file outside the four modules belongs to no package this guard can name.
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		// ParseComments because the build constraint is a comment, and a file excluded from every
+		// production build is not part of the production graph.
+		file, pErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly|parser.ParseComments)
+		if pErr != nil {
+			// A file that does not parse is a compile error the build tier owns, and reporting it
+			// here would send the reader to the wrong place.
+			return nil
+		}
+
+		isTest := strings.HasSuffix(rel, "_test.go")
+		if !isTest && exemptByBuildConstraint(file, fset) {
+			return nil
+		}
+
+		into := prod
+		if isTest {
+			into = test
+		}
+		if into[pkg] == nil {
+			into[pkg] = map[string]bool{}
+		}
+		for _, imported := range importPaths(file) {
+			into[pkg][imported] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	graph.prod = flatten(prod)
+	graph.test = flatten(test)
+
+	graph.corePkgs, err = topLevelCorePackages(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return graph, nil
+}
+
+func flatten(in map[string]map[string]bool) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for pkg, imports := range in {
+		list := make([]string, 0, len(imports))
+		for i := range imports {
+			list = append(list, i)
+		}
+		sort.Strings(list)
+		out[pkg] = list
+	}
+	return out
+}
+
+func importPaths(file *ast.File) []string {
+	paths := make([]string, 0, len(file.Imports))
+	for _, spec := range file.Imports {
+		if spec.Path == nil {
+			continue
+		}
+		paths = append(paths, strings.Trim(spec.Path.Value, `"`))
+	}
+	return paths
+}
+
+// modulePath reads the module line out of a go.mod. Reading it rather than hard-coding the four
+// paths means a module renamed in go.mod is a failure here rather than a graph that silently stops
+// recognising half the tree as first-party.
+func modulePath(goMod string) (string, error) {
+	content, err := os.ReadFile(goMod)
+	if err != nil {
+		return "", errs.Wrapf(err, "reading %s", goMod)
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, found := strings.CutPrefix(trimmed, "module "); found {
+			return strings.TrimSpace(after), nil
+		}
+	}
+	return "", errs.Errorf("%s has no module line", goMod)
+}
+
+// importPath turns a directory relative to the source root into the import path the compiler gives
+// it, and reports whether the directory belongs to one of the four modules. The longest module
+// directory wins, so cmd/goiabada-setup is not read as a subdirectory of anything.
+func (g *importGraph) importPath(dir string) (string, bool) {
+	best := ""
+	for moduleDir := range g.modules {
+		if dir != moduleDir && !strings.HasPrefix(dir, moduleDir+"/") {
+			continue
+		}
+		if len(moduleDir) > len(best) {
+			best = moduleDir
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	path := g.modules[best]
+	if dir != best {
+		path += "/" + strings.TrimPrefix(dir, best+"/")
+	}
+	return path, true
+}
+
+// moduleDir returns the module directory an import path belongs to, or "" when the path is not
+// first-party.
+func (g *importGraph) moduleDir(importPath string) string {
+	best, bestLen := "", -1
+	for dir, path := range g.modules {
+		if importPath != path && !strings.HasPrefix(importPath, path+"/") {
+			continue
+		}
+		if len(path) > bestLen {
+			best, bestLen = dir, len(path)
+		}
+	}
+	return best
+}
+
+// topCorePackage returns the top-level core package an import path belongs to, as "core/<name>", or
+// "" when the path is not under core. Ownership is recorded per top-level package because that is
+// the granularity the epic moves things at.
+func (g *importGraph) topCorePackage(importPath string) string {
+	corePath := g.modules["core"]
+	if !strings.HasPrefix(importPath, corePath+"/") {
+		return ""
+	}
+	return "core/" + strings.Split(strings.TrimPrefix(importPath, corePath+"/"), "/")[0]
+}
+
+// topLevelCorePackages lists the directories directly under core that hold at least one production
+// Go file at any depth. That is the set the ownership table must cover exactly: core/audit holds
+// nothing but a mocks directory and is still a directory whose fate has to be recorded.
+func topLevelCorePackages(root string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, "core"))
+	if err != nil {
+		return nil, errs.Wrapf(err, "reading the core module directory")
+	}
+
+	var pkgs []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		holds := false
+		wErr := filepath.WalkDir(filepath.Join(root, "core", entry.Name()), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+				holds = true
+			}
+			return nil
+		})
+		if wErr != nil {
+			return nil, wErr
+		}
+		if holds {
+			pkgs = append(pkgs, "core/"+entry.Name())
+		}
+	}
+	sort.Strings(pkgs)
+	return pkgs, nil
+}
+
+// edge is one package-level dependency, named the way the exception table names it: the source is
+// either a top-level core package or a module directory, and the target is always a top-level core
+// package.
+type edge struct {
+	from string
+	to   string
+}
+
+func checkArchitecture(tables architectureTables, graph *importGraph) []string {
+	findings := checkTableHygiene(tables, graph)
+
+	owners := map[string]string{}
+	for _, row := range tables.owners {
+		owners[row.pkg] = row.owner
+	}
+
+	violations := map[edge][]string{}
+	for e, sites := range kernelPurityViolations(owners, graph) {
+		violations[e] = append(violations[e], sites...)
+	}
+	for e, sites := range processIsolationViolations(owners, graph) {
+		violations[e] = append(violations[e], sites...)
+	}
+
+	findings = append(findings, checkModuleDirection(graph)...)
+	findings = append(findings, checkDeadPackages(tables, graph)...)
+	findings = append(findings, checkForeignClosure(tables, graph)...)
+	findings = append(findings, reconcileExceptions(tables, violations)...)
+
+	return findings
+}
+
+// checkModuleDirection holds the one rule with no exceptions: core depends on neither process, and
+// the two processes never link each other's code. Test files are checked too, because a test that
+// imports across a forbidden edge still proves the two modules are coupled.
+func checkModuleDirection(graph *importGraph) []string {
+	var findings []string
+	for _, kind := range []string{"production", "test"} {
+		source := graph.prod
+		if kind == "test" {
+			source = graph.test
+		}
+		for pkg, imports := range source {
+			from := graph.moduleDir(pkg)
+			for _, imported := range imports {
+				to := graph.moduleDir(imported)
+				if to == "" || to == from {
+					continue
+				}
+				if to == "core" && from != "core" {
+					continue
+				}
+				findings = append(findings, fmt.Sprintf(
+					"module direction: %s (%s) imports %s; %s may not import %s",
+					pkg, kind, imported, from, to))
+			}
+		}
+	}
+	return findings
+}
+
+// kernelPurityViolations reports every edge from a kernel package into a package owned by one of
+// the processes or already marked for deletion. A split package is not a target: until its issue
+// draws the line, there is nothing at package granularity to check.
+func kernelPurityViolations(owners map[string]string, graph *importGraph) map[edge][]string {
+	violations := map[edge][]string{}
+	for pkg, imports := range graph.prod {
+		from := graph.topCorePackage(pkg)
+		if from == "" || owners[from] != ownerKernel {
+			continue
+		}
+		for _, imported := range imports {
+			to := graph.topCorePackage(imported)
+			if to == "" || to == from {
+				continue
+			}
+			switch owners[to] {
+			case ownerAuthserver, ownerAdminconsole, ownerDelete:
+				violations[edge{from: from, to: to}] = append(violations[edge{from: from, to: to}], pkg)
+			}
+		}
+	}
+	return violations
+}
+
+// processIsolationViolations reports every edge from one module into a core package owned by the
+// other, and every edge from the setup wizard into a core package owned by either. The wizard ships
+// as a standalone binary, so a package it pulls in is a package a user downloads.
+func processIsolationViolations(owners map[string]string, graph *importGraph) map[edge][]string {
+	forbidden := map[string][]string{
+		"adminconsole":       {ownerAuthserver},
+		"authserver":         {ownerAdminconsole},
+		"cmd/goiabada-setup": {ownerAuthserver, ownerAdminconsole},
+	}
+
+	violations := map[edge][]string{}
+	for pkg, imports := range graph.prod {
+		from := graph.moduleDir(pkg)
+		refused, ok := forbidden[from]
+		if !ok {
+			continue
+		}
+		for _, imported := range imports {
+			to := graph.topCorePackage(imported)
+			if to == "" {
+				continue
+			}
+			for _, owner := range refused {
+				if owners[to] == owner {
+					violations[edge{from: from, to: to}] = append(violations[edge{from: from, to: to}], pkg)
+				}
+			}
+		}
+	}
+	return violations
+}
+
+// checkDeadPackages holds a delete row to its claim. A package with an importer is not dead, and
+// the row rather than the importer is what is wrong.
+func checkDeadPackages(tables architectureTables, graph *importGraph) []string {
+	var findings []string
+	for _, row := range tables.owners {
+		if row.owner != ownerDelete {
+			continue
+		}
+		for _, kind := range []string{"production", "test"} {
+			source := graph.prod
+			if kind == "test" {
+				source = graph.test
+			}
+			for pkg, imports := range source {
+				for _, imported := range imports {
+					if graph.topCorePackage(imported) != row.pkg {
+						continue
+					}
+					findings = append(findings, fmt.Sprintf(
+						"dead package: %s:%d records %s as %s, but %s imports %s (%s)",
+						architectureDoc, row.line, row.pkg, ownerDelete, pkg, imported, kind))
+				}
+			}
+		}
+	}
+	return findings
+}
+
+// checkForeignClosure asserts the declared reachability of each third-party module against the real
+// transitive closure of the admin console's production packages. This is the rule that measures the
+// harm the epic exists to remove: the admin console opens no database, and every driver in its
+// binary arrived through core.
+func checkForeignClosure(tables architectureTables, graph *importGraph) []string {
+	reachable := foreignClosure(graph, "adminconsole")
+
+	var findings []string
+	for _, row := range tables.foreign {
+		via, hit := reachable[row.module]
+		switch {
+		case hit && !row.reachable:
+			findings = append(findings, fmt.Sprintf(
+				"foreign closure: %s:%d records %s as unreachable from the admin console, but %s imports it",
+				architectureDoc, row.line, row.module, via))
+		case !hit && row.reachable:
+			findings = append(findings, fmt.Sprintf(
+				"foreign closure: %s:%d records %s as reachable from the admin console, but nothing reaches it any more; delete the row (%s)",
+				architectureDoc, row.line, row.module, row.clearedBy))
+		}
+	}
+	return findings
+}
+
+// foreignClosure walks the module's production packages over first-party edges and reports, for
+// every third-party import path found anywhere in that closure, one package that imports it. The
+// importer is carried so a failure can name where the dependency entered rather than only that it
+// did.
+func foreignClosure(graph *importGraph, moduleDir string) map[string]string {
+	seen := map[string]bool{}
+	var stack []string
+	for pkg := range graph.prod {
+		if graph.moduleDir(pkg) == moduleDir {
+			stack = append(stack, pkg)
+		}
+	}
+
+	found := map[string]string{}
+	for len(stack) > 0 {
+		pkg := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[pkg] {
+			continue
+		}
+		seen[pkg] = true
+		for _, imported := range graph.prod[pkg] {
+			if graph.moduleDir(imported) != "" {
+				stack = append(stack, imported)
+				continue
+			}
+			if isStdlib(imported) {
+				continue
+			}
+			// Longest declared prefix wins, so github.com/jackc/pgx/v5/stdlib is recorded against
+			// the module that ships it rather than as a module of its own.
+			if existing, ok := found[imported]; !ok || pkg < existing {
+				found[imported] = pkg
+			}
+		}
+	}
+
+	// Collapse import paths onto the module prefixes the table declares.
+	return foreignByPrefix(found)
+}
+
+// foreignByPrefix lets a table row name a module prefix and match every package under it.
+func foreignByPrefix(found map[string]string) map[string]string {
+	out := map[string]string{}
+	for path, importer := range found {
+		out[path] = importer
+		for i := len(path) - 1; i > 0; i-- {
+			if path[i] != '/' {
+				continue
+			}
+			prefix := path[:i]
+			if existing, ok := out[prefix]; !ok || importer < existing {
+				out[prefix] = importer
+			}
+		}
+	}
+	return out
+}
+
+// isStdlib reports whether an import path is part of the standard library, which is decided by the
+// absence of a dot in its first segment. That is the same rule the go command uses to tell a
+// standard package from a module path.
+func isStdlib(importPath string) bool {
+	first, _, _ := strings.Cut(importPath, "/")
+	return !strings.Contains(first, ".")
+}
+
+// reconcileExceptions is the burn-down. Every violation must be listed, and every listed exception
+// must still be a violation: an exception that stopped matching anything is the signal that the
+// issue which removed the edge forgot to remove its row.
+func reconcileExceptions(tables architectureTables, violations map[edge][]string) []string {
+	listed := map[edge]exceptionRow{}
+	var findings []string
+
+	for _, row := range tables.exceptions {
+		e := edge{from: row.from, to: row.to}
+		if _, duplicate := listed[e]; duplicate {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d lists the exception %s -> %s twice",
+				architectureDoc, row.line, row.from, row.to))
+			continue
+		}
+		listed[e] = row
+		if !issueRef.MatchString(row.issue) {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d: the exception %s -> %s names %q where an issue like #332 belongs; a temporary dependency with no issue is a waiver",
+				architectureDoc, row.line, row.from, row.to, row.issue))
+		}
+		if _, still := violations[e]; !still {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d lists %s -> %s as a temporary exception, but that edge no longer exists; delete the row (%s)",
+				architectureDoc, row.line, row.from, row.to, row.issue))
+		}
+	}
+
+	for e, sites := range violations {
+		if _, ok := listed[e]; ok {
+			continue
+		}
+		sort.Strings(sites)
+		rule := "kernel purity"
+		if !strings.HasPrefix(e.from, "core/") {
+			rule = "process isolation"
+		}
+		findings = append(findings, fmt.Sprintf(
+			"%s: %s imports %s at %s, and %s lists no exception for that edge; move the code or add a row naming the issue that will",
+			rule, e.from, e.to, strings.Join(sites, ", "), architectureDoc))
+	}
+
+	return findings
+}
+
+// checkTableHygiene holds the ownership table to the tree: one row per top-level core package,
+// every owner a value the rules understand, and an issue on exactly the rows that need one. The
+// completeness half is what makes a new core package a decision rather than a default.
+func checkTableHygiene(tables architectureTables, graph *importGraph) []string {
+	var findings []string
+
+	seen := map[string]int{}
+	for _, row := range tables.owners {
+		if first, duplicate := seen[row.pkg]; duplicate {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d gives %s a second ownership row; the first is at line %d",
+				architectureDoc, row.line, row.pkg, first))
+			continue
+		}
+		seen[row.pkg] = row.line
+
+		switch row.owner {
+		case ownerKernel:
+			if !noIssue(row.issue) {
+				findings = append(findings, fmt.Sprintf(
+					"table hygiene: %s:%d gives kernel package %s the issue %s; a package that is not moving has no issue",
+					architectureDoc, row.line, row.pkg, row.issue))
+			}
+		case ownerAuthserver, ownerAdminconsole, ownerSplit, ownerDelete:
+			if !issueRef.MatchString(row.issue) {
+				findings = append(findings, fmt.Sprintf(
+					"table hygiene: %s:%d says %s becomes %s but names %q where an issue like #332 belongs",
+					architectureDoc, row.line, row.pkg, row.owner, row.issue))
+			}
+		default:
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d gives %s the owner %q, which is none of %s, %s, %s, %s, %s",
+				architectureDoc, row.line, row.pkg, row.owner,
+				ownerKernel, ownerAuthserver, ownerAdminconsole, ownerSplit, ownerDelete))
+		}
+	}
+
+	onDisk := map[string]bool{}
+	for _, pkg := range graph.corePkgs {
+		onDisk[pkg] = true
+		if _, ok := seen[pkg]; !ok {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s holds no ownership row for %s; every top-level core package needs one, so that adding a package is a decision about where it belongs",
+				architectureDoc, pkg))
+		}
+	}
+	for pkg, line := range seen {
+		if !onDisk[pkg] {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d records ownership for %s, which holds no production Go file; delete the row",
+				architectureDoc, line, pkg))
+		}
+	}
+
+	for _, row := range tables.foreign {
+		if row.reachable && !issueRef.MatchString(row.clearedBy) {
+			findings = append(findings, fmt.Sprintf(
+				"table hygiene: %s:%d says %s is reachable from the admin console but names %q where the issue that clears it belongs",
+				architectureDoc, row.line, row.module, row.clearedBy))
+		}
+	}
+
+	return findings
+}

--- a/src/core/testutil/architecture_lint_test.go
+++ b/src/core/testutil/architecture_lint_test.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "testing"
+
+// TestArchitectureBoundaryHolds fails the core unit tier when the tree has drifted from the module
+// and package ownership rules recorded in ARCHITECTURE.md: an import the tables do not allow, an
+// exception listed for an edge that no longer exists, a core package with no ownership row, or a
+// third-party module reaching the admin console when the document says it does not.
+// AssertArchitecture carries the reasoning, including why the rules live in the document rather
+// than here. The auth server and the admin console call it from their own tiers.
+func TestArchitectureBoundaryHolds(t *testing.T) {
+	AssertArchitecture(t)
+}

--- a/src/core/testutil/architecture_rules_test.go
+++ b/src/core/testutil/architecture_rules_test.go
@@ -1,0 +1,763 @@
+package testutil
+
+// Seam 2: the rule table AssertArchitecture enforces, over fixture trees written into a temp
+// directory and read through the same graph builder the real caller uses.
+//
+// The synthetic half exists because the real half cannot fail informatively. The tree satisfies
+// ARCHITECTURE.md today by construction — the tables were written from it — so the real test passes
+// whether the rules match anything or not, which is the way a guard like this dies: quietly, still
+// green. Every rule below therefore gets a fixture that must be caught and, where the rule is
+// deliberately lenient, a fixture that must survive it (#279 sets out the same reasoning for the
+// error-construction lint).
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- fixture helpers -----------------------------------------------------------------------
+
+// writeTree lays out a miniature four-module repository. The module paths are deliberately not the
+// real ones: everything the guard knows about module identity it reads from these go.mod files, so
+// a fixture that passed only because a path was hard-coded somewhere would fail here.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	all := map[string]string{
+		"core/go.mod":               "module example.test/core\n",
+		"authserver/go.mod":         "module example.test/authserver\n",
+		"adminconsole/go.mod":       "module example.test/adminconsole\n",
+		"cmd/goiabada-setup/go.mod": "module example.test/setup\n",
+	}
+	for rel, src := range files {
+		all[rel] = src
+	}
+	for rel, src := range all {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+	}
+	return root
+}
+
+// pkg writes a package whose only content is its imports.
+func pkg(name string, imports ...string) string {
+	var b strings.Builder
+	b.WriteString("package " + name + "\n")
+	for _, i := range imports {
+		b.WriteString("\nimport _ \"" + i + "\"\n")
+	}
+	return b.String()
+}
+
+// ownerRows builds the ownership table from "<package> <owner> <issue>" triples.
+func ownerRows(rows ...string) []ownerRow {
+	out := make([]ownerRow, 0, len(rows))
+	for i, r := range rows {
+		f := strings.Fields(r)
+		out = append(out, ownerRow{pkg: f[0], owner: f[1], issue: f[2], line: i + 1})
+	}
+	return out
+}
+
+// exceptionRows builds the exception table from "<from> <to> <issue>" triples.
+func exceptionRows(rows ...string) []exceptionRow {
+	out := make([]exceptionRow, 0, len(rows))
+	for i, r := range rows {
+		f := strings.Fields(r)
+		out = append(out, exceptionRow{from: f[0], to: f[1], issue: f[2], line: i + 1})
+	}
+	return out
+}
+
+// foreignRows builds the foreign-module table from "<module> <yes|no> <issue>" triples.
+func foreignRows(rows ...string) []foreignRow {
+	out := make([]foreignRow, 0, len(rows))
+	for i, r := range rows {
+		f := strings.Fields(r)
+		out = append(out, foreignRow{module: f[0], reachable: f[1] == "yes", clearedBy: f[2], line: i + 1})
+	}
+	return out
+}
+
+// check runs the whole pipeline over a fixture tree and returns the findings, sorted the way
+// AssertArchitecture sorts them.
+//
+// Every package the ownership table names is given an empty file if the fixture did not write one,
+// so that a test about one rule is not also a test about table completeness. The tests that are
+// about completeness use checkTree, which writes exactly what it is given.
+func check(t *testing.T, files map[string]string, tables architectureTables) []string {
+	t.Helper()
+
+	stubbed := map[string]string{}
+	for rel, src := range files {
+		stubbed[rel] = src
+	}
+	for _, row := range tables.owners {
+		if !strings.HasPrefix(row.pkg, "core/") {
+			continue
+		}
+		written := false
+		for rel := range files {
+			if strings.HasPrefix(rel, row.pkg+"/") {
+				written = true
+				break
+			}
+		}
+		if !written {
+			name := strings.ReplaceAll(strings.TrimPrefix(row.pkg, "core/"), "-", "")
+			stubbed[row.pkg+"/stub.go"] = pkg(name)
+		}
+	}
+	return checkTree(t, stubbed, tables)
+}
+
+// checkTree runs the pipeline over exactly the files given, with nothing filled in.
+func checkTree(t *testing.T, files map[string]string, tables architectureTables) []string {
+	t.Helper()
+
+	graph, err := buildImportGraph(writeTree(t, files))
+	require.NoError(t, err)
+	findings := checkArchitecture(tables, graph)
+	sort.Strings(findings)
+	return findings
+}
+
+// assertFindings asserts the exact number of findings and that each one contains its fragment, in
+// the order the fragments are given.
+func assertFindings(t *testing.T, got []string, fragments ...string) {
+	t.Helper()
+
+	if !assert.Len(t, got, len(fragments), "findings:\n\t%s", strings.Join(got, "\n\t")) {
+		return
+	}
+	for i, want := range fragments {
+		assert.Contains(t, got[i], want)
+	}
+}
+
+// ---- rule 1: module direction --------------------------------------------------------------
+
+func TestArchitecture_ModuleDirection(t *testing.T) {
+	tables := architectureTables{owners: ownerRows("core/errs kernel -")}
+
+	t.Run("core may not import a process", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/errs/errs.go": pkg("errs", "example.test/authserver/internal/handlers"),
+		}, tables)
+		assertFindings(t, findings, "module direction: example.test/core/errs (production) imports example.test/authserver/internal/handlers; core may not import authserver")
+	})
+
+	t.Run("the two processes may not import each other", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/errs/errs.go":            pkg("errs"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/authserver/internal/b"),
+			"authserver/internal/b/b.go":   pkg("b"),
+		}, tables)
+		assertFindings(t, findings, "adminconsole may not import authserver")
+	})
+
+	// Rule 1 is the one rule that reads test files: a test importing across a forbidden edge still
+	// proves the two modules are coupled, and it still has to compile.
+	t.Run("a test file is checked too", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/errs/errs.go":                 pkg("errs"),
+			"adminconsole/internal/a/a.go":      pkg("a"),
+			"adminconsole/internal/a/a_test.go": pkg("a", "example.test/authserver/internal/b"),
+			"authserver/internal/b/b.go":        pkg("b"),
+		}, tables)
+		assertFindings(t, findings, "(test) imports example.test/authserver/internal/b")
+	})
+
+	t.Run("every module may import core, including the setup wizard", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/errs/errs.go":            pkg("errs"),
+			"authserver/internal/a/a.go":   pkg("a", "example.test/core/errs"),
+			"adminconsole/internal/b/b.go": pkg("b", "example.test/core/errs"),
+			"cmd/goiabada-setup/main.go":   pkg("main", "example.test/core/errs"),
+		}, tables)
+		assert.Empty(t, findings)
+	})
+}
+
+// ---- rule 2: kernel purity -----------------------------------------------------------------
+
+func TestArchitecture_KernelPurity(t *testing.T) {
+	t.Run("a kernel package may not import an authserver-owned package", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":     pkg("i18n", "example.test/core/models"),
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/models authserver #359")})
+		assertFindings(t, findings, "kernel purity: core/i18n imports core/models at example.test/core/i18n, and ARCHITECTURE.md lists no exception")
+	})
+
+	t.Run("a kernel package may not import a package already marked for deletion", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":   pkg("i18n", "example.test/core/audit"),
+			"core/audit/audit.go": pkg("audit"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/audit delete #333")})
+		// The dead-package rule fires as well: a package with an importer is not dead.
+		assertFindings(t, findings,
+			"dead package: ARCHITECTURE.md:2 records core/audit as delete",
+			"kernel purity: core/i18n imports core/audit")
+	})
+
+	// The leniency that makes the table usable mid-epic: a split package has no edge rule until the
+	// issue that splits it lands, because at package granularity there is nothing yet to check.
+	t.Run("a split package is not a target", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":   pkg("i18n", "example.test/core/oauth"),
+			"core/oauth/oauth.go": pkg("oauth"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/oauth split #338")})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("kernel to kernel is the point of the kernel", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go": pkg("i18n", "example.test/core/errs"),
+			"core/errs/errs.go": pkg("errs"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/errs kernel -")})
+		assert.Empty(t, findings)
+	})
+
+	// Rules 2 and 3 read production files only. A test may import a mock or a fixture from
+	// anywhere; holding test code to the production graph would make this very package unusable
+	// from the tiers that call the guard.
+	t.Run("a test file is not held to the production graph", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":      pkg("i18n"),
+			"core/i18n/i18n_test.go": pkg("i18n", "example.test/core/models"),
+			"core/models/models.go":  pkg("models"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/models authserver #359")})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("a package importing its own subpackage is not an edge", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":              pkg("i18n", "example.test/core/i18n/catalogs"),
+			"core/i18n/catalogs/catalogs.go": pkg("catalogs"),
+		}, architectureTables{owners: ownerRows("core/i18n kernel -")})
+		assert.Empty(t, findings)
+	})
+}
+
+// ---- rule 3: process isolation -------------------------------------------------------------
+
+func TestArchitecture_ProcessIsolation(t *testing.T) {
+	tables := architectureTables{owners: ownerRows(
+		"core/user authserver #346",
+		"core/uithemes adminconsole #348",
+		"core/oauth split #338",
+		"core/errs kernel -",
+	)}
+
+	t.Run("the admin console may not import an authserver-owned package", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/user/user.go":            pkg("user"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/user"),
+		}, tables)
+		assertFindings(t, findings, "process isolation: adminconsole imports core/user at example.test/adminconsole/internal/a")
+	})
+
+	t.Run("the auth server may not import an adminconsole-owned package", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/uithemes/uithemes.go":  pkg("uithemes"),
+			"authserver/internal/a/a.go": pkg("a", "example.test/core/uithemes"),
+		}, tables)
+		assertFindings(t, findings, "process isolation: authserver imports core/uithemes")
+	})
+
+	// The wizard ships as a standalone binary, so a package it pulls in is a package a user
+	// downloads. It may import the kernel and nothing else.
+	t.Run("the setup wizard may import neither process", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/user/user.go":          pkg("user"),
+			"core/errs/errs.go":          pkg("errs"),
+			"cmd/goiabada-setup/main.go": pkg("main", "example.test/core/user", "example.test/core/errs"),
+		}, tables)
+		assertFindings(t, findings, "process isolation: cmd/goiabada-setup imports core/user")
+	})
+
+	t.Run("a split package is not a target", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":          pkg("oauth"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/oauth"),
+		}, tables)
+		assert.Empty(t, findings)
+	})
+
+	t.Run("a test file is not held to the production graph", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/user/user.go":                 pkg("user"),
+			"adminconsole/internal/a/a.go":      pkg("a"),
+			"adminconsole/internal/a/a_test.go": pkg("a", "example.test/core/user"),
+		}, tables)
+		assert.Empty(t, findings)
+	})
+}
+
+// ---- rule 4: dead package ------------------------------------------------------------------
+
+func TestArchitecture_DeadPackage(t *testing.T) {
+	tables := architectureTables{owners: ownerRows("core/audit delete #333", "core/errs kernel -")}
+
+	t.Run("a delete row with no importer is what dead means", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/audit/mocks/mock.go": pkg("mocks"),
+			"core/errs/errs.go":        pkg("errs"),
+		}, tables)
+		assert.Empty(t, findings)
+	})
+
+	t.Run("a production importer disproves the row", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/audit/mocks/mock.go":   pkg("mocks"),
+			"authserver/internal/a/a.go": pkg("a", "example.test/core/audit/mocks"),
+		}, tables)
+		assertFindings(t, findings, "dead package: ARCHITECTURE.md:1 records core/audit as delete, but example.test/authserver/internal/a imports example.test/core/audit/mocks (production)")
+	})
+
+	// A test importer counts. A mocks package kept alive by one test is exactly the shape #333 is
+	// deleting, and it would be invisible to a production-only rule.
+	t.Run("a test importer disproves the row too", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/audit/mocks/mock.go":        pkg("mocks"),
+			"authserver/internal/a/a.go":      pkg("a"),
+			"authserver/internal/a/a_test.go": pkg("a", "example.test/core/audit/mocks"),
+		}, tables)
+		assertFindings(t, findings, "imports example.test/core/audit/mocks (test)")
+	})
+}
+
+// ---- rule 5: foreign closure ---------------------------------------------------------------
+
+func TestArchitecture_ForeignClosure(t *testing.T) {
+	tables := func(rows ...string) architectureTables {
+		return architectureTables{
+			owners:  ownerRows("core/oauth split #338", "core/data authserver #359"),
+			foreign: foreignRows(rows...),
+		}
+	}
+
+	// The headline the epic exists to remove, in miniature: the admin console imports no driver,
+	// and compiles one anyway because a core package three hops away does.
+	reaching := map[string]string{
+		"core/oauth/oauth.go":          pkg("oauth", "example.test/core/data"),
+		"core/data/data.go":            pkg("data", "modernc.org/sqlite"),
+		"adminconsole/internal/a/a.go": pkg("a", "example.test/core/oauth"),
+	}
+
+	t.Run("a module declared unreachable that is reachable is a regression", func(t *testing.T) {
+		findings := check(t, reaching, tables("modernc.org/sqlite no -"))
+		assertFindings(t, findings, "foreign closure: ARCHITECTURE.md:1 records modernc.org/sqlite as unreachable from the admin console, but example.test/core/data imports it")
+	})
+
+	t.Run("a module declared reachable that is reachable is the burn-down state", func(t *testing.T) {
+		findings := check(t, reaching, tables("modernc.org/sqlite yes #359"))
+		assert.Empty(t, findings)
+	})
+
+	// The half that makes the table shrink. When the edge goes, the row has to go with it, or the
+	// list would only ever grow.
+	t.Run("a module declared reachable that is no longer reachable is a row to delete", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":          pkg("oauth"),
+			"core/data/data.go":            pkg("data", "modernc.org/sqlite"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/oauth"),
+		}, tables("modernc.org/sqlite yes #359"))
+		assertFindings(t, findings, "nothing reaches it any more; delete the row (#359)")
+	})
+
+	t.Run("a row names the module, and a package under it matches", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":          pkg("oauth", "example.test/core/data"),
+			"core/data/data.go":            pkg("data", "github.com/jackc/pgx/v5/stdlib"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/oauth"),
+		}, tables("github.com/jackc/pgx/v5 no -"))
+		assertFindings(t, findings, "records github.com/jackc/pgx/v5 as unreachable")
+	})
+
+	t.Run("the standard library is not a foreign module", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":          pkg("oauth", "database/sql", "net/http"),
+			"core/data/data.go":            pkg("data"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/oauth"),
+		}, tables("database/sql no -"))
+		assert.Empty(t, findings)
+	})
+
+	// The closure is production-only because it is about what lands in a shipped binary, and the
+	// admin console's tests are not shipped.
+	t.Run("a test-only dependency is not in the binary", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":               pkg("oauth"),
+			"core/data/data.go":                 pkg("data"),
+			"adminconsole/internal/a/a.go":      pkg("a"),
+			"adminconsole/internal/a/a_test.go": pkg("a", "modernc.org/sqlite"),
+		}, tables("modernc.org/sqlite no -"))
+		assert.Empty(t, findings)
+	})
+
+	t.Run("the auth server's own dependencies are not the admin console's", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/oauth/oauth.go":        pkg("oauth"),
+			"core/data/data.go":          pkg("data"),
+			"authserver/internal/a/a.go": pkg("a", "modernc.org/sqlite"),
+		}, tables("modernc.org/sqlite no -"))
+		assert.Empty(t, findings)
+	})
+}
+
+// ---- rule 6: table hygiene -----------------------------------------------------------------
+
+func TestArchitecture_TableHygiene(t *testing.T) {
+	tree := map[string]string{
+		"core/errs/errs.go":   pkg("errs"),
+		"core/models/m.go":    pkg("models"),
+		"core/locales/l.json": "",
+	}
+
+	// Completeness is what makes adding a core package a decision rather than a default: the tier
+	// goes red until somebody says where the new package belongs.
+	t.Run("a core package with no row", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows("core/errs kernel -")})
+		assertFindings(t, findings, "ARCHITECTURE.md holds no ownership row for core/models")
+	})
+
+	t.Run("a row for a package that is not there", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel -", "core/models authserver #359", "core/ghost authserver #360")})
+		assertFindings(t, findings, "records ownership for core/ghost, which holds no production Go file")
+	})
+
+	// A directory of data files is not a package and owes no row.
+	t.Run("a directory with no Go file owes no row", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel -", "core/models authserver #359")})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("two rows for one package", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel -", "core/models authserver #359", "core/models split #350")})
+		assertFindings(t, findings, "gives core/models a second ownership row; the first is at line 2")
+	})
+
+	t.Run("a kernel package that names an issue", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel #123", "core/models authserver #359")})
+		assertFindings(t, findings, "gives kernel package core/errs the issue #123; a package that is not moving has no issue")
+	})
+
+	// A move with no issue is the thing the epic is trying not to accumulate: an intention with
+	// nobody responsible for it.
+	t.Run("a moving package that names no issue", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel -", "core/models authserver -")})
+		assertFindings(t, findings, "says core/models becomes authserver but names \"-\" where an issue like #332 belongs")
+	})
+
+	t.Run("an owner that is not one of the five", func(t *testing.T) {
+		findings := checkTree(t, tree, architectureTables{owners: ownerRows(
+			"core/errs kernel -", "core/models maybe #359")})
+		assertFindings(t, findings, "gives core/models the owner \"maybe\", which is none of kernel, authserver, adminconsole, split, delete")
+	})
+
+	t.Run("a reachable foreign module that names no clearing issue", func(t *testing.T) {
+		findings := checkTree(t, map[string]string{
+			"core/errs/errs.go":            pkg("errs", "modernc.org/sqlite"),
+			"core/models/m.go":             pkg("models"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/errs"),
+		}, architectureTables{
+			owners:  ownerRows("core/errs kernel -", "core/models authserver #359"),
+			foreign: foreignRows("modernc.org/sqlite yes -"),
+		})
+		assertFindings(t, findings, "is reachable from the admin console but names \"-\" where the issue that clears it belongs")
+	})
+}
+
+// ---- rule 6: exception reconciliation ------------------------------------------------------
+
+func TestArchitecture_Exceptions(t *testing.T) {
+	tree := map[string]string{
+		"core/i18n/i18n.go":     pkg("i18n", "example.test/core/models"),
+		"core/models/models.go": pkg("models"),
+	}
+	owners := ownerRows("core/i18n kernel -", "core/models authserver #359")
+
+	t.Run("a listed exception silences the violation it names", func(t *testing.T) {
+		findings := check(t, tree, architectureTables{
+			owners:     owners,
+			exceptions: exceptionRows("core/i18n core/models #337"),
+		})
+		assert.Empty(t, findings)
+	})
+
+	// An exception is scoped to the exact edge, not to the package at either end. Granting
+	// core/i18n one dependency must not grant it every dependency.
+	t.Run("an exception covers one edge and no other", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":     pkg("i18n", "example.test/core/models", "example.test/core/user"),
+			"core/models/models.go": pkg("models"),
+			"core/user/user.go":     pkg("user"),
+		}, architectureTables{
+			owners:     append(owners, ownerRows("core/user authserver #346")...),
+			exceptions: exceptionRows("core/i18n core/models #337"),
+		})
+		assertFindings(t, findings, "kernel purity: core/i18n imports core/user")
+	})
+
+	// The burn-down half. #335 already instructs its implementer to remove the exact exception rows
+	// this issue grants; this is what happens when that is forgotten.
+	t.Run("an exception for an edge that no longer exists", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":     pkg("i18n"),
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{
+			owners:     owners,
+			exceptions: exceptionRows("core/i18n core/models #337"),
+		})
+		assertFindings(t, findings, "lists core/i18n -> core/models as a temporary exception, but that edge no longer exists; delete the row (#337)")
+	})
+
+	t.Run("an exception that names no issue is a waiver", func(t *testing.T) {
+		findings := check(t, tree, architectureTables{
+			owners:     owners,
+			exceptions: exceptionRows("core/i18n core/models -"),
+		})
+		assertFindings(t, findings, "a temporary dependency with no issue is a waiver")
+	})
+
+	t.Run("the same exception listed twice", func(t *testing.T) {
+		findings := check(t, tree, architectureTables{
+			owners:     owners,
+			exceptions: exceptionRows("core/i18n core/models #337", "core/i18n core/models #350"),
+		})
+		assertFindings(t, findings, "lists the exception core/i18n -> core/models twice")
+	})
+
+	t.Run("a module-wide exception covers every package in that module", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/user/user.go":            pkg("user"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/user"),
+			"adminconsole/internal/b/b.go": pkg("b", "example.test/core/user"),
+		}, architectureTables{
+			owners:     ownerRows("core/user authserver #346"),
+			exceptions: exceptionRows("adminconsole core/user #346"),
+		})
+		assert.Empty(t, findings)
+	})
+}
+
+// ---- the import graph itself ---------------------------------------------------------------
+
+func TestArchitecture_ImportsAreReadFromTheAst(t *testing.T) {
+	owners := ownerRows("core/i18n kernel -", "core/models authserver #359")
+
+	// Reading the AST rather than the text is what lets the guard be exact in both directions.
+	t.Run("an import path in a comment or a string is not an edge", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go": `package i18n
+
+// This package used to import "example.test/core/models" and no longer does.
+const doc = "example.test/core/models"
+`,
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{owners: owners})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("an aliased import is still an edge", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go": `package i18n
+
+import m "example.test/core/models"
+
+var _ = m.X
+`,
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{owners: owners})
+		assertFindings(t, findings, "kernel purity: core/i18n imports core/models")
+	})
+
+	// A file excluded from every production build is not part of the production graph, which is the
+	// same judgement the error-construction lint makes about the same comment.
+	t.Run("a file excluded from production builds is not in the production graph", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go": `//go:build !production
+
+package i18n
+
+import _ "example.test/core/models"
+`,
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{owners: owners})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("a file that does not parse is the build tier's problem, not this one", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/i18n/i18n.go":     "package i18n\n\nthis is not Go\n",
+			"core/models/models.go": pkg("models"),
+		}, architectureTables{owners: owners})
+		assert.Empty(t, findings)
+	})
+
+	t.Run("module identity is read from go.mod", func(t *testing.T) {
+		root := writeTree(t, map[string]string{
+			"core/go.mod":       "module example.test/renamed-core\n",
+			"core/errs/errs.go": pkg("errs"),
+		})
+		graph, err := buildImportGraph(root)
+		require.NoError(t, err)
+		assert.Equal(t, "example.test/renamed-core", graph.modules["core"])
+		assert.Equal(t, "core/errs", graph.topCorePackage("example.test/renamed-core/errs"))
+	})
+}
+
+// ---- the document parser -------------------------------------------------------------------
+
+func TestArchitecture_DocParsing(t *testing.T) {
+	doc := `# Architecture
+
+Prose that mentions | pipes | and must not be read as a row.
+
+### Package ownership
+
+| package | owner | moves in |
+|---|---|---|
+| ` + "`core/api`" + ` | kernel | — |
+| ` + "`core/models`" + ` | authserver | #359 |
+
+More prose.
+
+### Temporary exceptions
+
+| from | to | issue |
+|---|---|---|
+| ` + "`core/api`" + ` | ` + "`core/models`" + ` | #350 |
+
+### Foreign modules
+
+| module | why | reachable today | cleared by |
+|---|---|---|---|
+| ` + "`modernc.org/sqlite`" + ` | SQLite driver | yes | #359 |
+| ` + "`github.com/pquerna/otp`" + ` | TOTP | no | — |
+`
+
+	tables, findings := parseArchitectureDoc(doc)
+	assert.Empty(t, findings)
+
+	assert.Equal(t, []ownerRow{
+		{pkg: "core/api", owner: "kernel", issue: "—", line: 9},
+		{pkg: "core/models", owner: "authserver", issue: "#359", line: 10},
+	}, tables.owners)
+	assert.Equal(t, []exceptionRow{
+		{from: "core/api", to: "core/models", issue: "#350", line: 18},
+	}, tables.exceptions)
+	assert.Equal(t, []foreignRow{
+		{module: "modernc.org/sqlite", reachable: true, clearedBy: "#359", line: 24},
+		{module: "github.com/pquerna/otp", reachable: false, clearedBy: "—", line: 25},
+	}, tables.foreign)
+}
+
+func TestArchitecture_DocParsingRejects(t *testing.T) {
+	t.Run("a missing table", func(t *testing.T) {
+		_, findings := parseArchitectureDoc("# Architecture\n")
+		assert.Len(t, findings, 3)
+		assert.Contains(t, findings[0], `has no "### Package ownership" table`)
+	})
+
+	t.Run("a row with the wrong number of cells", func(t *testing.T) {
+		_, findings := parseArchitectureDoc("### Package ownership\n\n| a | b | c |\n|---|---|---|\n| core/api | kernel |\n\n### Temporary exceptions\n\n| a | b | c |\n|---|---|---|\n\n### Foreign modules\n\n| a | b | c | d |\n|---|---|---|---|\n")
+		require.NotEmpty(t, findings)
+		assert.Contains(t, findings[0], "an ownership row needs 3 cells, found 2")
+	})
+
+	t.Run("a reachability cell that is neither yes nor no", func(t *testing.T) {
+		_, findings := parseArchitectureDoc("### Package ownership\n\n| a | b | c |\n|---|---|---|\n\n### Temporary exceptions\n\n| a | b | c |\n|---|---|---|\n\n### Foreign modules\n\n| a | b | c | d |\n|---|---|---|---|\n| mod | why | maybe | #1 |\n")
+		require.NotEmpty(t, findings)
+		assert.Contains(t, findings[0], `row's reachability is "maybe", which is neither yes nor no`)
+	})
+}
+
+func TestArchitecture_NoIssueSpellings(t *testing.T) {
+	// The document writes an em dash. A hyphen and an empty cell mean the same thing to a reader,
+	// and refusing them would make the guard a finding about typography rather than about the tree.
+	for _, cell := range []string{"—", "–", "-", "", "  "} {
+		assert.True(t, noIssue(cell), "%q", cell)
+	}
+	for _, cell := range []string{"#332", "later", "TODO"} {
+		assert.False(t, noIssue(cell), "%q", cell)
+	}
+}
+
+// ---- the real tree -------------------------------------------------------------------------
+
+// TestArchitecture_TheRealTreeIsHeldByItsExceptions proves the guard is connected to this
+// repository and not merely to its fixtures. The tree passes today because the tables were written
+// from it, so passing proves nothing on its own; removing one exception must make it fail, and the
+// finding must name the edge that exception was covering.
+func TestArchitecture_TheRealTreeIsHeldByItsExceptions(t *testing.T) {
+	root := SourceRoot(t)
+
+	doc, err := os.ReadFile(filepath.Join(filepath.Dir(root), architectureDoc))
+	require.NoError(t, err)
+	tables, findings := parseArchitectureDoc(string(doc))
+	require.Empty(t, findings)
+	require.NotEmpty(t, tables.exceptions)
+
+	graph, err := buildImportGraph(root)
+	require.NoError(t, err)
+	require.Empty(t, checkArchitecture(tables, graph))
+
+	for _, dropped := range tables.exceptions {
+		t.Run(dropped.from+" -> "+dropped.to, func(t *testing.T) {
+			kept := architectureTables{owners: tables.owners, foreign: tables.foreign}
+			for _, row := range tables.exceptions {
+				if row != dropped {
+					kept.exceptions = append(kept.exceptions, row)
+				}
+			}
+			findings := checkArchitecture(kept, graph)
+			require.Len(t, findings, 1)
+			assert.Contains(t, findings[0], dropped.from+" imports "+dropped.to)
+		})
+	}
+}
+
+// TestArchitecture_TheRealTreeReachesEveryForeignModuleItDeclares does the same for the foreign
+// table: flipping a declared reachability must produce a finding, in both directions.
+func TestArchitecture_TheRealTreeReachesEveryForeignModuleItDeclares(t *testing.T) {
+	root := SourceRoot(t)
+
+	doc, err := os.ReadFile(filepath.Join(filepath.Dir(root), architectureDoc))
+	require.NoError(t, err)
+	tables, _ := parseArchitectureDoc(string(doc))
+	require.NotEmpty(t, tables.foreign)
+
+	graph, err := buildImportGraph(root)
+	require.NoError(t, err)
+
+	for i, row := range tables.foreign {
+		t.Run(row.module, func(t *testing.T) {
+			flipped := architectureTables{owners: tables.owners, exceptions: tables.exceptions}
+			flipped.foreign = append(flipped.foreign, tables.foreign...)
+			flipped.foreign[i].reachable = !row.reachable
+			if flipped.foreign[i].reachable {
+				flipped.foreign[i].clearedBy = "#360"
+			}
+
+			findings := checkArchitecture(flipped, graph)
+			require.Len(t, findings, 1)
+			assert.Contains(t, findings[0], row.module)
+		})
+	}
+}

--- a/src/core/testutil/architecture_rules_test.go
+++ b/src/core/testutil/architecture_rules_test.go
@@ -195,7 +195,7 @@ func TestArchitecture_KernelPurity(t *testing.T) {
 			"core/i18n/i18n.go":     pkg("i18n", "example.test/core/models"),
 			"core/models/models.go": pkg("models"),
 		}, architectureTables{owners: ownerRows("core/i18n kernel -", "core/models authserver #359")})
-		assertFindings(t, findings, "kernel purity: core/i18n imports core/models at example.test/core/i18n, and ARCHITECTURE.md lists no exception")
+		assertFindings(t, findings, "kernel purity: core/i18n imports core/models, and ARCHITECTURE.md lists no exception")
 	})
 
 	t.Run("a kernel package may not import a package already marked for deletion", func(t *testing.T) {
@@ -263,7 +263,7 @@ func TestArchitecture_ProcessIsolation(t *testing.T) {
 			"core/user/user.go":            pkg("user"),
 			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/user"),
 		}, tables)
-		assertFindings(t, findings, "process isolation: adminconsole imports core/user at example.test/adminconsole/internal/a")
+		assertFindings(t, findings, "process isolation: adminconsole/internal/a imports core/user")
 	})
 
 	t.Run("the auth server may not import an adminconsole-owned package", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestArchitecture_ProcessIsolation(t *testing.T) {
 			"core/uithemes/uithemes.go":  pkg("uithemes"),
 			"authserver/internal/a/a.go": pkg("a", "example.test/core/uithemes"),
 		}, tables)
-		assertFindings(t, findings, "process isolation: authserver imports core/uithemes")
+		assertFindings(t, findings, "process isolation: authserver/internal/a imports core/uithemes")
 	})
 
 	// The wizard ships as a standalone binary, so a package it pulls in is a package a user
@@ -543,16 +543,45 @@ func TestArchitecture_Exceptions(t *testing.T) {
 		assertFindings(t, findings, "lists the exception core/i18n -> core/models twice")
 	})
 
-	t.Run("a module-wide exception covers every package in that module", func(t *testing.T) {
-		findings := check(t, map[string]string{
+	// Guidance point 4 of #332 asks for exact package edges, and this is what that buys: granting
+	// one package a dependency must not grant it to the package next door, or a second consumer
+	// could appear with nothing going red and the row count would stop measuring the work left.
+	t.Run("an exception names the importing package, not its module", func(t *testing.T) {
+		tree := map[string]string{
 			"core/user/user.go":            pkg("user"),
 			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/user"),
 			"adminconsole/internal/b/b.go": pkg("b", "example.test/core/user"),
+		}
+		owners := ownerRows("core/user authserver #346")
+
+		findings := check(t, tree, architectureTables{
+			owners:     owners,
+			exceptions: exceptionRows("adminconsole/internal/a core/user #346"),
+		})
+		assertFindings(t, findings, "process isolation: adminconsole/internal/b imports core/user")
+
+		findings = check(t, tree, architectureTables{
+			owners: owners,
+			exceptions: exceptionRows(
+				"adminconsole/internal/a core/user #346",
+				"adminconsole/internal/b core/user #346"),
+		})
+		assert.Empty(t, findings)
+	})
+
+	// A module name in the from column is no longer a grant at all: it matches no edge, so it reads
+	// as a stale row and says so.
+	t.Run("a module name in the from column grants nothing", func(t *testing.T) {
+		findings := check(t, map[string]string{
+			"core/user/user.go":            pkg("user"),
+			"adminconsole/internal/a/a.go": pkg("a", "example.test/core/user"),
 		}, architectureTables{
 			owners:     ownerRows("core/user authserver #346"),
 			exceptions: exceptionRows("adminconsole core/user #346"),
 		})
-		assert.Empty(t, findings)
+		assertFindings(t, findings,
+			"process isolation: adminconsole/internal/a imports core/user",
+			"lists adminconsole -> core/user as a temporary exception, but that edge no longer exists")
 	})
 }
 


### PR DESCRIPTION
Closes #332. First issue of the 29-issue Core Refactor epic: it establishes the rules every later issue is measured against, and moves no production package.

## What this adds

`ARCHITECTURE.md` at the repository root, and a guard that reads it.

The document is not prose about the rules — it *is* them. Its three tables are parsed by `AssertArchitecture` (`src/core/testutil/architecture.go`) and checked against the real import graph, read from the AST rather than matched as text. All three module unit tiers call it, the same arrangement as the gofmt, error, slog and agent-document guards.

It went at the root rather than under `docs/` because `/docs/` is gitignored on purpose: it holds the per-issue working documents that are deliberately not pushed.

**Six rules**: module direction, kernel purity, process isolation, dead package, foreign closure, table hygiene.

**Three tables**: the final owner of all 38 top-level `core` packages; 16 temporary exceptions, each an exact package edge with the issue that removes it; and the third-party modules the admin console must not compile.

## Why the document is executable

A dependency rule is invisible at every call site and is not a compile error until the day it becomes an import cycle, so it decays without anything going red. That is how `core` grew an application inside it: one reasonable-looking import at a time, until `adminconsole/go.mod` listed all four database drivers as indirect dependencies of a process that opens no database.

This repository already learned the same lesson about prose — `AssertAgentDocs` exists because the ceremony's documented state machine had moved underneath its description while every test stayed green (#252). This applies that precedent to dependency direction.

## The part that makes it a burn-down list

Every check runs **in both directions**. An edge the tables do not allow is a finding, and so is an exception left standing for an edge that no longer exists. #335 already instructs its implementer to "remove the exact architecture exceptions introduced by #332 for these edges"; that is now enforced rather than remembered. The same holds for the foreign-module table: when a driver stops reaching the admin console, its row has to go.

Exceptions name a package at both ends, never a module and never a parent, so granting one package a dependency does not quietly grant it to the package next door — and the row count keeps measuring the work left.

## Measured baseline

Every database driver reaches the admin console by the same shape:

```
adminconsole/cmd/goiabada-adminconsole -> core/oauth -> core/data -> core/data/<engine> -> driver
```

`core/data/database.go:15-18` imports all four engine packages, so importing `core/data` at all compiles every driver. Five of the core packages the admin console imports in production reach `core/data`: `core/oauth`, `core/user`, `core/middleware`, `core/validators`, `core/sessionstore`. Closing one path changes nothing on its own, which is why the guard asserts reachability rather than counting edges.

Module direction already holds today with no exceptions. `github.com/pquerna/otp` is recorded as unreachable so it cannot arrive before #348 moves `core/otp`.

One finding for the next issue: **`core/audit` is not in the repository.** `git ls-files core/audit` is empty. It exists only as a directory of generated mocks in a working tree that has run the mock generator, so #333 has nothing to delete from git — only a note to make about the generator. This one is here because the guard caught me: I wrote the row from my own working tree, and the completeness rule refused it.

## Old and new package paths

None. No production package moved, no import was rewritten, and no runtime behaviour changed. The diff is one markdown file, one `core/testutil` helper, four test files, and the two agent documents.

## Tests

The tests are more of the deliverable here than the guard is. The tree satisfies `ARCHITECTURE.md` by construction — the tables were written from it — so the real caller passes whether the rules match anything or not, which is how a guard like this dies: quietly, still green.

- `architecture_rules_test.go` runs the rule table over fixture trees in a temp directory: one fixture per rule, and one per deliberate leniency (a `split` package has no edge rule yet; test files sit outside the production graph; the standard library is not a foreign module; a build-constrained file is not in the production build; an import path in a comment is not an edge).
- Two tests take the real tables apart a row at a time: dropping each of the 16 exceptions in turn must produce exactly one finding naming that edge, and flipping each of the 7 declared reachabilities must fail.
- End to end, adding `import _ ".../core/models"` to `core/stringutil` produces `kernel purity: core/stringutil imports core/models, and ARCHITECTURE.md lists no exception for that edge; move the code or add a row naming the issue that will`.

## Verification

| check | result |
|---|---|
| `./run-tests.sh --type modules` | pass; the guard ran in all three tiers |
| `./run-tests.sh --type modules --race` | pass; no data races |
| `./run-tests.sh --type lint` | 0 issues across all four modules |
| repository-wide gofmt, error and slog guards | pass (they run in the module tiers) |
| `./run-tests.sh --type data --db sqlite` | pass |
| `./run-tests.sh --type integration --db sqlite` | pass |

Data and integration were run on sqlite only. The other three engines reach the same code through the same `Database` interface, and this PR changes no production runtime code — the diff is one markdown file, one `core/testutil` helper, four test files and the two agent documents — so the per-engine jobs in CI are the right place for the remaining matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


